### PR TITLE
Fixed version reporting across all packages

### DIFF
--- a/accordo/accordo/__init__.py
+++ b/accordo/accordo/__init__.py
@@ -54,7 +54,12 @@ from .snapshot import Snapshot
 from .validator import Accordo
 
 # Version
-__version__ = "0.4.0"
+from importlib.metadata import PackageNotFoundError, version as _get_version
+
+try:
+    __version__ = _get_version("accordo")
+except PackageNotFoundError:
+    __version__ = "0.4.0"
 
 # Public API
 __all__ = [

--- a/accordo/pyproject.toml
+++ b/accordo/pyproject.toml
@@ -12,9 +12,9 @@ description = "Accordo: Automated side-by-side correctness validation for GPU ke
 authors = [
     { name = "Muhammad Awad", email = "muhaawad@amd.com" },
 ]
-license = "MIT"
+license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "mcp[cli]",
@@ -41,6 +41,7 @@ cmake.build-type = "Release"
 # Persistent build dir so editable install can find the package (pip deletes temp build dir)
 build-dir = "build/{wheel_tag}"
 wheel.packages = ["accordo"]
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 # ---- setuptools-scm versioning ----
 [tool.setuptools_scm]

--- a/kerncap/kerncap/__init__.py
+++ b/kerncap/kerncap/__init__.py
@@ -1,5 +1,12 @@
 """kerncap — Kernel extraction and isolation tool for HIP and Triton on AMD GPUs."""
 
+from importlib.metadata import PackageNotFoundError, version as _get_version
+
+try:
+    __version__ = _get_version("kerncap")
+except PackageNotFoundError:
+    __version__ = "0.1.0"
+
 import logging
 import os
 import pathlib

--- a/kerncap/pyproject.toml
+++ b/kerncap/pyproject.toml
@@ -10,7 +10,7 @@ name = "kerncap"
 dynamic = ["version"]
 description = "Kernel extraction and isolation tool for HIP and Triton applications on AMD GPUs"
 readme = "README.md"
-license = "MIT"
+license = {text = "MIT"}
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.20",
@@ -40,6 +40,7 @@ kerncap-mcp = "kerncap.mcp.server:main"
 cmake.build-type = "Release"
 wheel.packages = ["kerncap"]
 wheel.install-dir = "kerncap"
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.scikit-build.cmake.define]
 CMAKE_INSTALL_LIBDIR = "lib"

--- a/linex/pyproject.toml
+++ b/linex/pyproject.toml
@@ -12,9 +12,9 @@ description = "Linex: Source-Level SQTT Profiling - Map GPU cycles to your sourc
 authors = [
     { name = "Muhammad Awad", email = "muhaawad@amd.com" },
 ]
-license = "MIT"
+license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "fastmcp>=2.0.0",
 ]
@@ -24,10 +24,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Profiling",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 [project.urls]

--- a/linex/src/linex/__init__.py
+++ b/linex/src/linex/__init__.py
@@ -10,5 +10,10 @@ providing cycle counts and performance metrics per source line.
 
 from .api import Linex, SourceLine, InstructionData
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version as _get_version
+
+try:
+    __version__ = _get_version("linex")
+except PackageNotFoundError:
+    __version__ = "0.1.0"
 __all__ = ["Linex", "SourceLine", "InstructionData"]

--- a/metrix/pyproject.toml
+++ b/metrix/pyproject.toml
@@ -12,9 +12,9 @@ description = "Metrix: GPU Profiling. Decoded. Clean metrics for humans, not har
 authors = [
     { name = "Muhammad Awad", email = "muhaawad@amd.com" },
 ]
-license = "MIT"
+license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "pandas>=1.5.0",
     "fastmcp>=2.0.0",
@@ -25,9 +25,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Profiling",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 [project.urls]

