### PR TITLE
[kerncap] (fix) handle EngineCore fork

### DIFF
--- a/kerncap/kerncap/capturer.py
+++ b/kerncap/kerncap/capturer.py
@@ -74,6 +74,7 @@ def run_capture(
         env["LD_PRELOAD"] = lib_path
     env["KERNCAP_KERNEL"] = kernel_name
     env["KERNCAP_OUTPUT"] = output_dir
+    env["KERNCAP_CAPTURE_CHILD"] = "1"
 
     if dispatch >= 0:
         env["KERNCAP_DISPATCH"] = str(dispatch)

--- a/kerncap/kerncap/triton_capture.py
+++ b/kerncap/kerncap/triton_capture.py
@@ -339,7 +339,7 @@ _HOOK_INSTALLER = textwrap.dedent('''\
 #   - If the hook fails (e.g. triton not installed), the error is
 #     swallowed and the process continues normally
 # ---------------------------------------------------------------------------
-_SITECUSTOMIZE = textwrap.dedent('''\
+_SITECUSTOMIZE = textwrap.dedent("""\
     import os as _os
     _hook = _os.environ.get("_KERNCAP_TRITON_HOOK")
     if _hook and _os.path.isfile(_hook):
@@ -347,7 +347,7 @@ _SITECUSTOMIZE = textwrap.dedent('''\
             exec(compile(open(_hook).read(), _hook, "exec"))
         except Exception:
             pass
-''')
+""")
 
 
 def run_triton_capture(
@@ -392,7 +392,9 @@ def run_triton_capture(
     # Create temp dir for sitecustomize.py and the hook script
     site_dir = tempfile.mkdtemp(prefix="kerncap_site_")
     hook_fd, hook_path = tempfile.mkstemp(
-        suffix=".py", prefix="kerncap_triton_hook_", dir=site_dir,
+        suffix=".py",
+        prefix="kerncap_triton_hook_",
+        dir=site_dir,
     )
 
     try:
@@ -415,7 +417,8 @@ def run_triton_capture(
 
         logger.debug(
             "Triton capture: sitecustomize at %s, hook at %s",
-            site_dir, hook_path,
+            site_dir,
+            hook_path,
         )
 
         try:

--- a/kerncap/kerncap/triton_capture.py
+++ b/kerncap/kerncap/triton_capture.py
@@ -4,35 +4,49 @@ Intercepts Triton kernel calls at the Python level to capture arguments
 including tensors, scalars, and constexpr values that are not visible
 at the HSA dispatch level.
 
-The capture works by generating a hook script that monkey-patches
-``triton.runtime.jit.JITFunction.run`` before executing the user's
-application.  When the target kernel fires, all Python-level arguments
-(torch tensors, scalars, None, etc.) are serialised to disk alongside
-a ``metadata.json`` that the reproducer generator consumes.
+The capture works by injecting a ``sitecustomize.py`` into ``PYTHONPATH``
+that installs a monkey-patch on ``triton.runtime.jit.JITFunction.run``
+at Python startup.  Because ``sitecustomize`` is imported by every Python
+interpreter (via the ``site`` module), this approach works across process
+boundaries — including child processes spawned via ``multiprocessing.spawn``
+(e.g. vLLM's EngineCore).
+
+When the target kernel fires, all Python-level arguments (torch tensors,
+scalars, None, etc.) are serialised to disk alongside a ``metadata.json``
+that the reproducer generator consumes.
 """
 
+import logging
 import os
+import shutil
 import subprocess
 import tempfile
 import textwrap
 from typing import List, Optional
 
+logger = logging.getLogger(__name__)
 
-# The hook script is written to a temp file and executed as the main
-# script, with the user's original script passed as argv[1].
-_CAPTURE_HOOK = textwrap.dedent('''\
+# ---------------------------------------------------------------------------
+# Hook code that monkey-patches triton.runtime.jit.JITFunction.run.
+#
+# This is written to a temp file and exec'd at Python startup via
+# sitecustomize.py.  It must be self-contained (no kerncap imports).
+# ---------------------------------------------------------------------------
+_HOOK_INSTALLER = textwrap.dedent('''\
     """kerncap Triton capture hook — auto-generated, do not edit."""
     import sys
     import os
     import json
     import inspect
-    import runpy
 
-    _target_kernel = os.environ["KERNCAP_KERNEL"]
-    _output_dir = os.environ["KERNCAP_OUTPUT"]
+    _target_kernel = os.environ.get("KERNCAP_KERNEL", "")
+    _output_dir = os.environ.get("KERNCAP_OUTPUT", "/tmp/kerncap_output")
     _dispatch = int(os.environ.get("KERNCAP_DISPATCH", "-1"))
     _call_count = 0
     _captured = False
+
+    if not _target_kernel:
+        raise RuntimeError("KERNCAP_KERNEL not set")
 
 
     def _install_hook():
@@ -40,14 +54,8 @@ _CAPTURE_HOOK = textwrap.dedent('''\
         import triton.runtime.jit
 
         _autotuner_config_keys = set()
-        # Tensor args from the capture, saved so the Autotuner hook can
-        # re-snapshot them AFTER the autotuner selects the best config.
-        _pending_ref = [None]  # use list for nonlocal mutation in Py 3
+        _pending_ref = [None]
 
-        # Hook the Autotuner so we can:
-        #   1. Learn which kwargs come from its configs (BLOCK_M, etc.)
-        #   2. Save reference outputs AFTER the best-config run (not
-        #      after the first benchmark run, which may use config[0]).
         try:
             from triton.runtime.autotuner import Autotuner
             import torch as _torch
@@ -62,14 +70,9 @@ _CAPTURE_HOOK = textwrap.dedent('''\
                             self_at.configs[0].kwargs.keys()
                         )
                 result = _OrigAutotunerRun(self_at, *args, **kwargs)
-                # After ALL autotuner configs have been benchmarked and
-                # the final best-config run is complete, snapshot the
-                # tensors — they now hold the definitive output.
                 if _pending_ref[0] is not None:
                     _torch.cuda.synchronize()
                     _save_reference_outputs(_pending_ref[0])
-                    # Capture the best autotuner config so the reproducer
-                    # can pin it and get bit-identical results.
                     _save_autotune_config(self_at)
                     _pending_ref[0] = None
                 return result
@@ -97,21 +100,13 @@ _CAPTURE_HOOK = textwrap.dedent('''\
 
             if should_capture:
                 _captured = True
-                # Save input tensors BEFORE the kernel runs
                 tensor_args = _save_capture(
                     self_jit, args, kwargs, grid, _autotuner_config_keys,
                 )
-                # Store tensor refs BEFORE _OrigRun so the autotuner
-                # hook can find them even if this config raises (the
-                # autotuner swallows per-config exceptions internally).
                 _pending_ref[0] = tensor_args
-                # Run the kernel
                 result = _OrigRun(
                     self_jit, *args, grid=grid, warmup=warmup, **kwargs,
                 )
-                # For non-autotuned kernels, save ref outputs now.
-                # For autotuned kernels, the autotuner hook will save
-                # after the best config run completes.
                 if not _autotuner_config_keys:
                     import torch as _torch
                     _torch.cuda.synchronize()
@@ -125,14 +120,9 @@ _CAPTURE_HOOK = textwrap.dedent('''\
 
 
     def _resolve_grid(grid, all_args=None):
-        """Normalise a Triton grid to a 3-tuple of ints.
-
-        Grid lambdas (e.g. ``lambda meta: (cdiv(N, meta['BLOCK_M']), …)``)
-        need a *meta* dict populated with scalar/constexpr values.
-        """
+        """Normalise a Triton grid to a 3-tuple of ints."""
         if callable(grid):
             if all_args:
-                # Build a meta dict from scalar/constexpr args
                 meta = {k: v for k, v in all_args.items()
                         if isinstance(v, (int, float, bool))}
                 try:
@@ -155,17 +145,7 @@ _CAPTURE_HOOK = textwrap.dedent('''\
 
 
     def _save_tensor_storage(tensor, filepath):
-        """Save a tensor's full underlying storage to preserve stride layout.
-
-        Unlike _save_tensor, this does NOT call .contiguous(), so non-standard
-        strides (e.g. padded row layouts) are preserved in the on-disk bytes.
-
-        We view the GPU storage as a flat uint8 tensor and copy THAT to CPU,
-        rather than calling tensor.cpu() which creates a contiguous copy and
-        discards the padded layout.  The caller must record tensor.stride()
-        and tensor.storage_offset() in metadata so the reproducer can
-        reconstruct the original view via torch.as_strided.
-        """
+        """Save a tensor's full underlying storage to preserve stride layout."""
         import torch
         storage = tensor.detach().untyped_storage()
         flat_gpu = torch.empty(storage.nbytes(), dtype=torch.uint8,
@@ -175,10 +155,7 @@ _CAPTURE_HOOK = textwrap.dedent('''\
         flat_cpu.numpy().tofile(filepath)
 
     def _save_tensor(tensor, filepath):
-        """Save a tensor's logical values as a contiguous binary file.
-
-        Used for reference outputs where we compare logical values, not layouts.
-        """
+        """Save a tensor's logical values as a contiguous binary file."""
         import torch
         cpu_tensor = tensor.detach().cpu().contiguous()
         if cpu_tensor.dtype == torch.bfloat16:
@@ -188,7 +165,7 @@ _CAPTURE_HOOK = textwrap.dedent('''\
 
 
     def _is_triton_dtype(val):
-        """Return True if *val* is a triton.language dtype (e.g. tl.bfloat16)."""
+        """Return True if *val* is a triton.language dtype."""
         try:
             import triton.language as _tl
             return isinstance(val, _tl.dtype)
@@ -196,10 +173,7 @@ _CAPTURE_HOOK = textwrap.dedent('''\
             return False
 
     def _triton_dtype_attr(val):
-        """Return the tl attribute name for a triton dtype object.
-
-        E.g. tl.bfloat16 -> "bfloat16", tl.float16 -> "float16".
-        """
+        """Return the tl attribute name for a triton dtype object."""
         import triton.language as _tl
         for attr in dir(_tl):
             if getattr(_tl, attr, None) is val:
@@ -208,11 +182,7 @@ _CAPTURE_HOOK = textwrap.dedent('''\
 
 
     def _save_capture(jit_fn, args, kwargs, grid, autotuner_config_keys):
-        """Save pre-kernel tensor inputs and scalar args.
-
-        Returns a list of (index, name, tensor) for all tensor args so
-        the caller can save their post-kernel state as reference outputs.
-        """
+        """Save pre-kernel tensor inputs and scalar args."""
         import torch
         import numpy as np
 
@@ -220,8 +190,6 @@ _CAPTURE_HOOK = textwrap.dedent('''\
 
         param_names = list(inspect.signature(jit_fn.fn).parameters.keys())
 
-        # Merge positional + keyword args by parameter name (needed
-        # both for metadata and for resolving callable grids).
         all_args = {}
         for i, name in enumerate(param_names):
             if i < len(args):
@@ -359,12 +327,26 @@ _CAPTURE_HOOK = textwrap.dedent('''\
         )
 
 
-    # ---- main ---------------------------------------------------------
     _install_hook()
+''')
 
-    _user_script = sys.argv[1]
-    sys.argv = sys.argv[1:]
-    runpy.run_path(_user_script, run_name="__main__")
+# ---------------------------------------------------------------------------
+# sitecustomize.py template — loaded at startup by every Python interpreter.
+#
+# Checks for _KERNCAP_TRITON_HOOK env var; if set, exec's the hook
+# installer.  Safe to shadow an existing sitecustomize because:
+#   - The env var is only set during a capture session
+#   - If the hook fails (e.g. triton not installed), the error is
+#     swallowed and the process continues normally
+# ---------------------------------------------------------------------------
+_SITECUSTOMIZE = textwrap.dedent('''\
+    import os as _os
+    _hook = _os.environ.get("_KERNCAP_TRITON_HOOK")
+    if _hook and _os.path.isfile(_hook):
+        try:
+            exec(compile(open(_hook).read(), _hook, "exec"))
+        except Exception:
+            pass
 ''')
 
 
@@ -377,10 +359,15 @@ def run_triton_capture(
 ) -> str:
     """Capture a Triton kernel's Python-level arguments.
 
-    Generates a temporary hook script that patches ``JITFunction.run``,
-    then re-invokes the user's Python command through it so that the
-    first non-warmup call to the target kernel is intercepted and all
-    arguments are serialised to *output_dir*.
+    Injects a ``sitecustomize.py`` via ``PYTHONPATH`` that installs the
+    Triton capture hook at interpreter startup.  This works across process
+    boundaries (e.g. ``multiprocessing.spawn``) because every Python
+    interpreter imports ``sitecustomize`` via the ``site`` module.
+
+    The command is run directly — no wrapping with ``runpy`` — so any
+    command that eventually spawns a Python process running Triton kernels
+    will be instrumented (``python script.py``, ``python -m module``,
+    ``vllm serve ...``, etc.).
 
     Parameters
     ----------
@@ -402,41 +389,18 @@ def run_triton_capture(
     """
     os.makedirs(output_dir, exist_ok=True)
 
-    # Find the Python interpreter and the script in the command
-    python_bin = None
-    script_idx = None
-    for i, tok in enumerate(cmd):
-        if python_bin is None:
-            if "python" in os.path.basename(tok):
-                python_bin = tok
-                continue
-        else:
-            # After we've found the Python binary, explicitly reject
-            # unsupported invocation styles like `python -m` and `python -c`.
-            if tok in ("-m", "-c"):
-                raise ValueError(
-                    f"Triton capture does not support Python invocation styles like `{tok}`"
-                )
-            script_idx = i
-            break
+    # Create temp dir for sitecustomize.py and the hook script
+    site_dir = tempfile.mkdtemp(prefix="kerncap_site_")
+    hook_fd, hook_path = tempfile.mkstemp(
+        suffix=".py", prefix="kerncap_triton_hook_", dir=site_dir,
+    )
 
-    if python_bin is None or script_idx is None:
-        raise ValueError(
-            f"Triton capture requires a 'python <script>' command, got: {' '.join(cmd)}"
-        )
-
-    hook_fd, hook_path = tempfile.mkstemp(suffix=".py", prefix="kerncap_triton_hook_")
     try:
         with os.fdopen(hook_fd, "w") as f:
-            f.write(_CAPTURE_HOOK)
+            f.write(_HOOK_INSTALLER)
 
-        # python [flags] hook.py  original_script.py [script_args ...]
-        modified_cmd = (
-            [python_bin]
-            + cmd[1:script_idx]  # any python flags (-u, etc.)
-            + [hook_path]
-            + cmd[script_idx:]  # original script + its args
-        )
+        with open(os.path.join(site_dir, "sitecustomize.py"), "w") as f:
+            f.write(_SITECUSTOMIZE)
 
         env = os.environ.copy()
         env["KERNCAP_KERNEL"] = kernel_name
@@ -444,9 +408,19 @@ def run_triton_capture(
         if dispatch >= 0:
             env["KERNCAP_DISPATCH"] = str(dispatch)
 
+        # Point every Python process at our sitecustomize.py
+        env["_KERNCAP_TRITON_HOOK"] = hook_path
+        existing_pp = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = f"{site_dir}:{existing_pp}" if existing_pp else site_dir
+
+        logger.debug(
+            "Triton capture: sitecustomize at %s, hook at %s",
+            site_dir, hook_path,
+        )
+
         try:
             proc = subprocess.run(
-                modified_cmd,
+                cmd,
                 env=env,
                 timeout=timeout,
                 capture_output=True,
@@ -469,7 +443,4 @@ def run_triton_capture(
 
         return output_dir
     finally:
-        try:
-            os.unlink(hook_path)
-        except OSError:
-            pass
+        shutil.rmtree(site_dir, ignore_errors=True)

--- a/kerncap/src/kerncap.hip
+++ b/kerncap/src/kerncap.hip
@@ -19,6 +19,7 @@
 #include <cinttypes>
 #include <cxxabi.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -82,6 +83,17 @@ CaptureState::CaptureState(
     const char* disp_env = std::getenv("KERNCAP_DISPATCH");
     target_dispatch_ = disp_env ? std::atoi(disp_env) : -1;
 
+    // Fork safety: record PID and check for multi-process mode
+    initial_pid_ = getpid();
+    capture_child_mode_ = (std::getenv("KERNCAP_CAPTURE_CHILD") != nullptr);
+
+    if (capture_child_mode_) {
+        pthread_atfork(nullptr, CaptureState::atfork_parent_handler, nullptr);
+    }
+
+    KERNCAP_INFO("Process pid=%d, capture_child_mode=%s",
+                 initial_pid_, capture_child_mode_ ? "true" : "false");
+
     if (target_kernel_.empty()) {
         KERNCAP_WARN("KERNCAP_KERNEL not set — will not capture any kernel");
     } else {
@@ -103,6 +115,51 @@ CaptureState::~CaptureState() {
     delete saved_api_.amd_ext_;
     delete saved_api_.finalizer_ext_;
     delete saved_api_.image_ext_;
+}
+
+// ---------------------------------------------------------------------------
+// Fork safety — multi-process support
+// ---------------------------------------------------------------------------
+void CaptureState::atfork_parent_handler() {
+    auto* inst = get_instance();
+    if (inst) {
+        inst->fork_detected_ = true;
+        KERNCAP_INFO("fork() detected in parent (pid=%d) — "
+                     "parent will become passive, child will capture",
+                     getpid());
+    }
+}
+
+void CaptureState::reset_inherited_state() {
+    if (child_state_reset_) return;
+    child_state_reset_ = true;
+
+    KERNCAP_INFO("Child process (pid=%d) resetting inherited state "
+                 "from parent (pid=%d)",
+                 getpid(), initial_pid_);
+
+    pointer_sizes_.clear();
+    vmem_tracked_.clear();
+    symbol_names_.clear();
+    handle_to_symbol_.clear();
+    symbol_to_executable_.clear();
+    pending_reader_blobs_.clear();
+    executable_blobs_.clear();
+    kernel_hsaco_.clear();
+    queue_agents_.clear();
+    target_dispatch_count_ = 0;
+    captured_ = false;
+    gpu_arch_.clear();
+}
+
+bool CaptureState::is_active_process() {
+    if (!capture_child_mode_) return true;
+    pid_t current = getpid();
+    if (current != initial_pid_) {
+        reset_inherited_state();
+        return true;
+    }
+    return !fork_detected_;
 }
 
 // ---------------------------------------------------------------------------
@@ -160,6 +217,10 @@ hsa_status_t CaptureState::hsa_executable_get_symbol_by_name(
         hsa_executable_t executable, const char* symbol_name,
         const hsa_agent_t* agent, hsa_executable_symbol_t* symbol) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_core_call(inst, hsa_executable_get_symbol_by_name,
+                             executable, symbol_name, agent, symbol);
+    }
     auto result = hsa_core_call(inst, hsa_executable_get_symbol_by_name,
                                 executable, symbol_name, agent, symbol);
     if (result == HSA_STATUS_SUCCESS) {
@@ -174,6 +235,10 @@ hsa_status_t CaptureState::hsa_executable_symbol_get_info(
         hsa_executable_symbol_t symbol,
         hsa_executable_symbol_info_t attribute, void* value) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_core_call(inst, hsa_executable_symbol_get_info,
+                             symbol, attribute, value);
+    }
     auto result = hsa_core_call(inst, hsa_executable_symbol_get_info,
                                 symbol, attribute, value);
     if (result == HSA_STATUS_SUCCESS &&
@@ -203,6 +268,10 @@ hsa_status_t CaptureState::hsa_code_object_reader_create_from_memory(
         const void* code_object, size_t size,
         hsa_code_object_reader_t* code_object_reader) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_core_call(inst, hsa_code_object_reader_create_from_memory,
+                             code_object, size, code_object_reader);
+    }
     auto result = hsa_core_call(inst, hsa_code_object_reader_create_from_memory,
                                 code_object, size, code_object_reader);
     if (result == HSA_STATUS_SUCCESS && code_object_reader) {
@@ -221,6 +290,11 @@ hsa_status_t CaptureState::hsa_executable_load_agent_code_object(
         hsa_code_object_reader_t code_object_reader,
         const char* options, hsa_loaded_code_object_t* loaded_code_object) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_core_call(inst, hsa_executable_load_agent_code_object,
+                             executable, agent, code_object_reader,
+                             options, loaded_code_object);
+    }
     auto result = hsa_core_call(inst, hsa_executable_load_agent_code_object,
                                 executable, agent, code_object_reader,
                                 options, loaded_code_object);
@@ -249,6 +323,10 @@ hsa_status_t CaptureState::hsa_executable_load_agent_code_object(
 hsa_status_t CaptureState::hsa_amd_memory_pool_allocate(
         hsa_amd_memory_pool_t pool, size_t size, uint32_t flags, void** ptr) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_ext_call(inst, hsa_amd_memory_pool_allocate,
+                            pool, size, flags, ptr);
+    }
     auto result = hsa_ext_call(inst, hsa_amd_memory_pool_allocate,
                                pool, size, flags, ptr);
     if (result == HSA_STATUS_SUCCESS && *ptr) {
@@ -260,6 +338,9 @@ hsa_status_t CaptureState::hsa_amd_memory_pool_allocate(
 
 hsa_status_t CaptureState::hsa_amd_memory_pool_free(void* ptr) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_ext_call(inst, hsa_amd_memory_pool_free, ptr);
+    }
     auto result = hsa_ext_call(inst, hsa_amd_memory_pool_free, ptr);
     if (result == HSA_STATUS_SUCCESS && ptr) {
         std::lock_guard lock(inst->ptr_mutex_);
@@ -271,6 +352,9 @@ hsa_status_t CaptureState::hsa_amd_memory_pool_free(void* ptr) {
 hsa_status_t CaptureState::hsa_memory_allocate(
         hsa_region_t region, size_t size, void** ptr) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_core_call(inst, hsa_memory_allocate, region, size, ptr);
+    }
     auto result = hsa_core_call(inst, hsa_memory_allocate, region, size, ptr);
     if (result == HSA_STATUS_SUCCESS && *ptr) {
         std::lock_guard lock(inst->ptr_mutex_);
@@ -285,6 +369,10 @@ hsa_status_t CaptureState::hsa_memory_allocate(
 hsa_status_t CaptureState::hsa_amd_vmem_address_reserve(
         void** va, size_t size, uint64_t address, uint64_t flags) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_ext_call(inst, hsa_amd_vmem_address_reserve,
+                            va, size, address, flags);
+    }
     auto result = hsa_ext_call(inst, hsa_amd_vmem_address_reserve,
                                va, size, address, flags);
     if (result == HSA_STATUS_SUCCESS && va && *va) {
@@ -298,6 +386,9 @@ hsa_status_t CaptureState::hsa_amd_vmem_address_reserve(
 hsa_status_t CaptureState::hsa_amd_vmem_address_free(
         void* va, size_t size) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_ext_call(inst, hsa_amd_vmem_address_free, va, size);
+    }
     auto result = hsa_ext_call(inst, hsa_amd_vmem_address_free, va, size);
     if (result == HSA_STATUS_SUCCESS && va) {
         std::lock_guard lock(inst->ptr_mutex_);
@@ -311,6 +402,10 @@ hsa_status_t CaptureState::hsa_amd_vmem_map(
         void* va, size_t size, size_t in_offset,
         hsa_amd_vmem_alloc_handle_t memory_handle, uint64_t flags) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_ext_call(inst, hsa_amd_vmem_map,
+                            va, size, in_offset, memory_handle, flags);
+    }
     auto result = hsa_ext_call(inst, hsa_amd_vmem_map,
                                va, size, in_offset, memory_handle, flags);
     if (result == HSA_STATUS_SUCCESS && va) {
@@ -324,6 +419,9 @@ hsa_status_t CaptureState::hsa_amd_vmem_map(
 hsa_status_t CaptureState::hsa_amd_vmem_unmap(
         void* va, size_t size) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_ext_call(inst, hsa_amd_vmem_unmap, va, size);
+    }
     auto result = hsa_ext_call(inst, hsa_amd_vmem_unmap, va, size);
     if (result == HSA_STATUS_SUCCESS && va) {
         std::lock_guard lock(inst->ptr_mutex_);
@@ -341,8 +439,18 @@ hsa_status_t CaptureState::hsa_queue_create(
         void (*callback)(hsa_status_t, hsa_queue_t*, void*),
         void* data, uint32_t private_segment_size,
         uint32_t group_segment_size, hsa_queue_t** queue) {
-    KERNCAP_INFO("Intercepted hsa_queue_create (size=%u, type=%u)", size, type);
     auto* inst = get_instance();
+
+    if (!inst->is_active_process()) {
+        KERNCAP_INFO("Passive mode (pid=%d): passing through hsa_queue_create",
+                     getpid());
+        return hsa_core_call(inst, hsa_queue_create, agent, size, type,
+                             callback, data, private_segment_size,
+                             group_segment_size, queue);
+    }
+
+    KERNCAP_INFO("Active mode (pid=%d): intercepting hsa_queue_create "
+                 "(size=%u, type=%u)", getpid(), size, type);
 
     auto result = hsa_ext_call(inst, hsa_amd_queue_intercept_create,
                                agent, size, type, callback, data,
@@ -370,6 +478,9 @@ hsa_status_t CaptureState::hsa_queue_create(
 
 hsa_status_t CaptureState::hsa_queue_destroy(hsa_queue_t* queue) {
     auto* inst = get_instance();
+    if (!inst->is_active_process()) {
+        return hsa_core_call(inst, hsa_queue_destroy, queue);
+    }
     {
         std::lock_guard g(mutex_);
         inst->queue_agents_.erase(queue);

--- a/kerncap/src/kerncap.hip
+++ b/kerncap/src/kerncap.hip
@@ -37,7 +37,7 @@ namespace kerncap {
 // Static members
 // ---------------------------------------------------------------------------
 CaptureState* CaptureState::singleton_{nullptr};
-std::mutex CaptureState::mutex_{};
+std::shared_mutex CaptureState::mutex_{};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -60,7 +60,7 @@ static const char* safe_getenv(const char* name, const char* fallback = "") {
 CaptureState* CaptureState::get_instance(
         HsaApiTable* table, uint64_t runtime_version,
         uint64_t failed_tool_count, const char* const* failed_tool_names) {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::lock_guard lock(mutex_);
     if (!singleton_ && table) {
         singleton_ = new CaptureState(
             table, runtime_version, failed_tool_count, failed_tool_names);
@@ -494,6 +494,7 @@ hsa_status_t CaptureState::hsa_queue_destroy(hsa_queue_t* queue) {
 // Kernel name resolution
 // ---------------------------------------------------------------------------
 std::string CaptureState::get_kernel_name(uint64_t kernel_object) {
+    std::shared_lock g(mutex_);
     auto hit = handle_to_symbol_.find(kernel_object);
     if (hit == handle_to_symbol_.end()) return "<unknown>";
     auto sit = symbol_names_.find(hit->second);
@@ -502,6 +503,7 @@ std::string CaptureState::get_kernel_name(uint64_t kernel_object) {
 }
 
 std::string CaptureState::get_kernel_symbol(uint64_t kernel_object) {
+    std::shared_lock g(mutex_);
     auto hit = handle_to_symbol_.find(kernel_object);
     if (hit == handle_to_symbol_.end()) return "";
     auto sit = symbol_names_.find(hit->second);
@@ -631,10 +633,19 @@ void CaptureState::capture_kernel(
     // dump exactly the right number of bytes (not a fixed 4096 slab).
     uint32_t kernarg_segment_size = 0;
     {
-        auto hit = handle_to_symbol_.find(disp->kernel_object);
-        if (hit != handle_to_symbol_.end()) {
+        hsa_executable_symbol_t sym{};
+        bool found = false;
+        {
+            std::shared_lock g(mutex_);
+            auto hit = handle_to_symbol_.find(disp->kernel_object);
+            if (hit != handle_to_symbol_.end()) {
+                sym = hit->second;
+                found = true;
+            }
+        }
+        if (found) {
             hsa_core_call(this, hsa_executable_symbol_get_info,
-                          hit->second,
+                          sym,
                           HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_KERNARG_SEGMENT_SIZE,
                           &kernarg_segment_size);
         }
@@ -683,8 +694,11 @@ void CaptureState::capture_kernel(
 
         // Query agent/ISA info
         hsa_agent_t agent{};
-        if (!queue_agents_.empty()) {
-            agent = queue_agents_.begin()->second;
+        {
+            std::shared_lock g(mutex_);
+            if (!queue_agents_.empty()) {
+                agent = queue_agents_.begin()->second;
+            }
         }
 
         char agent_name[64] = {};

--- a/kerncap/src/kerncap.hip
+++ b/kerncap/src/kerncap.hip
@@ -762,7 +762,7 @@ void CaptureState::on_submit_packet(
         const void* packets, uint64_t count, uint64_t /*user_que_idx*/,
         void* data, hsa_amd_queue_intercept_packet_writer writer) {
     auto* inst = get_instance();
-    if (!inst) {
+    if (!inst || !inst->is_active_process()) {
         writer(packets, count);
         return;
     }

--- a/kerncap/src/kerncap.hip
+++ b/kerncap/src/kerncap.hip
@@ -126,7 +126,7 @@ CaptureState::~CaptureState() {
 void CaptureState::atfork_parent_handler() {
     auto* inst = get_instance();
     if (inst) {
-        inst->fork_detected_ = true;
+        inst->fork_detected_.store(true, std::memory_order_relaxed);
         KERNCAP_INFO("fork() detected in parent (pid=%d) — "
                      "parent will become passive, child will capture",
                      getpid());
@@ -134,8 +134,7 @@ void CaptureState::atfork_parent_handler() {
 }
 
 void CaptureState::reset_inherited_state() {
-    if (child_state_reset_) return;
-    child_state_reset_ = true;
+    if (child_state_reset_.exchange(true, std::memory_order_relaxed)) return;
 
     KERNCAP_INFO("Child process (pid=%d) resetting inherited state "
                  "from parent (pid=%d)",
@@ -151,7 +150,7 @@ void CaptureState::reset_inherited_state() {
     kernel_hsaco_.clear();
     queue_agents_.clear();
     target_dispatch_count_ = 0;
-    captured_ = false;
+    captured_.store(false, std::memory_order_relaxed);
     gpu_arch_.clear();
 }
 
@@ -162,7 +161,7 @@ bool CaptureState::is_active_process() {
         reset_inherited_state();
         return true;
     }
-    return !fork_detected_;
+    return !fork_detected_.load(std::memory_order_relaxed);
 }
 
 // ---------------------------------------------------------------------------
@@ -753,7 +752,7 @@ void CaptureState::capture_kernel(
     snapshot_all_tracked_memory(disp);
 
     KERNCAP_INFO("Capture complete -> %s", meta_path.c_str());
-    captured_ = true;
+    captured_.store(true, std::memory_order_relaxed);
 }
 
 // ---------------------------------------------------------------------------
@@ -792,7 +791,7 @@ void CaptureState::handle_packets(
         bool is_target = !target_kernel_.empty() &&
                          kernel_name.find(target_kernel_) != std::string::npos;
 
-        if (is_target && !captured_) {
+        if (is_target && !captured_.load(std::memory_order_relaxed)) {
             // Check dispatch index filter
             bool should_capture = false;
             if (target_dispatch_ < 0) {

--- a/kerncap/src/kerncap.hip
+++ b/kerncap/src/kerncap.hip
@@ -88,7 +88,10 @@ CaptureState::CaptureState(
     capture_child_mode_ = (std::getenv("KERNCAP_CAPTURE_CHILD") != nullptr);
 
     if (capture_child_mode_) {
-        pthread_atfork(nullptr, CaptureState::atfork_parent_handler, nullptr);
+        if (pthread_atfork(nullptr, CaptureState::atfork_parent_handler, nullptr) != 0) {
+            KERNCAP_WARN("pthread_atfork failed — disabling capture_child_mode");
+            capture_child_mode_ = false;
+        }
     }
 
     KERNCAP_INFO("Process pid=%d, capture_child_mode=%s",

--- a/kerncap/src/kerncap.hpp
+++ b/kerncap/src/kerncap.hpp
@@ -73,6 +73,11 @@ public:
         uint64_t failed_tool_count = 0,
         const char* const* failed_tool_names = nullptr);
 
+    // Returns true if this process should perform queue interception.
+    // In multi-process apps (KERNCAP_CAPTURE_CHILD=1), the parent goes
+    // passive after fork and only the child actively intercepts.
+    bool is_active_process();
+
     // Saved (original) API table — public so macros can use it
     HsaApiTable saved_api_;
 
@@ -174,6 +179,12 @@ private:
     void capture_kernel(const hsa_kernel_dispatch_packet_t* disp,
                         const std::string& kernel_name);
 
+    // Fork safety: clear inherited tracking state in the child process
+    void reset_inherited_state();
+
+    // pthread_atfork parent handler — sets fork_detected_ flag
+    static void atfork_parent_handler();
+
 private:
     // ---- State ----
 
@@ -213,6 +224,12 @@ private:
     std::string output_dir_;        // KERNCAP_OUTPUT
     std::string gpu_arch_;          // e.g. "gfx90a" (queried at init)
     bool captured_ = false;         // true after a successful capture
+
+    // Fork safety (multi-process support)
+    pid_t initial_pid_ = 0;           // PID when CaptureState was created
+    bool capture_child_mode_ = false; // KERNCAP_CAPTURE_CHILD env var present
+    bool fork_detected_ = false;      // set by atfork parent handler after fork()
+    bool child_state_reset_ = false;  // true after inherited state cleared in child
 };
 
 }  // namespace kerncap

--- a/kerncap/src/kerncap.hpp
+++ b/kerncap/src/kerncap.hpp
@@ -190,7 +190,7 @@ private:
     // ---- State ----
 
     static CaptureState* singleton_;
-    static std::mutex mutex_;
+    static std::shared_mutex mutex_;
 
     HsaApiTable* api_table_;   // live table (hooked)
 

--- a/kerncap/src/kerncap.hpp
+++ b/kerncap/src/kerncap.hpp
@@ -12,6 +12,7 @@
 #include <hsa/hsa_api_trace.h>
 #include <hsa/hsa_ven_amd_loader.h>
 
+#include <atomic>
 #include <cstdint>
 #include <map>
 #include <mutex>
@@ -223,13 +224,13 @@ private:
     int target_dispatch_ = -1;      // KERNCAP_DISPATCH (-1 = first match)
     std::string output_dir_;        // KERNCAP_OUTPUT
     std::string gpu_arch_;          // e.g. "gfx90a" (queried at init)
-    bool captured_ = false;         // true after a successful capture
+    std::atomic<bool> captured_{false};  // true after a successful capture
 
     // Fork safety (multi-process support)
-    pid_t initial_pid_ = 0;           // PID when CaptureState was created
-    bool capture_child_mode_ = false; // KERNCAP_CAPTURE_CHILD env var present
-    bool fork_detected_ = false;      // set by atfork parent handler after fork()
-    bool child_state_reset_ = false;  // true after inherited state cleared in child
+    pid_t initial_pid_ = 0;              // PID when CaptureState was created
+    bool capture_child_mode_ = false;    // KERNCAP_CAPTURE_CHILD env var present
+    std::atomic<bool> fork_detected_{false};    // set by atfork parent handler after fork()
+    std::atomic<bool> child_state_reset_{false}; // true after inherited state cleared in child
 };
 
 }  // namespace kerncap

--- a/kerncap/tests/unit/test_capturer.py
+++ b/kerncap/tests/unit/test_capturer.py
@@ -107,6 +107,23 @@ class TestLdPreload:
 
     @patch("kerncap.capturer.subprocess.run")
     @patch("kerncap._get_lib_path", return_value="/fake/libkerncap.so")
+    def test_sets_capture_child_env(self, _mock_lib, mock_run, tmp_path):
+        dispatch = tmp_path / "dispatch.json"
+        dispatch.write_text("{}")
+
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+
+        run_capture(
+            kernel_name="kern",
+            cmd=["./app"],
+            output_dir=str(tmp_path),
+        )
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env.get("KERNCAP_CAPTURE_CHILD") == "1"
+
+    @patch("kerncap.capturer.subprocess.run")
+    @patch("kerncap._get_lib_path", return_value="/fake/libkerncap.so")
     def test_triton_delegates_to_triton_capture(self, _mock_lib, mock_run, tmp_path):
         with patch("kerncap.triton_capture.run_triton_capture") as mock_triton:
             mock_triton.return_value = str(tmp_path)


### PR DESCRIPTION
# Summary
- Adds multi-process (fork) safety to kerncap's HSA interception library so that when a parent process forks (e.g., vLLM's `EngineCore` spawning a child), only one process actively intercepts GPU queues — preventing dual interception that corrupted GPU memory during initialization.
- Uses `pthread_atfork` to detect forks: the parent becomes "passive" (passes all HSA calls through untouched) while the child resets inherited tracking state and takes over as the active interceptor.
- Guarded behind a new `KERNCAP_CAPTURE_CHILD` environment variable (set automatically by `run_capture`), so single-process workloads are completely unaffected.

## Problem
When profiling vLLM, the `EngineCore` process forks a child that also initializes HSA. Because kerncap's `libkerncap.so` is loaded via LD_PRELOAD, both the parent and child were intercepting `hsa_queue_create` — each calling `hsa_amd_queue_intercept_create` and registering packet callbacks. This dual interception corrupted GPU memory during HSA initialization, causing crashes or silent data corruption.