### PR TITLE
[Accordo] Handle type qualifiers in `get_kern_arg_data()`

### DIFF
--- a/accordo/_internal/ipc/communication.py
+++ b/accordo/_internal/ipc/communication.py
@@ -158,8 +158,11 @@ def get_kern_arg_data(pipe_name, args, ipc_file_name, ipc_timeout_seconds=30, pr
 	for handle, arg, array_size in zip(ipc_handles, pointer_args, ptr_sizes):
 		ptr = open_ipc_handle(handle)
 		logging.debug(f"Opened IPC Ptr: {ptr} (0x{ptr:x})")
-		arg_type = arg.split()[0]
-		logging.debug(f"arg_type: {arg_type}")
+		
+		# Strip type qualifiers (restrict, const, volatile) to get the base type
+		arg_type = " ".join(word for word in arg.split() if word not in ("restrict", "const", "volatile"))
+		arg_type = arg_type.split()[0] if arg_type.split() else arg
+		logging.debug(f"arg_type (after stripping qualifiers): {arg_type}")
 
 		if arg_type in type_map:
 			dtype = type_map[arg_type]


### PR DESCRIPTION
Consider a kernel whose arguments include type qualifiers such as `restrict`, `const`, `volatile`, etc. With current logic, `get_kern_arg_data()` will misinterpret the metadata, leading to an unexpected TypeError. 

```
DEBUG:root:Metadata content:
{
  "version": 1,
  "description": "Accordo kernel argument metadata",
  "args": [
    {
      "index": 0,
      "name": "arg0",
      "type": "restrict bf16*",
      "size": 8,
      "offset": 0,
      "is_pointer": true,
      "is_const": false,
      "is_output": true
    },
    ....
DEBUG:root:arg_type: restrict
Traceback (most recent call last):
  File "/work1/amd/colramos/audacious/intellikit/cole_test.py", line 9, in <module>
    ref = validator.capture_snapshot(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work1/amd/colramos/audacious/intellikit/accordo/validator.py", line 257, in capture_snapshot
    result_arrays = self._run_instrumented_app(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work1/amd/colramos/audacious/intellikit/accordo/validator.py", line 401, in _run_instrumented_app
    result_arrays = get_kern_arg_data(
                    ^^^^^^^^^^^^^^^^^^
  File "/work1/amd/colramos/audacious/intellikit/accordo/_internal/ipc/communication.py", line 179, in get_kern_arg_data
    raise TypeError(f"Unsupported pointer type: {arg_type}")
TypeError: Unsupported pointer type: restrict    
```

This PR pre-processes the kern arg striping any qualifiers.