### PR TITLE
[kerncap] DWARF fallback for framework header kernels

### DIFF
--- a/kerncap/kerncap/capturer.py
+++ b/kerncap/kerncap/capturer.py
@@ -93,8 +93,8 @@ def run_capture(
     meta_file = os.path.join(output_dir, "metadata.json")
 
     if not os.path.exists(dispatch_file) and not os.path.exists(meta_file):
-        stdout_preview = proc.stdout[:500] if proc.stdout else "N/A"
-        stderr_preview = proc.stderr[:500] if proc.stderr else "N/A"
+        stdout_preview = proc.stdout[:2000] if proc.stdout else "N/A"
+        stderr_preview = proc.stderr[:2000] if proc.stderr else "N/A"
         raise RuntimeError(
             f"Capture did not produce output in {output_dir}. "
             f"App stdout: {stdout_preview}\n"

--- a/kerncap/kerncap/cli.py
+++ b/kerncap/kerncap/cli.py
@@ -61,7 +61,13 @@ def main(verbose):
 @main.command()
 @click.argument("cmd", nargs=-1, required=True)
 @click.option("--output", "-o", default=None, help="Write profile results to JSON file.")
-def profile(cmd, output):
+@click.option(
+    "--timeout",
+    default=None,
+    type=int,
+    help="Maximum seconds to wait for the application (default: no limit).",
+)
+def profile(cmd, output, timeout):
     """Profile an application and rank kernels by execution time.
 
     CMD is the application command to profile (e.g., ./my_app --flag).
@@ -72,7 +78,7 @@ def profile(cmd, output):
     click.echo(f"Profiling: {' '.join(cmd_list)}")
 
     try:
-        kernels = run_profile(cmd_list, output_path=output)
+        kernels = run_profile(cmd_list, output_path=output, timeout=timeout)
     except Exception as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
@@ -118,7 +124,13 @@ def profile(cmd, output):
     help="Extra preprocessor defines for reproducer (e.g. -D GGML_USE_HIP). "
     "May be specified multiple times.",
 )
-def extract(kernel_name, cmd, source_dir, output, language, dispatch, defines):
+@click.option(
+    "--timeout",
+    default=300,
+    type=int,
+    help="Maximum seconds to wait for the application (default: 300).",
+)
+def extract(kernel_name, cmd, source_dir, output, language, dispatch, defines, timeout):
     """Extract a kernel into a standalone reproducer.
 
     KERNEL_NAME is the kernel name (or substring) to capture.
@@ -134,6 +146,7 @@ def extract(kernel_name, cmd, source_dir, output, language, dispatch, defines):
             language=language,
             dispatch=dispatch,
             defines=list(defines) if defines else None,
+            timeout=timeout,
         )
     except Exception as e:
         click.echo(f"Extract failed: {e}", err=True)

--- a/kerncap/kerncap/profiler.py
+++ b/kerncap/kerncap/profiler.py
@@ -35,6 +35,7 @@ def run_profile(
     cmd: List[str],
     output_path: Optional[str] = None,
     rocprof_bin: Optional[str] = None,
+    timeout: Optional[int] = None,
 ) -> List[KernelStat]:
     """Profile an application with rocprofv3 --kernel-trace --stats.
 
@@ -47,6 +48,8 @@ def run_profile(
         returned in-memory.
     rocprof_bin : str, optional
         Path to rocprofv3 binary.  Auto-detected if None.
+    timeout : int, optional
+        Maximum seconds to wait for the application.  None means no limit.
 
     Returns
     -------
@@ -72,11 +75,15 @@ def run_profile(
             "--",
         ] + cmd
 
-        proc = subprocess.run(
-            full_cmd,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            proc = subprocess.run(
+                full_cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            raise TimeoutError(f"Application did not complete within {timeout}s")
 
         stats_csv = _find_stats_csv(tmpdir)
 

--- a/kerncap/kerncap/profiler.py
+++ b/kerncap/kerncap/profiler.py
@@ -216,7 +216,7 @@ def _write_profile_json(kernels: List[KernelStat], path: str, cmd: List[str]) ->
                 "stddev_ns": k.stddev_ns,
             }
             for k in kernels
-        ]
+        ],
     }
     with open(path, "w") as f:
         json.dump(data, f, indent=2)

--- a/kerncap/kerncap/profiler.py
+++ b/kerncap/kerncap/profiler.py
@@ -109,7 +109,7 @@ def run_profile(
         kernels = parse_kernel_trace_stats(stats_csv)
 
     if output_path:
-        _write_profile_json(kernels, output_path)
+        _write_profile_json(kernels, output_path, cmd)
 
     return kernels
 
@@ -195,11 +195,15 @@ def parse_kernel_trace_stats(csv_path: str) -> List[KernelStat]:
     return kernels
 
 
-def _write_profile_json(kernels: List[KernelStat], path: str) -> None:
+def _write_profile_json(kernels: List[KernelStat], path: str, cmd: List[str]) -> None:
     """Write profiling results as JSON."""
     import json
+    import shlex
+    from datetime import datetime, timezone
 
     data = {
+        "cmd": shlex.join(cmd),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "kernels": [
             {
                 "name": k.name,

--- a/kerncap/kerncap/source_finder.py
+++ b/kerncap/kerncap/source_finder.py
@@ -993,7 +993,7 @@ def _parse_readelf_output(output: str) -> List[str]:
         if path and "/" in path:
             files.add(os.path.normpath(path))
 
-    return list(files)
+    return sorted(files)
 
 
 def _pick_main_file(user_files: List[str], base_name: str) -> str:

--- a/kerncap/kerncap/source_finder.py
+++ b/kerncap/kerncap/source_finder.py
@@ -881,7 +881,9 @@ def _extract_dwarf_source_files(obj_path: str) -> Optional[List[str]]:
     Returns a list of source file paths, or ``None`` if no debug info
     is available.
     """
+    rocm = os.environ.get("ROCM_PATH", "/opt/rocm")
     for dwarfdump in [
+        os.path.join(rocm, "llvm", "bin", "llvm-dwarfdump"),
         "/opt/rocm/llvm/bin/llvm-dwarfdump",
         "llvm-dwarfdump",
     ]:

--- a/kerncap/kerncap/source_finder.py
+++ b/kerncap/kerncap/source_finder.py
@@ -1048,6 +1048,12 @@ def _find_hip_kernel_via_dwarf(
         _logger.debug("DWARF: no debug info in %s", obj_path)
         return None
 
+    if compile_dir:
+        dwarf_files = [
+            os.path.join(compile_dir, f) if not os.path.isabs(f) else f
+            for f in dwarf_files
+        ]
+
     abs_source_dir = os.path.abspath(source_dir)
     user_files = [
         f

--- a/kerncap/kerncap/source_finder.py
+++ b/kerncap/kerncap/source_finder.py
@@ -1036,8 +1036,7 @@ def _find_hip_kernel_via_dwarf(
     user_files = [
         f
         for f in dwarf_files
-        if os.path.abspath(f).startswith(abs_source_dir + os.sep)
-        and os.path.isfile(f)
+        if os.path.abspath(f).startswith(abs_source_dir + os.sep) and os.path.isfile(f)
     ]
 
     if not user_files:
@@ -1069,9 +1068,7 @@ def _find_hip_kernel_via_dwarf(
             for d in extra_defines or []:
                 k, _, v = d.partition("=")
                 merged_defs[k] = v or None
-            compile_defines = [
-                f"{k}={v}" if v else k for k, v in merged_defs.items()
-            ]
+            compile_defines = [f"{k}={v}" if v else k for k, v in merged_defs.items()]
         if cc_includes:
             include_paths = cc_includes
 

--- a/kerncap/kerncap/source_finder.py
+++ b/kerncap/kerncap/source_finder.py
@@ -717,6 +717,22 @@ def _find_translation_unit(
     return candidates[0]
 
 
+def _nm_has_symbol(nm_output: str, symbol: str) -> bool:
+    """Check whether *symbol* appears as an exact symbol in ``nm`` output.
+
+    Each ``nm`` output line has the form ``[address] type symbol``.  We compare
+    the symbol column for exact equality to avoid false positives when the
+    target is a prefix/substring of another symbol.
+    """
+    for line in nm_output.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[2] == symbol:
+            return True
+        if len(parts) == 2 and parts[1] == symbol:
+            return True
+    return False
+
+
 def _match_tu_via_object_symbols(
     mangled_name: str,
     candidates: List[Tuple[str, str, str]],
@@ -776,7 +792,7 @@ def _match_tu_via_object_symbols(
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
 
-        if mangled_name in proc.stdout:
+        if _nm_has_symbol(proc.stdout, mangled_name):
             _logger.debug(
                 "Matched translation unit %s via nm on %s",
                 tu_path,
@@ -857,7 +873,7 @@ def _find_tu_by_symbol(
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
 
-        if mangled_name in proc.stdout:
+        if _nm_has_symbol(proc.stdout, mangled_name):
             cmd = cmd_str
             if not cmd:
                 cmd = " ".join(shlex.quote(a) for a in args) if args else ""

--- a/kerncap/kerncap/source_finder.py
+++ b/kerncap/kerncap/source_finder.py
@@ -1050,8 +1050,7 @@ def _find_hip_kernel_via_dwarf(
 
     if compile_dir:
         dwarf_files = [
-            os.path.join(compile_dir, f) if not os.path.isabs(f) else f
-            for f in dwarf_files
+            os.path.join(compile_dir, f) if not os.path.isabs(f) else f for f in dwarf_files
         ]
 
     abs_source_dir = os.path.abspath(source_dir)

--- a/kerncap/kerncap/source_finder.py
+++ b/kerncap/kerncap/source_finder.py
@@ -239,6 +239,17 @@ def _find_hip_kernel(
     mangled_name: str = "",
 ) -> Optional[KernelSource]:
     """Locate a __global__ HIP kernel in a C++/HIP source tree."""
+    if mangled_name:
+        cc_path = _find_compile_commands_from_source_dir(source_dir)
+        if cc_path:
+            result = _find_hip_kernel_via_dwarf(
+                kernel_name, mangled_name, source_dir, cc_path, extra_defines
+            )
+            if result:
+                _logger.info("Source discovery via DWARF debug info succeeded")
+                return result
+            _logger.debug("DWARF discovery failed, falling back to source grep")
+
     search_files: List[str] = []
     for root, _, files in os.walk(source_dir):
         for fname in files:
@@ -791,6 +802,296 @@ def _extract_output_path(tokens: List[str], working_dir: str) -> Optional[str]:
                 path = os.path.join(working_dir, path)
             return os.path.normpath(path)
     return None
+
+
+# ---------------------------------------------------------------------------
+# DWARF-based source discovery
+# ---------------------------------------------------------------------------
+
+
+def _find_tu_by_symbol(
+    mangled_name: str,
+    compile_commands_path: str,
+) -> Optional[Tuple[str, str, str, str]]:
+    """Find the translation unit that compiled a mangled symbol.
+
+    Scans all entries in ``compile_commands.json``, extracts object file
+    paths via ``-o``, and runs ``nm`` on each to find which one contains
+    *mangled_name*.
+
+    Returns ``(tu_path, compile_command, compile_dir, object_file_path)``
+    or ``None``.
+    """
+    import json as _json
+    import shlex
+
+    try:
+        with open(compile_commands_path, "r") as f:
+            entries = _json.load(f)
+    except (OSError, ValueError):
+        return None
+
+    for entry in entries:
+        entry_file = entry.get("file", "")
+        if not os.path.isabs(entry_file):
+            entry_file = os.path.join(entry.get("directory", ""), entry_file)
+        entry_abs = os.path.abspath(entry_file)
+
+        cmd_str = entry.get("command", "")
+        args = entry.get("arguments", [])
+        tokens = args if args else shlex.split(cmd_str) if cmd_str else []
+
+        obj_path = _extract_output_path(tokens, entry.get("directory", ""))
+        if not obj_path or not os.path.isfile(obj_path):
+            continue
+
+        try:
+            proc = subprocess.run(
+                ["nm", obj_path],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if proc.returncode != 0:
+                continue
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            continue
+
+        if mangled_name in proc.stdout:
+            cmd = cmd_str
+            if not cmd:
+                cmd = " ".join(shlex.quote(a) for a in args) if args else ""
+            directory = entry.get("directory", "")
+            _logger.debug(
+                "Found TU %s for symbol %s via nm on %s",
+                entry_abs,
+                mangled_name,
+                obj_path,
+            )
+            return entry_abs, cmd, directory, obj_path
+
+    return None
+
+
+def _extract_dwarf_source_files(obj_path: str) -> Optional[List[str]]:
+    """Extract source file paths from DWARF debug info in an object file.
+
+    Tries ``llvm-dwarfdump`` first (ships with ROCm at
+    ``/opt/rocm/llvm/bin/``), falls back to ``readelf``.
+    Returns a list of source file paths, or ``None`` if no debug info
+    is available.
+    """
+    for dwarfdump in [
+        "/opt/rocm/llvm/bin/llvm-dwarfdump",
+        "llvm-dwarfdump",
+    ]:
+        try:
+            proc = subprocess.run(
+                [dwarfdump, "--debug-line", obj_path],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if proc.returncode == 0 and proc.stdout.strip():
+                files = _parse_llvm_dwarfdump_output(proc.stdout)
+                if files:
+                    return files
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            continue
+
+    try:
+        proc = subprocess.run(
+            ["readelf", "--debug-dump=decodedline", obj_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            files = _parse_readelf_output(proc.stdout)
+            if files:
+                return files
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    return None
+
+
+def _parse_llvm_dwarfdump_output(output: str) -> List[str]:
+    """Parse ``llvm-dwarfdump --debug-line`` output to extract source paths.
+
+    Extracts ``include_directories`` and ``file_names`` from the line table
+    prologue, then joins directory + filename to reconstruct full paths.
+    """
+    directories: Dict[int, str] = {}
+    files: List[str] = []
+
+    dir_re = re.compile(r'include_directories\[\s*(\d+)\]\s*=\s*"([^"]+)"')
+    for m in dir_re.finditer(output):
+        directories[int(m.group(1))] = m.group(2)
+
+    file_re = re.compile(
+        r"file_names\[\s*\d+\]:\s*\n"
+        r'\s+name:\s*"([^"]+)"\s*\n'
+        r"\s+dir_index:\s*(\d+)",
+    )
+    for m in file_re.finditer(output):
+        name = m.group(1)
+        dir_idx = int(m.group(2))
+        if os.path.isabs(name):
+            files.append(name)
+        elif dir_idx in directories:
+            files.append(os.path.join(directories[dir_idx], name))
+        else:
+            files.append(name)
+
+    seen: Set[str] = set()
+    unique: List[str] = []
+    for f in files:
+        norm = os.path.normpath(f)
+        if norm not in seen:
+            seen.add(norm)
+            unique.append(norm)
+
+    return unique
+
+
+def _parse_readelf_output(output: str) -> List[str]:
+    """Parse ``readelf --debug-dump=decodedline`` output for source paths.
+
+    Extracts file paths from ``CU:`` headers and decoded line-table data
+    rows.
+    """
+    files: Set[str] = set()
+
+    cu_re = re.compile(r"^CU:\s+(.+?):\s*$", re.MULTILINE)
+    for m in cu_re.finditer(output):
+        path = m.group(1).strip()
+        if path:
+            files.add(os.path.normpath(path))
+
+    line_re = re.compile(r"^(\S+)\s+\d+\s+0x", re.MULTILINE)
+    for m in line_re.finditer(output):
+        path = m.group(1).strip()
+        if path and "/" in path:
+            files.add(os.path.normpath(path))
+
+    return list(files)
+
+
+def _pick_main_file(user_files: List[str], base_name: str) -> str:
+    """Pick the best main_file from DWARF-discovered user source files.
+
+    Preference order:
+    1. Compilable source (.cu/.hip/.cpp) whose basename contains *base_name*
+    2. Any compilable source file
+    3. Header whose basename contains *base_name*
+    4. First file in the list
+    """
+    source_exts = (".cu", ".hip", ".cpp", ".cxx", ".cc")
+
+    for f in user_files:
+        if f.endswith(source_exts) and base_name in os.path.basename(f):
+            return f
+
+    for f in user_files:
+        if f.endswith(source_exts):
+            return f
+
+    for f in user_files:
+        if base_name in os.path.basename(f):
+            return f
+
+    return user_files[0]
+
+
+def _find_hip_kernel_via_dwarf(
+    kernel_name: str,
+    mangled_name: str,
+    source_dir: str,
+    compile_commands_path: str,
+    extra_defines: Optional[List[str]] = None,
+) -> Optional[KernelSource]:
+    """Find a HIP kernel source via DWARF debug info in object files.
+
+    Works backward from the compiled object: use the mangled symbol to
+    find the object file, read its DWARF line tables to discover which
+    source files contributed, then filter by *source_dir* to separate
+    user code from framework/system headers.
+    """
+    tu_match = _find_tu_by_symbol(mangled_name, compile_commands_path)
+    if not tu_match:
+        _logger.debug("DWARF: no TU found for symbol %s", mangled_name)
+        return None
+
+    tu_path, compile_cmd, compile_dir, obj_path = tu_match
+
+    dwarf_files = _extract_dwarf_source_files(obj_path)
+    if not dwarf_files:
+        _logger.debug("DWARF: no debug info in %s", obj_path)
+        return None
+
+    abs_source_dir = os.path.abspath(source_dir)
+    user_files = [
+        f
+        for f in dwarf_files
+        if os.path.abspath(f).startswith(abs_source_dir + os.sep)
+        and os.path.isfile(f)
+    ]
+
+    if not user_files:
+        _logger.debug(
+            "DWARF: none of %d source files are under %s",
+            len(dwarf_files),
+            source_dir,
+        )
+        return None
+
+    base_name = _extract_base_name(kernel_name)
+    main_file = _pick_main_file(user_files, base_name)
+
+    compile_defines = list(extra_defines or [])
+    include_paths: List[str] = []
+
+    if compile_cmd:
+        cc_defines = _extract_defines_from_command(compile_cmd, [])
+        cc_includes = _extract_includes_from_command(
+            compile_cmd,
+            [],
+            working_dir=compile_dir,
+        )
+        if cc_defines:
+            merged_defs: Dict[str, Optional[str]] = {}
+            for d in cc_defines:
+                k, _, v = d.partition("=")
+                merged_defs[k] = v or None
+            for d in extra_defines or []:
+                k, _, v = d.partition("=")
+                merged_defs[k] = v or None
+            compile_defines = [
+                f"{k}={v}" if v else k for k, v in merged_defs.items()
+            ]
+        if cc_includes:
+            include_paths = cc_includes
+
+    _logger.info(
+        "DWARF discovery: %d user files, main_file=%s, TU=%s",
+        len(user_files),
+        main_file,
+        tu_path,
+    )
+
+    return KernelSource(
+        language="hip",
+        kernel_name=kernel_name,
+        main_file=main_file,
+        source_files=user_files,
+        include_paths=include_paths or _detect_include_paths(source_dir),
+        compile_defines=compile_defines,
+        kernel_function=base_name,
+        translation_unit=tu_path,
+        compile_command=compile_cmd,
+        compile_dir=compile_dir,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/kerncap/tests/unit/test_dwarf_source_finder.py
+++ b/kerncap/tests/unit/test_dwarf_source_finder.py
@@ -1,0 +1,599 @@
+"""Unit tests for DWARF-based source discovery in kerncap.source_finder."""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kerncap.source_finder import (
+    _extract_dwarf_source_files,
+    _find_hip_kernel_via_dwarf,
+    _find_tu_by_symbol,
+    _parse_llvm_dwarfdump_output,
+    _parse_readelf_output,
+    _pick_main_file,
+    find_kernel_source,
+)
+
+SAMPLE_DWARFDUMP_OUTPUT = """\
+debug_line[0x00000000]
+Line table prologue:
+    total_length: 0x000001e8
+          format: DWARF32
+         version: 5
+    address_size: 8
+   seg_select_size: 0
+ prologue_length: 0x00000067
+ min_inst_length: 1
+max_ops_per_inst: 1
+ default_is_stmt: 1
+       line_base: -5
+      line_range: 14
+     opcode_base: 13
+standard_opcode_lengths[DW_LNS_copy] = 0
+standard_opcode_lengths[DW_LNS_advance_pc] = 1
+standard_opcode_lengths[DW_LNS_advance_line] = 1
+standard_opcode_lengths[DW_LNS_set_file] = 1
+standard_opcode_lengths[DW_LNS_set_column] = 1
+standard_opcode_lengths[DW_LNS_negate_stmt] = 0
+standard_opcode_lengths[DW_LNS_set_basic_block] = 0
+standard_opcode_lengths[DW_LNS_const_add_pc] = 0
+standard_opcode_lengths[DW_LNS_fixed_advance_pc] = 1
+standard_opcode_lengths[DW_LNS_set_prologue_end] = 0
+standard_opcode_lengths[DW_LNS_set_epilogue_begin] = 0
+standard_opcode_lengths[DW_LNS_set_isa] = 1
+include_directories[  0] = "/home/user/project/build"
+include_directories[  1] = "/home/user/project/src"
+include_directories[  2] = "/home/user/project/include"
+include_directories[  3] = "/opt/rocm/include"
+file_names[  0]:
+           name: "main.cpp"
+      dir_index: 1
+   md5_checksum: 0123456789abcdef0123456789abcdef
+file_names[  1]:
+           name: "helper.h"
+      dir_index: 2
+   md5_checksum: fedcba9876543210fedcba9876543210
+file_names[  2]:
+           name: "hip_runtime.h"
+      dir_index: 3
+   md5_checksum: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"""
+
+SAMPLE_READELF_OUTPUT = """\
+Contents of the .debug_line section:
+
+CU: /home/user/project/src/main.cpp:
+File name                            Line number    Starting address    View    Stmt
+/home/user/project/src/main.cpp               1            0x1000               x
+/home/user/project/include/helper.h          10            0x1020               x
+/opt/rocm/include/hip_runtime.h              20            0x1040               x
+/home/user/project/src/main.cpp              30            0x1060               x
+"""
+
+
+class TestParseLlvmDwarfdumpOutput:
+    """Tests for DWARF line table prologue parsing."""
+
+    def test_parse_basic_output(self):
+        files = _parse_llvm_dwarfdump_output(SAMPLE_DWARFDUMP_OUTPUT)
+        assert len(files) == 3
+        assert "/home/user/project/src/main.cpp" in files
+        assert "/home/user/project/include/helper.h" in files
+        assert "/opt/rocm/include/hip_runtime.h" in files
+
+    def test_empty_output_returns_empty(self):
+        assert _parse_llvm_dwarfdump_output("") == []
+
+    def test_no_file_names_returns_empty(self):
+        output = 'include_directories[  0] = "/path"\n'
+        assert _parse_llvm_dwarfdump_output(output) == []
+
+    def test_absolute_name_ignores_dir_index(self):
+        output = (
+            'include_directories[  0] = "/should/not/use"\n'
+            'file_names[  0]:\n'
+            '           name: "/absolute/path/file.cpp"\n'
+            '      dir_index: 0\n'
+        )
+        files = _parse_llvm_dwarfdump_output(output)
+        assert len(files) == 1
+        assert files[0] == "/absolute/path/file.cpp"
+
+    def test_deduplication(self):
+        output = (
+            'include_directories[  0] = "/path"\n'
+            'file_names[  0]:\n'
+            '           name: "file.cpp"\n'
+            '      dir_index: 0\n'
+            'file_names[  1]:\n'
+            '           name: "file.cpp"\n'
+            '      dir_index: 0\n'
+        )
+        files = _parse_llvm_dwarfdump_output(output)
+        assert len(files) == 1
+
+    def test_missing_dir_index_uses_name_as_is(self):
+        output = (
+            'file_names[  0]:\n'
+            '           name: "orphan.cpp"\n'
+            '      dir_index: 99\n'
+        )
+        files = _parse_llvm_dwarfdump_output(output)
+        assert len(files) == 1
+        assert files[0] == "orphan.cpp"
+
+    def test_dwarf_v4_format(self):
+        """DWARF v4 uses 1-based indices and mod_time/length fields."""
+        output = (
+            'include_directories[  1] = "/home/user/src"\n'
+            'include_directories[  2] = "/home/user/include"\n'
+            'file_names[  1]:\n'
+            '           name: "kernel.cu"\n'
+            '      dir_index: 1\n'
+            '           mod_time: 0x00000000\n'
+            '             length: 0x00000000\n'
+            'file_names[  2]:\n'
+            '           name: "types.h"\n'
+            '      dir_index: 2\n'
+            '           mod_time: 0x00000000\n'
+            '             length: 0x00000000\n'
+        )
+        files = _parse_llvm_dwarfdump_output(output)
+        assert len(files) == 2
+        assert "/home/user/src/kernel.cu" in files
+        assert "/home/user/include/types.h" in files
+
+
+class TestParseReadelfOutput:
+    """Tests for readelf --debug-dump=decodedline parsing."""
+
+    def test_parse_basic_output(self):
+        files = _parse_readelf_output(SAMPLE_READELF_OUTPUT)
+        assert "/home/user/project/src/main.cpp" in files
+        assert "/home/user/project/include/helper.h" in files
+        assert "/opt/rocm/include/hip_runtime.h" in files
+
+    def test_empty_output_returns_empty(self):
+        assert _parse_readelf_output("") == []
+
+    def test_deduplication(self):
+        files = _parse_readelf_output(SAMPLE_READELF_OUTPUT)
+        main_count = sum(1 for f in files if f.endswith("main.cpp"))
+        assert main_count == 1
+
+    def test_cu_header_extracted(self):
+        output = "CU: /path/to/file.cpp:\n"
+        files = _parse_readelf_output(output)
+        assert "/path/to/file.cpp" in files
+
+
+class TestPickMainFile:
+    """Tests for main_file selection from DWARF-discovered user files."""
+
+    def test_prefer_source_with_matching_name(self):
+        files = [
+            "/project/src/utils.cpp",
+            "/project/src/my_kernel.cu",
+            "/project/src/common.h",
+        ]
+        assert _pick_main_file(files, "my_kernel") == "/project/src/my_kernel.cu"
+
+    def test_prefer_source_over_header(self):
+        files = [
+            "/project/include/kernel.h",
+            "/project/src/driver.cpp",
+        ]
+        result = _pick_main_file(files, "something_else")
+        assert result == "/project/src/driver.cpp"
+
+    def test_prefer_source_over_matching_header(self):
+        """A non-matching source is preferred over a name-matching header."""
+        files = [
+            "/project/src/driver.cpp",
+            "/project/include/my_kernel.cuh",
+        ]
+        result = _pick_main_file(files, "my_kernel")
+        assert result == "/project/src/driver.cpp"
+
+    def test_fallback_to_name_matching_header(self):
+        files = [
+            "/project/include/my_kernel.cuh",
+        ]
+        result = _pick_main_file(files, "my_kernel")
+        assert result == "/project/include/my_kernel.cuh"
+
+    def test_fallback_to_first_file(self):
+        files = [
+            "/project/include/types.h",
+            "/project/include/macros.h",
+        ]
+        result = _pick_main_file(files, "nonexistent")
+        assert result == files[0]
+
+    def test_hip_extension_recognized(self):
+        files = [
+            "/project/src/kernel.hip",
+            "/project/include/common.h",
+        ]
+        result = _pick_main_file(files, "anything")
+        assert result == "/project/src/kernel.hip"
+
+
+class TestSourceDirFiltering:
+    """Tests for source_dir-based filtering in DWARF discovery."""
+
+    def test_filters_framework_headers(self):
+        dwarf_files = [
+            "/home/user/project/src/main.cpp",
+            "/home/user/project/include/helper.h",
+            "/opt/rocm/include/hip_runtime.h",
+            "/home/user/kokkos/core/Kokkos_Parallel.hpp",
+        ]
+        source_dir = "/home/user/project"
+        abs_source_dir = os.path.abspath(source_dir)
+
+        user_files = [
+            f
+            for f in dwarf_files
+            if os.path.abspath(f).startswith(abs_source_dir + os.sep)
+        ]
+
+        assert len(user_files) == 2
+        assert "/home/user/project/src/main.cpp" in user_files
+        assert "/home/user/project/include/helper.h" in user_files
+        assert "/opt/rocm/include/hip_runtime.h" not in user_files
+        assert "/home/user/kokkos/core/Kokkos_Parallel.hpp" not in user_files
+
+    def test_partial_path_not_matched(self):
+        """source_dir '/home/user/project' must not match '/home/user/project_extra/'."""
+        dwarf_files = [
+            "/home/user/project_extra/src/file.cpp",
+        ]
+        source_dir = "/home/user/project"
+        abs_source_dir = os.path.abspath(source_dir)
+
+        user_files = [
+            f
+            for f in dwarf_files
+            if os.path.abspath(f).startswith(abs_source_dir + os.sep)
+        ]
+        assert len(user_files) == 0
+
+
+class TestFindTuBySymbol:
+    """Tests for TU discovery via nm symbol lookup."""
+
+    def test_finds_matching_tu(self, tmp_path):
+        obj = tmp_path / "kernel.o"
+        obj.write_bytes(b"")
+
+        cc = tmp_path / "compile_commands.json"
+        cc.write_text(
+            json.dumps(
+                [
+                    {
+                        "directory": str(tmp_path),
+                        "command": f"/opt/rocm/llvm/bin/clang -x hip -c kernel.cu -o {obj}",
+                        "file": str(tmp_path / "kernel.cu"),
+                    }
+                ]
+            )
+        )
+
+        nm_proc = MagicMock()
+        nm_proc.returncode = 0
+        nm_proc.stdout = "0000000000001000 T _Z10my_kernelPfPfi\n"
+
+        with patch("subprocess.run", return_value=nm_proc):
+            result = _find_tu_by_symbol("_Z10my_kernelPfPfi", str(cc))
+
+        assert result is not None
+        tu_path, cmd, comp_dir, found_obj = result
+        assert "kernel.cu" in tu_path
+        assert comp_dir == str(tmp_path)
+        assert found_obj == str(obj)
+
+    def test_returns_none_when_symbol_not_found(self, tmp_path):
+        obj = tmp_path / "kernel.o"
+        obj.write_bytes(b"")
+
+        cc = tmp_path / "compile_commands.json"
+        cc.write_text(
+            json.dumps(
+                [
+                    {
+                        "directory": str(tmp_path),
+                        "command": f"/opt/rocm/llvm/bin/clang -x hip -c kernel.cu -o {obj}",
+                        "file": str(tmp_path / "kernel.cu"),
+                    }
+                ]
+            )
+        )
+
+        nm_proc = MagicMock()
+        nm_proc.returncode = 0
+        nm_proc.stdout = "                 U hipMalloc\n"
+
+        with patch("subprocess.run", return_value=nm_proc):
+            result = _find_tu_by_symbol("_Z10nonexistentPfPfi", str(cc))
+
+        assert result is None
+
+    def test_returns_none_when_no_compile_commands(self, tmp_path):
+        result = _find_tu_by_symbol(
+            "_Z10my_kernelPfPfi", str(tmp_path / "nonexistent.json")
+        )
+        assert result is None
+
+    def test_handles_nm_failure(self, tmp_path):
+        obj = tmp_path / "kernel.o"
+        obj.write_bytes(b"")
+
+        cc = tmp_path / "compile_commands.json"
+        cc.write_text(
+            json.dumps(
+                [
+                    {
+                        "directory": str(tmp_path),
+                        "command": f"/opt/rocm/llvm/bin/clang -x hip -c kernel.cu -o {obj}",
+                        "file": str(tmp_path / "kernel.cu"),
+                    }
+                ]
+            )
+        )
+
+        nm_proc = MagicMock()
+        nm_proc.returncode = 1
+        nm_proc.stdout = ""
+
+        with patch("subprocess.run", return_value=nm_proc):
+            result = _find_tu_by_symbol("_Z10my_kernelPfPfi", str(cc))
+
+        assert result is None
+
+    def test_handles_arguments_array(self, tmp_path):
+        """compile_commands.json may use 'arguments' instead of 'command'."""
+        obj = tmp_path / "kernel.o"
+        obj.write_bytes(b"")
+
+        cc = tmp_path / "compile_commands.json"
+        cc.write_text(
+            json.dumps(
+                [
+                    {
+                        "directory": str(tmp_path),
+                        "arguments": [
+                            "/opt/rocm/llvm/bin/clang",
+                            "-x",
+                            "hip",
+                            "-c",
+                            "kernel.cu",
+                            "-o",
+                            str(obj),
+                        ],
+                        "file": str(tmp_path / "kernel.cu"),
+                    }
+                ]
+            )
+        )
+
+        nm_proc = MagicMock()
+        nm_proc.returncode = 0
+        nm_proc.stdout = "0000000000001000 T _Z9my_kernelPf\n"
+
+        with patch("subprocess.run", return_value=nm_proc):
+            result = _find_tu_by_symbol("_Z9my_kernelPf", str(cc))
+
+        assert result is not None
+        _, cmd, _, _ = result
+        assert cmd != ""
+
+
+class TestDwarfFallback:
+    """Tests for DWARF fallback behavior."""
+
+    def test_fallback_no_debug_info(self, tmp_path):
+        """_extract_dwarf_source_files returns None when no debug info."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = ""
+
+        with patch("subprocess.run", return_value=mock_proc):
+            result = _extract_dwarf_source_files(str(tmp_path / "kernel.o"))
+
+        assert result is None
+
+    def test_fallback_no_compile_commands(self, tmp_path):
+        """Without compile_commands.json, DWARF is skipped, grep path used."""
+        kernel = tmp_path / "kernel.hip"
+        kernel.write_text(
+            "__global__ void my_kernel(float* a, int n) {\n"
+            "    int i = threadIdx.x;\n"
+            "}\n"
+        )
+
+        result = find_kernel_source(
+            "my_kernel",
+            str(tmp_path),
+            language="hip",
+            mangled_name="_Z9my_kernelPfi",
+        )
+        assert result is not None
+        assert result.kernel_function == "my_kernel"
+        assert "kernel.hip" in result.main_file
+
+    def test_fallback_tools_not_found(self, tmp_path):
+        """When all DWARF tools raise FileNotFoundError, returns None."""
+        with patch(
+            "subprocess.run", side_effect=FileNotFoundError("tool not found")
+        ):
+            result = _extract_dwarf_source_files(str(tmp_path / "kernel.o"))
+
+        assert result is None
+
+    def test_fallback_subprocess_timeout(self, tmp_path):
+        """When DWARF tools time out, returns None."""
+        import subprocess
+
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="llvm-dwarfdump", timeout=30),
+        ):
+            result = _extract_dwarf_source_files(str(tmp_path / "kernel.o"))
+
+        assert result is None
+
+
+class TestEndToEndDwarfPath:
+    """End-to-end test for the full DWARF discovery chain."""
+
+    def test_full_dwarf_chain(self, tmp_path):
+        """Mock the full chain: compile_commands + nm + dwarfdump -> KernelSource."""
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        kernel_file = src_dir / "my_kernel.hip"
+        kernel_file.write_text("__global__ void my_kernel(float* a) {}\n")
+        helper_file = src_dir / "helper.h"
+        helper_file.write_text("inline void helper() {}\n")
+
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+        obj_file = build_dir / "my_kernel.o"
+        obj_file.write_bytes(b"")
+
+        cc_path = build_dir / "compile_commands.json"
+        cc_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "directory": str(build_dir),
+                        "command": (
+                            f"/opt/rocm/llvm/bin/clang -DUSE_HIP "
+                            f"-I{src_dir} -x hip {kernel_file} "
+                            f"-c -o {obj_file}"
+                        ),
+                        "file": str(kernel_file),
+                    }
+                ]
+            )
+        )
+
+        nm_proc = MagicMock()
+        nm_proc.returncode = 0
+        nm_proc.stdout = "0000000000001000 T _Z9my_kernelPf\n"
+
+        dwarfdump_output = (
+            "Line table prologue:\n"
+            f'include_directories[  0] = "{build_dir}"\n'
+            f'include_directories[  1] = "{src_dir}"\n'
+            'include_directories[  2] = "/opt/rocm/include"\n'
+            "file_names[  0]:\n"
+            '           name: "my_kernel.hip"\n'
+            "      dir_index: 1\n"
+            "file_names[  1]:\n"
+            '           name: "helper.h"\n'
+            "      dir_index: 1\n"
+            "file_names[  2]:\n"
+            '           name: "hip_runtime.h"\n'
+            "      dir_index: 2\n"
+        )
+        dwarfdump_proc = MagicMock()
+        dwarfdump_proc.returncode = 0
+        dwarfdump_proc.stdout = dwarfdump_output
+
+        def mock_run(cmd, **kwargs):
+            if cmd[0] == "nm":
+                return nm_proc
+            if "dwarfdump" in cmd[0]:
+                return dwarfdump_proc
+            return MagicMock(returncode=1, stdout="")
+
+        with patch("subprocess.run", side_effect=mock_run):
+            result = _find_hip_kernel_via_dwarf(
+                kernel_name="my_kernel",
+                mangled_name="_Z9my_kernelPf",
+                source_dir=str(src_dir),
+                compile_commands_path=str(cc_path),
+                extra_defines=["EXTRA_DEF"],
+            )
+
+        assert result is not None
+        assert result.language == "hip"
+        assert result.kernel_function == "my_kernel"
+        assert "my_kernel.hip" in result.main_file
+        assert len(result.source_files) == 2
+        assert result.translation_unit != ""
+        assert result.compile_command != ""
+
+        define_names = [d.split("=")[0] for d in result.compile_defines]
+        assert "USE_HIP" in define_names
+        assert "EXTRA_DEF" in define_names
+
+    def test_dwarf_path_filters_system_headers(self, tmp_path):
+        """System/framework headers from DWARF should not appear in user_files."""
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        kernel_file = src_dir / "app.cpp"
+        kernel_file.write_text("void app() {}\n")
+
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+        obj_file = build_dir / "app.o"
+        obj_file.write_bytes(b"")
+
+        cc_path = build_dir / "compile_commands.json"
+        cc_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "directory": str(build_dir),
+                        "command": f"clang -x hip {kernel_file} -c -o {obj_file}",
+                        "file": str(kernel_file),
+                    }
+                ]
+            )
+        )
+
+        nm_proc = MagicMock()
+        nm_proc.returncode = 0
+        nm_proc.stdout = "0000000000001000 T _Z3appv\n"
+
+        dwarfdump_output = (
+            "Line table prologue:\n"
+            f'include_directories[  0] = "{src_dir}"\n'
+            'include_directories[  1] = "/opt/rocm/include"\n'
+            'include_directories[  2] = "/home/other/kokkos/core/src"\n'
+            "file_names[  0]:\n"
+            '           name: "app.cpp"\n'
+            "      dir_index: 0\n"
+            "file_names[  1]:\n"
+            '           name: "hip_runtime.h"\n'
+            "      dir_index: 1\n"
+            "file_names[  2]:\n"
+            '           name: "Kokkos_Parallel.hpp"\n'
+            "      dir_index: 2\n"
+        )
+        dwarfdump_proc = MagicMock()
+        dwarfdump_proc.returncode = 0
+        dwarfdump_proc.stdout = dwarfdump_output
+
+        def mock_run(cmd, **kwargs):
+            if cmd[0] == "nm":
+                return nm_proc
+            if "dwarfdump" in cmd[0]:
+                return dwarfdump_proc
+            return MagicMock(returncode=1, stdout="")
+
+        with patch("subprocess.run", side_effect=mock_run):
+            result = _find_hip_kernel_via_dwarf(
+                kernel_name="app",
+                mangled_name="_Z3appv",
+                source_dir=str(src_dir),
+                compile_commands_path=str(cc_path),
+            )
+
+        assert result is not None
+        assert len(result.source_files) == 1
+        assert "app.cpp" in result.source_files[0]

--- a/kerncap/tests/unit/test_dwarf_source_finder.py
+++ b/kerncap/tests/unit/test_dwarf_source_finder.py
@@ -93,9 +93,9 @@ class TestParseLlvmDwarfdumpOutput:
     def test_absolute_name_ignores_dir_index(self):
         output = (
             'include_directories[  0] = "/should/not/use"\n'
-            'file_names[  0]:\n'
+            "file_names[  0]:\n"
             '           name: "/absolute/path/file.cpp"\n'
-            '      dir_index: 0\n'
+            "      dir_index: 0\n"
         )
         files = _parse_llvm_dwarfdump_output(output)
         assert len(files) == 1
@@ -104,22 +104,18 @@ class TestParseLlvmDwarfdumpOutput:
     def test_deduplication(self):
         output = (
             'include_directories[  0] = "/path"\n'
-            'file_names[  0]:\n'
+            "file_names[  0]:\n"
             '           name: "file.cpp"\n'
-            '      dir_index: 0\n'
-            'file_names[  1]:\n'
+            "      dir_index: 0\n"
+            "file_names[  1]:\n"
             '           name: "file.cpp"\n'
-            '      dir_index: 0\n'
+            "      dir_index: 0\n"
         )
         files = _parse_llvm_dwarfdump_output(output)
         assert len(files) == 1
 
     def test_missing_dir_index_uses_name_as_is(self):
-        output = (
-            'file_names[  0]:\n'
-            '           name: "orphan.cpp"\n'
-            '      dir_index: 99\n'
-        )
+        output = 'file_names[  0]:\n           name: "orphan.cpp"\n      dir_index: 99\n'
         files = _parse_llvm_dwarfdump_output(output)
         assert len(files) == 1
         assert files[0] == "orphan.cpp"
@@ -129,16 +125,16 @@ class TestParseLlvmDwarfdumpOutput:
         output = (
             'include_directories[  1] = "/home/user/src"\n'
             'include_directories[  2] = "/home/user/include"\n'
-            'file_names[  1]:\n'
+            "file_names[  1]:\n"
             '           name: "kernel.cu"\n'
-            '      dir_index: 1\n'
-            '           mod_time: 0x00000000\n'
-            '             length: 0x00000000\n'
-            'file_names[  2]:\n'
+            "      dir_index: 1\n"
+            "           mod_time: 0x00000000\n"
+            "             length: 0x00000000\n"
+            "file_names[  2]:\n"
             '           name: "types.h"\n'
-            '      dir_index: 2\n'
-            '           mod_time: 0x00000000\n'
-            '             length: 0x00000000\n'
+            "      dir_index: 2\n"
+            "           mod_time: 0x00000000\n"
+            "             length: 0x00000000\n"
         )
         files = _parse_llvm_dwarfdump_output(output)
         assert len(files) == 2
@@ -235,9 +231,7 @@ class TestSourceDirFiltering:
         abs_source_dir = os.path.abspath(source_dir)
 
         user_files = [
-            f
-            for f in dwarf_files
-            if os.path.abspath(f).startswith(abs_source_dir + os.sep)
+            f for f in dwarf_files if os.path.abspath(f).startswith(abs_source_dir + os.sep)
         ]
 
         assert len(user_files) == 2
@@ -255,9 +249,7 @@ class TestSourceDirFiltering:
         abs_source_dir = os.path.abspath(source_dir)
 
         user_files = [
-            f
-            for f in dwarf_files
-            if os.path.abspath(f).startswith(abs_source_dir + os.sep)
+            f for f in dwarf_files if os.path.abspath(f).startswith(abs_source_dir + os.sep)
         ]
         assert len(user_files) == 0
 
@@ -322,9 +314,7 @@ class TestFindTuBySymbol:
         assert result is None
 
     def test_returns_none_when_no_compile_commands(self, tmp_path):
-        result = _find_tu_by_symbol(
-            "_Z10my_kernelPfPfi", str(tmp_path / "nonexistent.json")
-        )
+        result = _find_tu_by_symbol("_Z10my_kernelPfPfi", str(tmp_path / "nonexistent.json"))
         assert result is None
 
     def test_handles_nm_failure(self, tmp_path):
@@ -409,9 +399,7 @@ class TestDwarfFallback:
         """Without compile_commands.json, DWARF is skipped, grep path used."""
         kernel = tmp_path / "kernel.hip"
         kernel.write_text(
-            "__global__ void my_kernel(float* a, int n) {\n"
-            "    int i = threadIdx.x;\n"
-            "}\n"
+            "__global__ void my_kernel(float* a, int n) {\n    int i = threadIdx.x;\n}\n"
         )
 
         result = find_kernel_source(
@@ -426,9 +414,7 @@ class TestDwarfFallback:
 
     def test_fallback_tools_not_found(self, tmp_path):
         """When all DWARF tools raise FileNotFoundError, returns None."""
-        with patch(
-            "subprocess.run", side_effect=FileNotFoundError("tool not found")
-        ):
+        with patch("subprocess.run", side_effect=FileNotFoundError("tool not found")):
             result = _extract_dwarf_source_files(str(tmp_path / "kernel.o"))
 
         assert result is None


### PR DESCRIPTION
- Utilizing supplemental DWARF information when apps utilizing frameworks like Kokkos (e.g. LAMMPS) `__global__` lives in framework headers and which wasn't indexed. Utilizes DWARF line tables to attribute mangled kernel names to source files.
- Adding `--timeout` options to profile and extract
- Increasing debugging output when an error occurs capturing kernel