### PR TITLE
metrix: list devices from on-disk backends instead of hardcoded subset

### DIFF
--- a/metrix/src/metrix/cli/list_cmd.py
+++ b/metrix/src/metrix/cli/list_cmd.py
@@ -88,13 +88,13 @@ def list_devices():
     # listed (with empty marketing name) so new backends are visible the
     # moment their gfx*.py file is added.
     _META = {
-        "gfx90a":  ("AMD Instinct MI200", "CDNA 2"),
-        "gfx942":  ("AMD Instinct MI300", "CDNA 3"),
-        "gfx950":  ("AMD Instinct MI355X", "CDNA 4"),
-        "gfx1030": ("AMD Radeon RX 6000",  "RDNA 2"),
-        "gfx1100": ("AMD Radeon RX 7900",  "RDNA 3"),
-        "gfx1151": ("AMD Strix Halo APU",  "RDNA 3.5"),
-        "gfx1201": ("AMD Radeon RX 9070",  "RDNA 4"),
+        "gfx90a": ("AMD Instinct MI200", "CDNA 2"),
+        "gfx942": ("AMD Instinct MI300", "CDNA 3"),
+        "gfx950": ("AMD Instinct MI355X", "CDNA 4"),
+        "gfx1030": ("AMD Radeon RX 6000", "RDNA 2"),
+        "gfx1100": ("AMD Radeon RX 7900", "RDNA 3"),
+        "gfx1151": ("AMD Strix Halo APU", "RDNA 3.5"),
+        "gfx1201": ("AMD Radeon RX 9070", "RDNA 4"),
     }
 
     from pathlib import Path

--- a/metrix/src/metrix/cli/list_cmd.py
+++ b/metrix/src/metrix/cli/list_cmd.py
@@ -73,18 +73,42 @@ def list_profiles():
 
 
 def list_devices():
-    """List supported devices"""
+    """List supported devices.
+
+    Discovers backend modules on disk under ``metrix/backends/gfx*.py`` so
+    the output stays in sync with what's actually installed (instead of a
+    hardcoded list that drifts as new backends are added).
+    """
 
     print("╔════════════════════════════════════════════════════════════════════╗")
     print("║                   SUPPORTED DEVICES                                 ║")
     print("╚════════════════════════════════════════════════════════════════════╝\n")
 
-    devices = [
-        ("gfx90a", "AMD Instinct MI200", "CDNA 2"),
-        ("gfx942", "AMD Instinct MI300", "CDNA 3"),
-    ]
+    # Friendly metadata for known archs.  Backends not in this map are still
+    # listed (with empty marketing name) so new backends are visible the
+    # moment their gfx*.py file is added.
+    _META = {
+        "gfx90a":  ("AMD Instinct MI200", "CDNA 2"),
+        "gfx942":  ("AMD Instinct MI300", "CDNA 3"),
+        "gfx950":  ("AMD Instinct MI355X", "CDNA 4"),
+        "gfx1030": ("AMD Radeon RX 6000",  "RDNA 2"),
+        "gfx1100": ("AMD Radeon RX 7900",  "RDNA 3"),
+        "gfx1151": ("AMD Strix Halo APU",  "RDNA 3.5"),
+        "gfx1201": ("AMD Radeon RX 9070",  "RDNA 4"),
+    }
 
-    for arch, name, generation in devices:
-        print(f"  • {arch:10s}  {name:30s}  ({generation})")
+    from pathlib import Path
+
+    import metrix
+
+    backends_dir = Path(metrix.__file__).parent / "backends"
+    archs = sorted(p.stem for p in backends_dir.glob("gfx*.py"))
+
+    if not archs:
+        print("  (no backend modules found under metrix/backends/)")
+    else:
+        for arch in archs:
+            name, generation = _META.get(arch, ("", "unknown"))
+            print(f"  • {arch:10s}  {name:30s}  ({generation})")
 
     print("\nUse --device <arch> to specify target architecture")


### PR DESCRIPTION
## Summary

`metrix list devices` printed a hardcoded list of just two devices:

```text
• gfx90a   AMD Instinct MI200   (CDNA 2)
• gfx942   AMD Instinct MI300   (CDNA 3)
```

…even though the package now ships **seven** backend modules in `metrix/backends/`: `gfx1030`, `gfx1100`, `gfx1151`, `gfx1201`, `gfx90a`, `gfx942`, `gfx950`. The hardcoded list drifted as new backends were added in #109, #122, #123, #124. Users on RDNA hardware (e.g. gfx1201 on Radeon RX 9070) checked `list devices`, saw only MI200/MI300, and reasonably concluded their GPU wasn't supported — even though profiling actually works end-to-end on those backends.

## Fix

Discover backends at runtime by globbing `metrix/backends/gfx*.py` and attach friendly marketing names from a small `_META` table:

```text
$ metrix list devices

╔════════════════════════════════════════════════════════════════════╗
║                   SUPPORTED DEVICES                                 ║
╚════════════════════════════════════════════════════════════════════╝

  • gfx1030     AMD Radeon RX 6000              (RDNA 2)
  • gfx1100     AMD Radeon RX 7900              (RDNA 3)
  • gfx1151     AMD Strix Halo APU              (RDNA 3.5)
  • gfx1201     AMD Radeon RX 9070              (RDNA 4)
  • gfx90a      AMD Instinct MI200              (CDNA 2)
  • gfx942      AMD Instinct MI300              (CDNA 3)
  • gfx950      AMD Instinct MI355X             (CDNA 4)

Use --device <arch> to specify target architecture
```

Any future backend added under `metrix/backends/` shows up in the list automatically, even before its marketing name is registered in `_META` (it just prints with an empty name and "unknown" generation, instead of being silently invisible).

## Test plan

- [x] `metrix list devices` now reports all 7 backends matching the on-disk modules (verified on a gfx1201 host with the package installed editable).
- [x] No backend modules in a malformed install: prints `(no backend modules found under metrix/backends/)` instead of crashing.
- [x] (Reviewer) When the next backend lands (e.g. gfx1102, gfx12-generic), just add an entry to `_META` to give it a marketing name; no other changes needed.

Made with [Cursor](https://cursor.com)