### PR TITLE
Only run CI for packages that changed

### DIFF
--- a/.github/workflows/intellikit-ci-test.yml
+++ b/.github/workflows/intellikit-ci-test.yml
@@ -18,7 +18,55 @@ permissions:
   contents: read
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.build-matrix.outputs.packages }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            accordo:
+              - 'accordo/**'
+            kerncap:
+              - 'kerncap/**'
+            linex:
+              - 'linex/**'
+            metrix:
+              - 'metrix/**'
+            nexus:
+              - 'nexus/**'
+            rocm_mcp:
+              - 'rocm_mcp/**'
+            uprof_mcp:
+              - 'uprof_mcp/**'
+            infra:
+              - '.github/**'
+              - 'apptainer/**'
+              - 'docker/**'
+              - 'install/**'
+              - 'pyproject.toml'
+
+      - name: Build package matrix
+        id: build-matrix
+        run: |
+          ALL='["accordo","kerncap","linex","metrix","nexus","rocm_mcp","uprof_mcp"]'
+
+          # Infra changes or non-PR events → test everything
+          if [[ "${{ steps.filter.outputs.infra }}" == "true" || "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "packages=${ALL}" >> "$GITHUB_OUTPUT"
+          else
+            echo "packages=${{ steps.filter.outputs.changes }}" >> "$GITHUB_OUTPUT"
+          fi
+
   build-container-image:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.packages != '[]'
     runs-on: [self-hosted, mi3xx]
     timeout-minutes: 30
 
@@ -43,13 +91,13 @@ jobs:
 
   test-installation:
     name: Test ${{ matrix.install_method }} - ${{ matrix.package }}
-    needs: build-container-image
+    needs: [detect-changes, build-container-image]
     runs-on: [self-hosted, mi3xx]
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        package: [accordo, kerncap, linex, metrix, nexus, rocm_mcp, uprof_mcp]
+        package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
         install_method: [editable, non-editable, github]
 
     steps:
@@ -65,7 +113,7 @@ jobs:
           else
             GIT_SHA="${{ github.sha }}"
           fi
-          
+
           # Subpackage installation with import test
           if [ "${{ matrix.install_method }}" = "editable" ]; then
             bash .github/scripts/container_exec.sh "
@@ -83,4 +131,3 @@ jobs:
               python3 -c 'import ${{ matrix.package }}'
             "
           fi
-

--- a/.github/workflows/intellikit-pytest.yml
+++ b/.github/workflows/intellikit-pytest.yml
@@ -19,7 +19,54 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.build-matrix.outputs.packages }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            accordo:
+              - 'accordo/**'
+            kerncap:
+              - 'kerncap/**'
+            linex:
+              - 'linex/**'
+            metrix:
+              - 'metrix/**'
+            nexus:
+              - 'nexus/**'
+            infra:
+              - '.github/**'
+              - 'apptainer/**'
+              - 'docker/**'
+              - 'install/**'
+              - 'pyproject.toml'
+
+      - name: Build package matrix
+        id: build-matrix
+        run: |
+          ALL='["accordo","kerncap","linex","metrix","nexus"]'
+
+          # Infra changes or non-PR events → test everything
+          if [[ "${{ steps.filter.outputs.infra }}" == "true" || "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "packages=${ALL}" >> "$GITHUB_OUTPUT"
+          else
+            # Filter to only pytest-eligible packages (exclude rocm_mcp, uprof_mcp)
+            CHANGED='${{ steps.filter.outputs.changes }}'
+            FILTERED=$(echo "$CHANGED" | jq -c '[.[] | select(. == "accordo" or . == "kerncap" or . == "linex" or . == "metrix" or . == "nexus")]')
+            echo "packages=${FILTERED}" >> "$GITHUB_OUTPUT"
+          fi
+
   build-container-image:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.packages != '[]'
     runs-on: [self-hosted, mi3xx]
     timeout-minutes: 30
     steps:
@@ -43,13 +90,13 @@ jobs:
 
   pytest:
     name: pytest ${{ matrix.install_method }} - ${{ matrix.package }}
-    needs: build-container-image
+    needs: [detect-changes, build-container-image]
     runs-on: [self-hosted, mi3xx]
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        package: [accordo, kerncap, linex, metrix, nexus]
+        package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
         install_method: [editable, non-editable]
 
     steps:


### PR DESCRIPTION
## Summary
- Adds `dorny/paths-filter` to detect which package directories changed in a PR
- Only the affected packages are included in the CI test and pytest matrices
- Shared infra changes (`.github/`, `apptainer/`, root `pyproject.toml`) still trigger the full suite
- Pushes to main and `workflow_dispatch` run everything as before

## Before
Every PR runs ~34 jobs (21 install tests + 10 pytest + 3 lint) regardless of what changed.

## After
A PR touching only `linex/` runs 3 install tests + 2 pytest + 3 lint = **8 jobs** instead of 34.

## Test plan
- [ ] Open a PR that only touches one package, verify only that package's tests run
- [ ] Open a PR that touches `.github/`, verify all packages are tested
- [ ] Verify push to main still runs everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)