### PR TITLE
Replace TemporaryDirectory(delete=False) with mkdtemp for Python 3.10 compat

### DIFF
--- a/rocm_mcp/src/rocm_mcp/compile/hip_compiler_mcp.py
+++ b/rocm_mcp/src/rocm_mcp/compile/hip_compiler_mcp.py
@@ -54,8 +54,8 @@ async def compile_hip_source_file(
 
     try:
         if output_file is None:
-            with tempfile.TemporaryDirectory(delete=False) as tmpdir:
-                output_file = Path(tmpdir) / source_file.stem
+            tmpdir = tempfile.mkdtemp()
+            output_file = Path(tmpdir) / source_file.stem
     except Exception as e:
         msg = f"Failed to create output file: {e!s}"
         await ctx.error(msg)
@@ -108,12 +108,12 @@ async def compile_hip_source_string(
         executable.
     """
     try:
-        with tempfile.TemporaryDirectory(delete=False) as tmpdir:
-            source_file = Path(tmpdir) / "hip_source.cpp"
-            if output_file is None:
-                output_file = Path(tmpdir) / "hip_exe"
-            with source_file.open("w") as f:
-                f.write(source)
+        tmpdir = tempfile.mkdtemp()
+        source_file = Path(tmpdir) / "hip_source.cpp"
+        if output_file is None:
+            output_file = Path(tmpdir) / "hip_exe"
+        with source_file.open("w") as f:
+            f.write(source)
     except Exception as e:
         msg = f"Failed to create temporary source file: {e!s}"
         await ctx.error(msg)


### PR DESCRIPTION
## Summary
- Replace `tempfile.TemporaryDirectory(delete=False)` with `tempfile.mkdtemp()` in HIP compiler MCP
- `delete=` parameter was added in Python 3.12 but package requires `>=3.10`
- `mkdtemp()` achieves the same behavior (persistent temp dir) and works on all supported Python versions

Fixes #136

## Test plan
- [ ] Verify `compile_hip_source_file` works on Python 3.10/3.11
- [ ] Verify compiled binary persists after function returns
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)