--- a/metrix/setup.py
+++ b/metrix/setup.py
@@ -1,34 +1,34 @@
-"""
-Metrix setup configuration
-"""
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 from setuptools import setup, find_packages
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
+# This setup.py provides backward compatibility for legacy metadata fields
+# that don't map directly from pyproject.toml's modern PEP 621 format.
 setup(
     name="metrix",
-    version="0.1.0",
-    author="AMD",
     description="GPU Profiling. Decoded. Clean metrics for humans, not hardware counters for engineers.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/amd/metrix",
+    url="https://github.com/AMDResearch/intellikit/tree/main/metrix",
+    author="Muhammad Awad",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
+    python_requires=">=3.10",
+    install_requires=[
+        "pandas>=1.5.0",
+    ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Profiling",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-    ],
-    python_requires=">=3.9",
-    install_requires=[
-        "pandas>=1.5.0",
+        "Programming Language :: Python :: 3.12",
     ],
     entry_points={
         "console_scripts": [

--- a/metrix/src/metrix/__init__.py
+++ b/metrix/src/metrix/__init__.py
@@ -3,7 +3,12 @@ Metrix - GPU Profiling. Decoded.
 Clean, human-readable metrics for AMD GPUs
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version as _get_version
+
+try:
+    __version__ = _get_version("metrix")
+except PackageNotFoundError:
+    __version__ = "0.1.0"
 
 from .api import Metrix
 from .profiler.engine import Profiler

--- a/nexus/nexus/__init__.py
+++ b/nexus/nexus/__init__.py
@@ -18,7 +18,12 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Dict, Any, List, Iterator
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version as _get_version
+
+try:
+    __version__ = _get_version("nexus")
+except PackageNotFoundError:
+    __version__ = "0.1.0"
 
 
 def _find_nexus_lib() -> Optional[Path]:

--- a/nexus/pyproject.toml
+++ b/nexus/pyproject.toml
@@ -12,9 +12,9 @@ description = "HSA Packet Source Code Extractor for AMD ROCm - Research tool for
 authors = [
     { name = "Muhammad Awad", email = "muhaawad@amd.com" },
 ]
-license = "MIT"
+license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "fastmcp>=2.0.0",
 ]
@@ -36,6 +36,7 @@ nexus-mcp = "nexus.mcp.server:main"
 [tool.scikit-build]
 cmake.build-type = "Release"
 wheel.packages = ["nexus"]
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.scikit-build.cmake.define]
 LLVM_INSTALL_DIR = {env="LLVM_INSTALL_DIR", default="/opt/rocm/llvm"}


### PR DESCRIPTION
## Summary

- Fixed `__version__` returning hardcoded values in all packages — now reads the real version from installed metadata via `importlib.metadata`
- Fixed `pip show` not displaying the `License` field — changed `license = "MIT"` to `license = {text = "MIT"}` in pyproject.toml
- Fixed `requires-python` claiming `>=3.8` when `fastmcp>=2.0.0` requires `>=3.10`
- Fixed scikit-build-core packages (accordo, nexus, kerncap) not picking up setuptools-scm — added `metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"`
- Deleted metrix's legacy `setup.py` that hardcoded `version="0.1.0"` and overrode setuptools-scm — replaced with a minimal one (like iris) for backward compatibility

## Packages updated

metrix, linex, accordo, nexus, kerncap

## Before / After

```
# Before
pip show metrix → Version: 0.1.0
python -c "import metrix; print(metrix.__version__)" → 0.1.0

# After
pip show metrix → Version: 0.1.0.post120+gd6b0b56ad
python -c "import metrix; print(metrix.__version__)" → 0.1.0.post120+gd6b0b56ad
```

## Test plan

Tested all 5 packages on hpcfund (Python 3.12) with 3 install methods each:

| Package | `pip install -e .` | `pip install .` | `pip install git+...` |
|---------|--------------------|-----------------|-----------------------|
| metrix | pass | pass | pass |
| linex | pass | pass | pass |
| accordo | pass | pass | pass |
| nexus | pass | pass | pass |
| kerncap | pass | pass | pass |

- [x] All packages show correct `.postN+g<hash>` version
- [x] All packages show `License: MIT` in `pip show`
- [x] CI lint and tests pass
- [x] ruff format/check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)