### PR TITLE
Fix GitHub Pages: upload dist directly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,17 +38,11 @@ jobs:
         working-directory: docs
         run: npm run build
 
-      - name: Prepare artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          mkdir -p docs/_site/IntelliKit
-          cp -r docs/dist/* docs/_site/IntelliKit/
-
       - name: Upload artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/_site
+          path: docs/dist
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Remove the _site/IntelliKit nesting from the workflow. GitHub Pages mounts the artifact at /IntelliKit/ automatically for project sites. The double-nesting was causing 404s.