### PR TITLE
Add test coverage reporting to CI

### DIFF
--- a/.github/scripts/coverage_summary.py
+++ b/.github/scripts/coverage_summary.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Aggregate per-package Cobertura XML reports into a single markdown table.
+# Usage: coverage_summary.py <directory-of-coverage-xml-files>
+
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+EXPECTED_ARGC = 2
+
+
+def read_report(path: Path) -> tuple[str, int, int] | None:
+    """Extract ``(package, covered, valid)`` from one Cobertura XML file.
+
+    Args:
+        path: Report to read. Named ``coverage-<package>.xml`` by the workflow.
+
+    Returns:
+        The package name with its covered and total line counts, or ``None``
+        if the file could not be parsed.
+    """
+    try:
+        # Trusted input: these files are produced by pytest-cov in this same
+        # workflow run, not supplied by a third party.
+        root = ET.parse(path).getroot()  # noqa: S314
+        covered = int(root.get("lines-covered", "0"))
+        valid = int(root.get("lines-valid", "0"))
+    except (ET.ParseError, ValueError) as exc:
+        print(f"warning: could not parse {path.name}: {exc}", file=sys.stderr)
+        return None
+    return path.stem.removeprefix("coverage-"), covered, valid
+
+
+def percent(covered: int, valid: int) -> float:
+    """Return ``covered`` as a percentage of ``valid``, or 0.0 when empty."""
+    return 100.0 * covered / valid if valid else 0.0
+
+
+def main() -> int:
+    """Print a markdown coverage table and return a process exit code."""
+    if len(sys.argv) != EXPECTED_ARGC:
+        print("usage: coverage_summary.py <coverage-dir>", file=sys.stderr)
+        return 2
+
+    reports = sorted(Path(sys.argv[1]).glob("coverage-*.xml"))
+    rows = [row for row in (read_report(path) for path in reports) if row is not None]
+
+    print("## Test Coverage\n")
+
+    if not rows:
+        print("No coverage reports were produced.")
+        return 0
+
+    total_covered = sum(covered for _, covered, _ in rows)
+    total_valid = sum(valid for _, _, valid in rows)
+
+    print("| Package | Lines | Covered | Coverage |")
+    print("| --- | ---: | ---: | ---: |")
+    for package, covered, valid in rows:
+        print(f"| {package} | {valid} | {covered} | {percent(covered, valid):.1f}% |")
+    print(
+        f"| **Overall** | **{total_valid}** | **{total_covered}** "
+        f"| **{percent(total_covered, total_valid):.1f}%** |"
+    )
+    print(
+        "\nMeasured on the editable install leg only. Packages not listed were "
+        "unchanged in this run and did not execute."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/intellikit-pytest.yml
+++ b/.github/workflows/intellikit-pytest.yml
@@ -103,13 +103,48 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Coverage is collected on the editable leg only. The non-editable leg
+      # installs into site-packages, so measuring both would report two
+      # different source paths for the same package.
       - name: Pytest ${{ matrix.install_method }} - ${{ matrix.package }}
         run: |
           bash .github/scripts/container_exec.sh "
             if [ '${{ matrix.install_method }}' = 'editable' ]; then
               pip install -e ${{ matrix.package }}
+              python3 -m pytest ${{ matrix.package }}/tests -v --tb=short --cov=${{ matrix.package }} --cov-report=term --cov-report=xml:coverage-${{ matrix.package }}.xml
             else
               pip install ./${{ matrix.package }}
+              python3 -m pytest ${{ matrix.package }}/tests -v --tb=short
             fi
-            python3 -m pytest ${{ matrix.package }}/tests -v --tb=short
           "
+
+      # always() so a failing test suite still reports the coverage it reached.
+      - name: Upload coverage report
+        if: always() && matrix.install_method == 'editable'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.package }}
+          path: coverage-${{ matrix.package }}.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
+  coverage-summary:
+    name: Coverage summary
+    needs: [detect-changes, pytest]
+    if: always() && needs.detect-changes.outputs.packages != '[]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download coverage reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: coverage-reports
+          merge-multiple: true
+
+      - name: Report coverage
+        run: |
+          python3 .github/scripts/coverage_summary.py coverage-reports >> "$GITHUB_STEP_SUMMARY"
+          python3 .github/scripts/coverage_summary.py coverage-reports

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,11 @@ vector_add_template
 
 # Resources
 resources/
+# Coverage
+.coverage
+.coverage.*
+coverage-*.xml
+htmlcov/
+
+# Virtualenvs
+.venv/

--- a/apptainer/intellikit.def
+++ b/apptainer/intellikit.def
@@ -25,7 +25,7 @@ From: rocm/pytorch:rocm7.1_ubuntu24.04_py3.13_pytorch_release_2.9.1
 
     # Install Python packages with pip
     pip3 install --upgrade pip && \
-    pip3 install wheel jupyter pytest
+    pip3 install wheel jupyter pytest pytest-cov
 
     # Clone and install Triton
     cd /opt


### PR DESCRIPTION
## Why

Coverage is currently not measured anywhere in the pipeline — there are no `pytest-cov` or `--cov` references in `.github/`. That means there is no baseline to set a coverage target against.

## What

- **`apptainer/intellikit.def`** — install `pytest-cov` alongside the existing `pytest`. Changing the def bumps its hash, so `container_build.sh` rebuilds the image once and the dependency is guaranteed present before any `--cov` run.
- **`.github/workflows/intellikit-pytest.yml`** — collect coverage on the existing pytest matrix and upload one Cobertura report per package. New `coverage-summary` job aggregates them.
- **`.github/scripts/coverage_summary.py`** — sums `lines-covered` / `lines-valid` across the per-package reports and writes a markdown table to the workflow summary.
- **`.gitignore`** — ignore coverage artifacts.

## Notes on the approach

**Editable leg only.** The matrix runs each package as `editable` and `non-editable`. Coverage is collected on `editable` only — the non-editable leg installs into `site-packages`, so measuring both would report two different source paths for the same package and double-count the totals.

**Upload uses `always()`.** A failing suite still reports the coverage it reached, rather than losing the data.

**Reporting only.** No `--cov-fail-under`, so this cannot fail a build that would otherwise pass. A threshold can be added once there is a baseline to argue from.

**Partial runs are honest.** `detect-changes` only tests packages that changed, so the overall figure covers the packages in that run. The summary states this explicitly rather than presenting it as a repo-wide number.

## Example output

| Package | Lines | Covered | Coverage |
| --- | ---: | ---: | ---: |
| linex | 213 | 75 | 35.2% |
| metrix | 2637 | 1539 | 58.4% |
| **Overall** | **2850** | **1614** | **56.6%** |

## Testing

- `coverage_summary.py` run against real `pytest-cov` output, plus empty-directory, malformed-XML, and missing-argument cases — all exit cleanly.
- `ruff check` and `ruff format --check` pass (repo config is `select = ["ALL"]`).
- Workflow YAML parsed and job graph verified.

The numbers above were produced off-GPU, where ROCm-dependent tests fail, so they are a floor rather than a real reading. The first CI run on the MI3xx runners will give the actual baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)