### PR TITLE
fix (kerncap): ROCm package discovery in scikit-build builds

### DIFF
--- a/kerncap/pyproject.toml
+++ b/kerncap/pyproject.toml
@@ -45,6 +45,7 @@ metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 [tool.scikit-build.cmake.define]
 CMAKE_INSTALL_LIBDIR = "lib"
 CMAKE_INSTALL_BINDIR = "bin"
+ROCM_PATH = {env="ROCM_PATH", default="/opt/rocm"}
 
 # ---- setuptools-scm versioning ----
 [tool.setuptools_scm]

--- a/kerncap/src/CMakeLists.txt
+++ b/kerncap/src/CMakeLists.txt
@@ -1,5 +1,5 @@
-find_package(hsa-runtime64 REQUIRED)
-find_package(hip REQUIRED)
+find_package(hsa-runtime64 REQUIRED HINTS ${ROCM_PATH})
+find_package(hip REQUIRED HINTS ${ROCM_PATH})
 find_package(rocprofiler-sdk REQUIRED HINTS ${ROCM_PATH})
 
 # Vendored header-only dependencies


### PR DESCRIPTION
# Summary

Fix kerncap's ROCm CMake package discovery during `pip` / scikit-build builds.

# Context

On my machine, `pip install ./kerncap` failed during CMake configure even though ROCm and `hipcc` were installed. CMake found the HIP compiler, but did not find ROCm package config files like `hsa-runtime64-config.cmake` unless ROCm's prefix was provided explicitly.

The package configs are present under `/opt/rocm/lib/cmake/...`; CMake just was not being pointed at that prefix for the `hsa-runtime64` and `hip` lookups.

# Fix

This PR passes `ROCM_PATH` into kerncap's scikit-build CMake configuration, defaulting to `/opt/rocm` while still allowing users to override it via the environment:

```toml
ROCM_PATH = {env="ROCM_PATH", default="/opt/rocm"}
```

Then kerncap uses that path as a local package hint:

```cmake
find_package(hsa-runtime64 REQUIRED HINTS ${ROCM_PATH})
find_package(hip REQUIRED HINTS ${ROCM_PATH})
find_package(rocprofiler-sdk REQUIRED HINTS ${ROCM_PATH})
```

This avoids adding a custom `FindHSA.cmake` module and keeps kerncap using ROCm's official CMake package targets.

# Environment

```text
OS: Ubuntu 22.04.5 LTS (Jammy)
Python: 3.10.12
pip: 25.2
CMake: 3.30.3
HIP: 7.1.25424-4179531dcd
AMD clang: 20.0.0git, roc-7.1.0
ROCm symlink: /opt/rocm -> /opt/rocm-7.1.0
ROCm package config paths:
  /opt/rocm/lib/cmake/hsa-runtime64
  /opt/rocm/lib/cmake/hip
  /opt/rocm/lib/cmake/rocprofiler-sdk
```

# Validation

```bash
cd kerncap
pip install .
```
