### PR TITLE
Update pinned kerneldb hash

### DIFF
--- a/accordo/pyproject.toml
+++ b/accordo/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "numpy",
-    "kerneldb @ git+https://github.com/AMDResearch/kerneldb.git@508f7fcf7fbd88c9eb6850e9fdac2e41d24c399a"
+    "kerneldb @ git+https://github.com/AMDResearch/kerneldb.git@c67ceefb548125c6ef9bc4042207f11fcb624c62"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.8"
 
 dependencies = [
     "numpy",
-    "kerneldb @ git+https://github.com/AMDResearch/kerneldb.git@508f7fcf7fbd88c9eb6850e9fdac2e41d24c399a"
+    "kerneldb @ git+https://github.com/AMDResearch/kerneldb.git@c67ceefb548125c6ef9bc4042207f11fcb624c62"
 ]
 
 [project.urls]


### PR DESCRIPTION
Requesting we update the pinned kerneldb commit hash to latest 1/14/26 commit

<img width="1224" height="410" alt="image" src="https://github.com/user-attachments/assets/97de04e6-bd79-45d2-9bae-b0b27a3c6c4c" />
