### PR TITLE
Fix GitHub Pages path nesting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,11 +38,17 @@ jobs:
         working-directory: docs
         run: npm run build
 
+      - name: Prepare artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p docs/_site/IntelliKit
+          cp -r docs/dist/* docs/_site/IntelliKit/
+
       - name: Upload artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/dist
+          path: docs/_site
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Astro 4 outputs flat to dist/ but applies /IntelliKit/ as base to all URLs. Nest the build output under _site/IntelliKit/ so GitHub Pages serves files at the correct path.