### PR TITLE
Fix docs: lowercase base path for GitHub Pages

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,7 +3,7 @@ import starlight from "@astrojs/starlight";
 
 export default defineConfig({
   site: "https://amdresearch.github.io",
-  base: "/IntelliKit",
+  base: "/intellikit",
   integrations: [
     starlight({
       title: "IntelliKit",

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -63,9 +63,9 @@ CACHE PERFORMANCE:
 
 ## Next steps
 
-- **Dive deeper into profiling** — see [Metrix](/IntelliKit/tools/metrix/) for all available metrics
-- **Map performance to source lines** — see [Linex](/IntelliKit/tools/linex/) for source-level profiling
-- **Extract and isolate a kernel** — see [Kerncap](/IntelliKit/tools/kerncap/) for standalone reproducers
-- **Inspect GPU execution** — see [Nexus](/IntelliKit/tools/nexus/) for HSA packet tracing
-- **Validate optimizations** — see [Accordo](/IntelliKit/tools/accordo/) for correctness checking
-- **Set up MCP servers** — see [MCP Setup](/IntelliKit/guides/mcp-setup/) for LLM integration
+- **Dive deeper into profiling** — see [Metrix](/intellikit/tools/metrix/) for all available metrics
+- **Map performance to source lines** — see [Linex](/intellikit/tools/linex/) for source-level profiling
+- **Extract and isolate a kernel** — see [Kerncap](/intellikit/tools/kerncap/) for standalone reproducers
+- **Inspect GPU execution** — see [Nexus](/intellikit/tools/nexus/) for HSA packet tracing
+- **Validate optimizations** — see [Accordo](/intellikit/tools/accordo/) for correctness checking
+- **Set up MCP servers** — see [MCP Setup](/intellikit/guides/mcp-setup/) for LLM integration

--- a/docs/src/content/docs/guides/mcp-setup.mdx
+++ b/docs/src/content/docs/guides/mcp-setup.mdx
@@ -7,7 +7,7 @@ IntelliKit provides several MCP servers that let LLM agents compile HIP code, pr
 
 ## Prerequisites
 
-- IntelliKit installed (see [Installation](/IntelliKit/getting-started/installation/))
+- IntelliKit installed (see [Installation](/intellikit/getting-started/installation/))
 - `uv` (recommended) or `pip`
 - ROCm for GPU-related servers
 - AMD uProf for `uprof-profiler-mcp`
@@ -90,4 +90,4 @@ curl -sSL https://raw.githubusercontent.com/AMDResearch/intellikit/main/install/
 
 Target options: `--target cursor` | `claude` | `codex` | `agents` | `github`
 
-See the [Installation page](/IntelliKit/getting-started/installation/) for more details on the skills script.
+See the [Installation page](/intellikit/getting-started/installation/) for more details on the skills script.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -5,7 +5,7 @@ hero:
   tagline: "Agent-first tooling for AMD hardware"
   actions:
     - text: Get Started
-      link: /IntelliKit/getting-started/installation/
+      link: /intellikit/getting-started/installation/
       icon: open-book
       variant: minimal
     - text: View on GitHub
@@ -20,13 +20,13 @@ IntelliKit is a set of Python tools for AMD-focused performance and validation. 
 
 | Tool | Role | Description |
 |------|------|-------------|
-| [**Kerncap**](/IntelliKit/tools/kerncap/) | Isolate | Capture kernel dispatches, build standalone reproducers for HIP and Triton |
-| [**Metrix**](/IntelliKit/tools/metrix/) | Profile | Human-readable metrics from hardware counters: bandwidth, cache, compute |
-| [**Linex**](/IntelliKit/tools/linex/) | Profile | Source-line timing and stall analysis — map GPU performance to your code |
-| [**Nexus**](/IntelliKit/tools/nexus/) | Inspect | Intercept HSA packets to see what ran on the GPU: assembly and HIP source |
-| [**Accordo**](/IntelliKit/tools/accordo/) | Validate | Prove an optimized kernel still matches a reference implementation |
-| [**ROCm MCP**](/IntelliKit/tools/rocm-mcp/) | MCP | HIP compiler, HIP docs, and rocminfo servers for LLM agents |
-| [**uProf MCP**](/IntelliKit/tools/uprof-mcp/) | CPU | MCP bridge to AMD uProf for host-side CPU hotspot analysis |
+| [**Kerncap**](/intellikit/tools/kerncap/) | Isolate | Capture kernel dispatches, build standalone reproducers for HIP and Triton |
+| [**Metrix**](/intellikit/tools/metrix/) | Profile | Human-readable metrics from hardware counters: bandwidth, cache, compute |
+| [**Linex**](/intellikit/tools/linex/) | Profile | Source-line timing and stall analysis — map GPU performance to your code |
+| [**Nexus**](/intellikit/tools/nexus/) | Inspect | Intercept HSA packets to see what ran on the GPU: assembly and HIP source |
+| [**Accordo**](/intellikit/tools/accordo/) | Validate | Prove an optimized kernel still matches a reference implementation |
+| [**ROCm MCP**](/intellikit/tools/rocm-mcp/) | MCP | HIP compiler, HIP docs, and rocminfo servers for LLM agents |
+| [**uProf MCP**](/intellikit/tools/uprof-mcp/) | CPU | MCP bridge to AMD uProf for host-side CPU hotspot analysis |
 
 ## Install
 

--- a/docs/src/content/docs/tools/rocm-mcp.mdx
+++ b/docs/src/content/docs/tools/rocm-mcp.mdx
@@ -71,4 +71,4 @@ uv run ./examples/hip_compiler.py
 pytest
 ```
 
-See the [MCP Setup guide](/IntelliKit/guides/mcp-setup/) for a complete multi-server configuration.
+See the [MCP Setup guide](/intellikit/guides/mcp-setup/) for a complete multi-server configuration.


### PR DESCRIPTION
GitHub Pages URLs are case-sensitive. The site serves at `/intellikit/` but base was `/IntelliKit/`. All asset and link URLs now use lowercase to match.