### PR TITLE
Add IntelliKit overview slide deck

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/slides/*.pdf filter=lfs diff=lfs merge=lfs -text

--- a/docs/slides/intellikit-overview.pdf
+++ b/docs/slides/intellikit-overview.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70fdcb6a09c6cce129071a31c147f36ac22726c597d71cf20d6f257d178e01c5
+size 2192643


### PR DESCRIPTION
Add the overview slide deck (PDF) under `docs/slides/`, tracked via Git LFS to keep the binary out of git history. 

- Accompanying video is deferred for a later PR as its 20MB size could cause us to hit 1GB/month free tier quota. I recommend hosting this video elsewhere (e.g. YouTube) to reduce overhead
- Deferred official integration into docs for a future PR