### PR TITLE
Document INTELLIKIT_UPROF_CLI env var for uProf path configuration

### DIFF
--- a/docs/tools/uprof-mcp.md
+++ b/docs/tools/uprof-mcp.md
@@ -38,6 +38,24 @@ uv pip install .
 pip install .
 ```
 
+## Setting the uProf Path
+
+uProf MCP needs to know where AMD uProf is installed. There are three ways to set this, in order of precedence:
+
+1. **Environment variable** `INTELLIKIT_UPROF_CLI`:
+   ```bash
+   export INTELLIKIT_UPROF_CLI=/opt/AMDuProf_5.3-521/bin/AMDuProfCLI
+   ```
+
+2. **Constructor argument** (Python API only):
+   ```python
+   profiler = UProfProfiler(uprof="/opt/AMDuProf_5.3-521/bin/AMDuProfCLI")
+   ```
+
+3. **Default path**: `/opt/AMDuProf_5.1-701/bin/AMDuProfCLI`
+
+For MCP server usage, set the environment variable in the MCP client configuration (see below).
+
 ## Configuration
 
 Add the following to your MCP client configuration:
@@ -47,13 +65,16 @@ Add the following to your MCP client configuration:
   "mcpServers": {
     "uprof-profiler-mcp": {
       "command": "uv",
-      "args": ["run", "--directory", "/path/to/uprof_mcp", "uprof-profiler-mcp"]
+      "args": ["run", "--directory", "/path/to/uprof_mcp", "uprof-profiler-mcp"],
+      "env": {
+        "INTELLIKIT_UPROF_CLI": "/opt/AMDuProf_5.3-521/bin/AMDuProfCLI"
+      }
     }
   }
 }
 ```
 
-Replace `/path/to/uprof_mcp` with the actual path where you have cloned or installed the package.
+Replace `/path/to/uprof_mcp` with the actual path where you have cloned or installed the package, and update the uProf path to match your installation.
 
 ## Python API (non-agentic)
 
@@ -97,8 +118,13 @@ The following describes the uProf MCP Python API for non-agentic use.
 ```python
 from uprof_mcp.uprof_profiler import UProfProfiler
 
-profiler = UProfProfiler(logger=None)
+profiler = UProfProfiler(logger=None, uprof=None)
 ```
+
+**Constructor parameters:**
+
+- `logger` (logging.Logger | None): Logger instance. If None, a default logger is created.
+- `uprof` (str | PathLike | None): Path to the uProf CLI executable. If None, uses the `INTELLIKIT_UPROF_CLI` environment variable, or falls back to the default path.
 
 **Methods:**
 

--- a/uprof_mcp/README.md
+++ b/uprof_mcp/README.md
@@ -27,6 +27,22 @@ uv pip install .
 pip install .
 ```
 
+## Setting the uProf Path
+
+uProf MCP needs to know where AMD uProf is installed. There are three ways to set this, in order of precedence:
+
+1. **Environment variable** `INTELLIKIT_UPROF_CLI`:
+   ```bash
+   export INTELLIKIT_UPROF_CLI=/opt/AMDuProf_5.3-521/bin/AMDuProfCLI
+   ```
+
+2. **Constructor argument** (Python API only):
+   ```python
+   profiler = UProfProfiler(uprof="/opt/AMDuProf_5.3-521/bin/AMDuProfCLI")
+   ```
+
+3. **Default path**: `/opt/AMDuProf_5.1-701/bin/AMDuProfCLI`
+
 ## Configuration
 
 To use this server with an MCP client, add the following to your configuration file:
@@ -36,13 +52,16 @@ To use this server with an MCP client, add the following to your configuration f
   "mcpServers": {
     "uprof-profiler-mcp": {
       "command": "uv",
-      "args": ["run", "--directory", "/path/to/uprof_mcp", "uprof-profiler-mcp"]
+      "args": ["run", "--directory", "/path/to/uprof_mcp", "uprof-profiler-mcp"],
+      "env": {
+        "INTELLIKIT_UPROF_CLI": "/opt/AMDuProf_5.3-521/bin/AMDuProfCLI"
+      }
     }
   }
 }
 ```
 
-*Note: Adjust `/path/to/uprof_mcp` to the actual path where you have cloned or installed the package.*
+*Note: Adjust `/path/to/uprof_mcp` to the actual path where you have cloned or installed the package, and update the uProf path to match your installation.*
 
 ## Usage
 
@@ -114,8 +133,13 @@ This project uses `uv` for dependency management.
 ```python
 from uprof_mcp.uprof_profiler import UProfProfiler
 
-profiler = UProfProfiler(logger=None)
+profiler = UProfProfiler(logger=None, uprof=None)
 ```
+
+**Constructor parameters:**
+
+- `logger` (logging.Logger | None): Logger instance. If None, a default logger is created.
+- `uprof` (str | PathLike | None): Path to the uProf CLI executable. If None, uses the `INTELLIKIT_UPROF_CLI` environment variable, or falls back to the default path.
 
 **Methods:**
 


### PR DESCRIPTION
## Summary

- Added documentation for `INTELLIKIT_UPROF_CLI` environment variable to both `docs/tools/uprof-mcp.md` and `uprof_mcp/README.md`
- Documented all three ways to set the uProf path (env var > constructor arg > default) with correct precedence order
- MCP client config example now includes `env` block showing how to set the path
- API reference updated to document the `uprof` constructor parameter

## Test plan

- [x] Verified path resolution precedence on MI300X (env var > constructor > default)
- [x] All three methods work as documented

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)