### PR TITLE
Add tests for the metrix CLI, MCP server, and backends

### DIFF
--- a/metrix/tests/unit/test_backends_and_utils.py
+++ b/metrix/tests/unit/test_backends_and_utils.py
@@ -1,0 +1,386 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for architecture detection, backend plumbing, and shared helpers.
+
+None of these need a GPU: ``rocminfo``/``hipcc``/``rocprofv3`` are all replaced
+at their call sites, so the failure paths (which are the interesting ones) can
+actually be reached.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metrix.backends import detect as detect_mod
+from metrix.backends import device_info
+from metrix.backends.detect import detect_gpu_arch, detect_or_default
+from metrix.utils.common import split_counters_into_passes
+
+# --------------------------------------------------------------------------
+# detect
+# --------------------------------------------------------------------------
+
+
+def _completed(stdout="", stderr="", rc=0):
+    return subprocess.CompletedProcess(
+        args=["rocminfo"], returncode=rc, stdout=stdout, stderr=stderr
+    )
+
+
+def test_detect_parses_arch_from_rocminfo():
+    out = "Agent 1\n  Name:  gfx942\n"
+    with patch.object(subprocess, "run", return_value=_completed(stdout=out)):
+        assert detect_gpu_arch() == "gfx942"
+
+
+def test_detect_raises_when_rocminfo_returns_nonzero():
+    with patch.object(subprocess, "run", return_value=_completed(stderr="nope", rc=1)):
+        with pytest.raises(RuntimeError, match="rocminfo failed"):
+            detect_gpu_arch()
+
+
+def test_detect_raises_when_no_arch_in_output():
+    with patch.object(subprocess, "run", return_value=_completed(stdout="nothing here")):
+        with pytest.raises(RuntimeError, match="No AMD GPU architecture"):
+            detect_gpu_arch()
+
+
+def test_detect_raises_when_rocminfo_missing():
+    with patch.object(subprocess, "run", side_effect=FileNotFoundError):
+        with pytest.raises(RuntimeError, match="rocminfo not found"):
+            detect_gpu_arch()
+
+
+def test_detect_raises_on_timeout():
+    with patch.object(subprocess, "run", side_effect=subprocess.TimeoutExpired("rocminfo", 5)):
+        with pytest.raises(RuntimeError, match="timed out"):
+            detect_gpu_arch()
+
+
+def test_detect_or_default_prefers_explicit_arch():
+    # Explicit request must short-circuit before any subprocess call.
+    with patch.object(detect_mod, "detect_gpu_arch") as probe:
+        assert detect_or_default("gfx1201") == "gfx1201"
+        probe.assert_not_called()
+
+
+def test_detect_or_default_autodetects_when_unset():
+    with patch.object(detect_mod, "detect_gpu_arch", return_value="gfx950"):
+        assert detect_or_default() == "gfx950"
+
+
+def test_detect_or_default_falls_back_to_gfx942():
+    with patch.object(detect_mod, "detect_gpu_arch", side_effect=RuntimeError("no gpu")):
+        assert detect_or_default() == "gfx942"
+
+
+# --------------------------------------------------------------------------
+# split_counters_into_passes
+# --------------------------------------------------------------------------
+
+
+def test_empty_counters_yield_one_empty_pass():
+    # Timing-only mode still needs exactly one (empty) pass.
+    assert split_counters_into_passes([]) == [[]]
+
+
+def test_no_block_limits_returns_single_pass_when_small():
+    counters = ["A", "B"]
+    assert split_counters_into_passes(counters) == [counters]
+
+
+def test_no_block_limits_chunks_by_max_per_pass():
+    counters = [f"C{i}" for i in range(7)]
+    passes = split_counters_into_passes(counters, max_per_pass=3)
+    assert [len(p) for p in passes] == [3, 3, 1]
+    assert sum(passes, []) == counters
+
+
+def test_simple_chunking_logs_when_logger_supplied():
+    logger = MagicMock()
+    split_counters_into_passes([f"C{i}" for i in range(5)], max_per_pass=2, logger=logger)
+    logger.info.assert_called_once()
+
+
+def test_block_limits_without_mapper_is_an_error():
+    with pytest.raises(ValueError, match="get_counter_block must be provided"):
+        split_counters_into_passes(["A"], block_limits={"SQ": 2})
+
+
+def test_block_aware_packing_respects_per_block_limit():
+    counters = ["SQ_1", "SQ_2", "SQ_3"]
+    passes = split_counters_into_passes(
+        counters,
+        block_limits={"SQ": 2},
+        get_counter_block=lambda c: c.split("_")[0],
+    )
+    # SQ allows 2 per pass, so 3 counters need 2 passes.
+    assert [len(p) for p in passes] == [2, 1]
+    assert sorted(sum(passes, [])) == sorted(counters)
+
+
+def test_block_aware_packing_interleaves_blocks():
+    counters = ["SQ_1", "SQ_2", "TA_1"]
+    passes = split_counters_into_passes(
+        counters,
+        block_limits={"SQ": 2, "TA": 2},
+        get_counter_block=lambda c: c.split("_")[0],
+    )
+    # Both blocks fit within their limits, so one pass suffices.
+    assert len(passes) == 1
+    assert sorted(passes[0]) == sorted(counters)
+
+
+def test_unknown_block_uses_default_limit():
+    counters = [f"XX_{i}" for i in range(5)]
+    passes = split_counters_into_passes(
+        counters,
+        block_limits={"SQ": 8},
+        get_counter_block=lambda c: c.split("_")[0],
+        default_block_limit=2,
+        max_per_pass=8,
+    )
+    assert [len(p) for p in passes] == [2, 2, 1]
+
+
+def test_max_per_pass_caps_total_across_blocks():
+    counters = ["SQ_1", "SQ_2", "TA_1", "TA_2"]
+    passes = split_counters_into_passes(
+        counters,
+        block_limits={"SQ": 4, "TA": 4},
+        get_counter_block=lambda c: c.split("_")[0],
+        max_per_pass=2,
+    )
+    assert all(len(p) <= 2 for p in passes)
+    assert sorted(sum(passes, [])) == sorted(counters)
+
+
+def test_block_aware_packing_logs_when_logger_supplied():
+    logger = MagicMock()
+    split_counters_into_passes(
+        ["SQ_1"],
+        block_limits={"SQ": 1},
+        get_counter_block=lambda c: "SQ",
+        logger=logger,
+    )
+    logger.debug.assert_called()
+    logger.info.assert_called_once()
+
+
+def test_every_counter_survives_packing():
+    counters = [f"{b}_{i}" for b in ("SQ", "TA", "TCC") for i in range(5)]
+    passes = split_counters_into_passes(
+        counters,
+        block_limits={"SQ": 2, "TA": 1, "TCC": 3},
+        get_counter_block=lambda c: c.split("_")[0],
+        max_per_pass=4,
+    )
+    # Nothing may be dropped or duplicated by the bin-packer.
+    assert sorted(sum(passes, [])) == sorted(counters)
+
+
+# --------------------------------------------------------------------------
+# gfx backends
+# --------------------------------------------------------------------------
+
+BACKENDS = [
+    ("gfx90a", "GFX90aBackend"),
+    ("gfx942", "GFX942Backend"),
+    ("gfx950", "GFX950Backend"),
+    ("gfx1030", "GFX1030Backend"),
+    ("gfx1100", "GFX1100Backend"),
+    ("gfx1151", "GFX1151Backend"),
+    ("gfx1201", "GFX1201Backend"),
+]
+
+
+def _make_backend(module_name, class_name):
+    """Build a backend with device probing stubbed out.
+
+    Uses a real ``DeviceSpecs`` rather than a mock: the base class calls
+    ``dataclasses.fields()`` on it to build expression variables, which a
+    ``MagicMock`` cannot satisfy.
+    """
+    import importlib
+
+    from metrix.backends.base import DeviceSpecs
+
+    mod = importlib.import_module(f"metrix.backends.{module_name}")
+    specs = DeviceSpecs(
+        arch=module_name,
+        name=f"test-{module_name}",
+        num_cu=64,
+        max_waves_per_cu=32,
+        wavefront_size=64,
+        base_clock_mhz=1700.0,
+        hbm_bandwidth_gbs=3200.0,
+        l2_size_mb=8.0,
+        lds_size_per_cu_kb=64.0,
+    )
+    with patch.object(mod, "query_device_specs", return_value=specs):
+        return mod, getattr(mod, class_name)()
+
+
+@pytest.mark.parametrize("module_name,class_name", BACKENDS)
+def test_backend_reports_its_own_arch(module_name, class_name):
+    _mod, backend = _make_backend(module_name, class_name)
+    assert backend.device_specs.arch == module_name
+
+
+@pytest.mark.parametrize("module_name,class_name", BACKENDS)
+def test_backend_block_limits_are_positive_ints(module_name, class_name):
+    _mod, backend = _make_backend(module_name, class_name)
+    limits = backend._get_counter_block_limits()
+    assert limits, f"{class_name} declared no block limits"
+    assert all(isinstance(v, int) and v > 0 for v in limits.values())
+
+
+@pytest.mark.parametrize("module_name,class_name", BACKENDS)
+def test_backend_groups_counters_without_dropping_any(module_name, class_name):
+    _mod, backend = _make_backend(module_name, class_name)
+    limits = backend._get_counter_block_limits()
+    block = next(iter(limits))
+    counters = [f"{block}_{i}" for i in range(limits[block] + 1)]
+    passes = backend._get_counter_groups(counters)
+    assert sorted(sum(passes, [])) == sorted(counters)
+
+
+@pytest.mark.parametrize("module_name,class_name", BACKENDS)
+def test_backend_run_rocprof_delegates_to_wrapper(module_name, class_name):
+    import sys
+
+    _mod, backend = _make_backend(module_name, class_name)
+    # The RDNA backends subclass GFX1201Backend and inherit _run_rocprof, so
+    # ROCProfV3Wrapper must be patched in whichever module defines it.
+    defining_mod = sys.modules[type(backend)._run_rocprof.__module__]
+    sentinel = [object()]
+    wrapper = MagicMock()
+    wrapper.profile.return_value = sentinel
+    with patch.object(defining_mod, "ROCProfV3Wrapper", return_value=wrapper) as ctor:
+        got = backend._run_rocprof("./app", ["SQ_WAVES"], kernel_filter="gemm.*")
+    assert got is sentinel
+    ctor.assert_called_once()
+    assert wrapper.profile.call_args.kwargs["kernel_filter"] == "gemm.*"
+
+
+def test_empty_counter_list_still_yields_one_pass():
+    _mod, backend = _make_backend("gfx942", "GFX942Backend")
+    assert backend._get_counter_groups([]) == [[]]
+
+
+# --------------------------------------------------------------------------
+# device_info
+# --------------------------------------------------------------------------
+
+
+def test_find_hip_source_returns_packaged_file():
+    src = device_info._find_hip_source()
+    # gpu_query.hip ships as package data, so this must resolve.
+    assert src is not None
+    assert src.name == "gpu_query.hip"
+
+
+def test_find_hip_source_returns_none_when_absent():
+    with (
+        patch.object(Path, "is_file", return_value=False),
+        patch("metrix.backends.__path__", []),
+    ):
+        assert device_info._find_hip_source() is None
+
+
+def test_compile_requires_hipcc(tmp_path):
+    device_info._compiled_binary = None
+    with patch.object(device_info.shutil, "which", return_value=None):
+        with pytest.raises(RuntimeError, match="hipcc not found"):
+            device_info._compile_gpu_query(tmp_path / "gpu_query.hip")
+
+
+def test_compile_reports_hipcc_failure(tmp_path):
+    device_info._compiled_binary = None
+    failed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+    with (
+        patch.object(device_info.shutil, "which", return_value="/usr/bin/hipcc"),
+        patch.object(device_info.subprocess, "run", return_value=failed),
+    ):
+        with pytest.raises(RuntimeError, match="hipcc failed"):
+            device_info._compile_gpu_query(tmp_path / "gpu_query.hip")
+
+
+def test_compile_reports_timeout(tmp_path):
+    device_info._compiled_binary = None
+    with (
+        patch.object(device_info.shutil, "which", return_value="/usr/bin/hipcc"),
+        patch.object(
+            device_info.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired("hipcc", 120),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="timed out"):
+            device_info._compile_gpu_query(tmp_path / "gpu_query.hip")
+
+
+def test_run_gpu_query_errors_when_source_missing():
+    with patch.object(device_info, "_find_hip_source", return_value=None):
+        with pytest.raises(RuntimeError, match="Cannot find gpu_query.hip"):
+            device_info._run_gpu_query()
+
+
+def test_run_gpu_query_parses_json(tmp_path):
+    payload = [{"arch": "gfx942", "cu_count": 304}]
+    ok = subprocess.CompletedProcess(args=[], returncode=0, stdout=json.dumps(payload), stderr="")
+    with (
+        patch.object(device_info, "_find_hip_source", return_value=tmp_path / "s.hip"),
+        patch.object(device_info, "_compile_gpu_query", return_value=tmp_path / "bin"),
+        patch.object(device_info.subprocess, "run", return_value=ok),
+    ):
+        assert device_info._run_gpu_query() == payload
+
+
+def test_run_gpu_query_passes_device_id(tmp_path):
+    ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr="")
+    with (
+        patch.object(device_info, "_find_hip_source", return_value=tmp_path / "s.hip"),
+        patch.object(device_info, "_compile_gpu_query", return_value=tmp_path / "bin"),
+        patch.object(device_info.subprocess, "run", return_value=ok) as run,
+    ):
+        device_info._run_gpu_query(device_id=3)
+    assert run.call_args[0][0][-1] == "3"
+
+
+def test_run_gpu_query_reports_nonzero_exit(tmp_path):
+    bad = subprocess.CompletedProcess(args=[], returncode=2, stdout="", stderr="no device")
+    with (
+        patch.object(device_info, "_find_hip_source", return_value=tmp_path / "s.hip"),
+        patch.object(device_info, "_compile_gpu_query", return_value=tmp_path / "bin"),
+        patch.object(device_info.subprocess, "run", return_value=bad),
+    ):
+        with pytest.raises(RuntimeError, match="gpu_query failed"):
+            device_info._run_gpu_query()
+
+
+def test_run_gpu_query_reports_bad_json(tmp_path):
+    ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="not json", stderr="")
+    with (
+        patch.object(device_info, "_find_hip_source", return_value=tmp_path / "s.hip"),
+        patch.object(device_info, "_compile_gpu_query", return_value=tmp_path / "bin"),
+        patch.object(device_info.subprocess, "run", return_value=ok),
+    ):
+        with pytest.raises(RuntimeError, match="invalid JSON"):
+            device_info._run_gpu_query()
+
+
+def test_run_gpu_query_reports_missing_binary(tmp_path):
+    with (
+        patch.object(device_info, "_find_hip_source", return_value=tmp_path / "s.hip"),
+        patch.object(device_info, "_compile_gpu_query", return_value=tmp_path / "bin"),
+        patch.object(device_info.subprocess, "run", side_effect=FileNotFoundError),
+    ):
+        with pytest.raises(RuntimeError, match="gpu_query failed"):
+            device_info._run_gpu_query()

--- a/metrix/tests/unit/test_catalog_and_result.py
+++ b/metrix/tests/unit/test_catalog_and_result.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for the metric catalog helpers and the profiler result placeholders."""
+
+from __future__ import annotations
+
+import pytest
+
+from metrix.metrics import METRIC_CATALOG, METRIC_PROFILES
+from metrix.metrics.catalog import (
+    get_metric_info,
+    get_metrics_by_category,
+    list_all_metrics,
+    list_all_profiles,
+)
+from metrix.profiler.engine import Profiler
+from metrix.profiler.result import CollectionResult, KernelDispatch
+
+KNOWN_METRIC = "memory.hbm_bandwidth_utilization"
+
+
+# --------------------------------------------------------------------------
+# catalog helpers
+# --------------------------------------------------------------------------
+
+
+def test_get_metrics_by_category_filters_to_that_category():
+    category = METRIC_CATALOG[KNOWN_METRIC]["category"].value
+    found = get_metrics_by_category(category)
+    assert KNOWN_METRIC in found
+    assert all(METRIC_CATALOG[m]["category"].value == category for m in found)
+
+
+def test_get_metrics_by_unknown_category_is_empty():
+    assert get_metrics_by_category("no-such-category") == []
+
+
+def test_get_metric_info_returns_the_catalog_entry():
+    assert get_metric_info(KNOWN_METRIC) is METRIC_CATALOG[KNOWN_METRIC]
+
+
+def test_get_metric_info_rejects_unknown_metric():
+    with pytest.raises(ValueError, match="Unknown metric"):
+        get_metric_info("memory.not_a_real_metric")
+
+
+def test_list_all_metrics_matches_catalog():
+    assert list_all_metrics() == list(METRIC_CATALOG.keys())
+
+
+def test_list_all_profiles_matches_profiles():
+    assert list_all_profiles() == list(METRIC_PROFILES.keys())
+
+
+def test_every_profile_references_only_real_metrics():
+    # A profile naming a metric that does not exist would fail at runtime.
+    for name, definition in METRIC_PROFILES.items():
+        for metric in definition["metrics"]:
+            assert metric in METRIC_CATALOG, f"profile '{name}' references unknown '{metric}'"
+
+
+# --------------------------------------------------------------------------
+# profiler.result
+# --------------------------------------------------------------------------
+
+
+def test_kernel_dispatch_holds_its_fields():
+    d = KernelDispatch(
+        dispatch_id=1,
+        kernel_name="gemm",
+        device_id=0,
+        grid_size=(64, 1, 1),
+        block_size=(256, 1, 1),
+        duration_ns=1234,
+        raw_counters={"SQ_WAVES": 8.0},
+        metrics={KNOWN_METRIC: 0.5},
+    )
+    assert d.kernel_name == "gemm"
+    assert d.grid_size == (64, 1, 1)
+    # Optional source info defaults to absent.
+    assert d.source_file is None
+    assert d.source_line is None
+
+
+def test_collection_result_starts_empty():
+    assert CollectionResult().dispatches == []
+
+
+def test_collection_result_query_returns_dispatches():
+    result = CollectionResult()
+    result.dispatches.append("d1")
+    # query() is a passthrough until filtering is implemented.
+    assert result.query() == ["d1"]
+    assert result.query(kernel_pattern="anything") == ["d1"]
+
+
+def test_collection_result_exporters_are_still_stubs(tmp_path):
+    result = CollectionResult()
+    # Documented as unimplemented: they must no-op rather than raise.
+    assert result.to_json(tmp_path / "out.json") is None
+    assert result.to_dataframe() is None
+
+
+# --------------------------------------------------------------------------
+# profiler.engine
+# --------------------------------------------------------------------------
+
+
+def test_profiler_records_requested_arch():
+    assert Profiler(device_arch="gfx942").device_arch == "gfx942"
+
+
+def test_profiler_arch_defaults_to_none():
+    assert Profiler().device_arch is None
+
+
+def test_profiler_profile_is_not_implemented():
+    # The real engine lives in the backends; this placeholder must say so
+    # loudly rather than silently returning nothing.
+    with pytest.raises(NotImplementedError):
+        Profiler().profile("./app")

--- a/metrix/tests/unit/test_cli.py
+++ b/metrix/tests/unit/test_cli.py
@@ -1,0 +1,536 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for the Metrix CLI.
+
+These exercise the CLI end-to-end without a GPU: the backend is replaced by a
+fake that returns real ``Statistics`` dataclasses, so a renamed field breaks
+these tests rather than silently passing the way a ``MagicMock`` would.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from unittest.mock import patch
+
+import pytest
+
+from metrix.backends import Statistics
+from metrix.cli.info_cmd import info_command, show_metric_info, show_profile_info
+from metrix.cli.list_cmd import (
+    list_command,
+    list_devices,
+    list_metrics,
+    list_profiles,
+)
+from metrix.cli.main import create_parser, main
+from metrix.cli.profile_cmd import (
+    _write_csv_output,
+    _write_json_output,
+    _write_text_output,
+    profile_command,
+)
+from metrix.metrics import METRIC_CATALOG, METRIC_PROFILES
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+KNOWN_METRIC = "memory.hbm_bandwidth_utilization"
+
+
+def _stats(avg: float = 50.0, unit: str = "%") -> Statistics:
+    """A real Statistics instance, not a mock."""
+    return Statistics(min=avg / 2, max=avg * 2, avg=avg, count=3, unit=unit)
+
+
+class FakeDeviceSpecs:
+    arch = "gfx942"
+
+
+class FakeBackend:
+    """Minimal stand-in for a CounterBackend.
+
+    Implements only the surface ``profile_command`` actually touches.
+    """
+
+    def __init__(self, dispatch_keys=None, unsupported=None, available=None):
+        self.device_specs = FakeDeviceSpecs()
+        self._unsupported_metrics = unsupported or {}
+        self._available = available or [KNOWN_METRIC]
+        self._keys = ["dispatch_1:gemm_kernel"] if dispatch_keys is None else dispatch_keys
+        self._aggregated = {
+            key: {"duration_us": _stats(100.0 + i * 50, "us")} for i, key in enumerate(self._keys)
+        }
+        self.profile_calls = []
+
+    def get_available_metrics(self):
+        return list(self._available)
+
+    def profile(self, **kwargs):
+        self.profile_calls.append(kwargs)
+
+    def get_dispatch_keys(self):
+        return list(self._keys)
+
+    def compute_metric_stats(self, dispatch_key, metric):
+        return _stats()
+
+    def get_metric_counters(self, metric_name):
+        return ["TCC_HIT_sum", "TCC_MISS_sum"]
+
+
+class Args:
+    """argparse.Namespace stand-in with the profile defaults filled in."""
+
+    def __init__(self, **kw):
+        defaults = {
+            "target": "./app",
+            "profile": None,
+            "metrics": None,
+            "time_only": False,
+            "kernel": None,
+            "num_replays": 1,
+            "aggregate": False,
+            "top": None,
+            "output": None,
+            "no_counters": False,
+        }
+        defaults.update(kw)
+        for k, v in defaults.items():
+            setattr(self, k, v)
+
+
+@pytest.fixture
+def patched_backend():
+    """Patch arch detection + backend lookup, yielding the FakeBackend."""
+    backend = FakeBackend()
+    with (
+        patch("metrix.cli.profile_cmd.detect_or_default", return_value="gfx942"),
+        patch("metrix.cli.profile_cmd.get_backend", return_value=backend),
+    ):
+        yield backend
+
+
+# --------------------------------------------------------------------------
+# profile_cmd — metric selection
+# --------------------------------------------------------------------------
+
+
+def test_profile_time_only_collects_no_metrics(patched_backend):
+    assert profile_command(Args(time_only=True)) == 0
+    assert patched_backend.profile_calls[0]["metrics"] == []
+
+
+def test_profile_explicit_metrics_are_split_and_stripped(patched_backend):
+    profile_command(Args(metrics=f" {KNOWN_METRIC} , memory.l2_hit_rate "))
+    assert patched_backend.profile_calls[0]["metrics"] == [
+        KNOWN_METRIC,
+        "memory.l2_hit_rate",
+    ]
+
+
+def test_profile_default_uses_all_backend_metrics(patched_backend):
+    profile_command(Args())
+    assert patched_backend.profile_calls[0]["metrics"] == patched_backend.get_available_metrics()
+
+
+def test_profile_named_profile_uses_catalog_metrics(patched_backend):
+    name = next(iter(METRIC_PROFILES))
+    profile_command(Args(profile=name))
+    assert patched_backend.profile_calls[0]["metrics"] == METRIC_PROFILES[name]["metrics"]
+
+
+def test_profile_unknown_profile_returns_1(patched_backend):
+    assert profile_command(Args(profile="does-not-exist")) == 1
+    assert patched_backend.profile_calls == []
+
+
+# --------------------------------------------------------------------------
+# profile_cmd — unsupported-metric handling (the two branches differ)
+# --------------------------------------------------------------------------
+
+
+def test_explicitly_requested_unsupported_metric_is_an_error():
+    backend = FakeBackend(unsupported={KNOWN_METRIC: "no such counter"})
+    with (
+        patch("metrix.cli.profile_cmd.detect_or_default", return_value="gfx942"),
+        patch("metrix.cli.profile_cmd.get_backend", return_value=backend),
+    ):
+        # --metrics is an explicit request, so this must fail rather than skip.
+        assert profile_command(Args(metrics=KNOWN_METRIC)) == 1
+        assert backend.profile_calls == []
+
+
+def test_unsupported_metric_from_profile_is_filtered_not_fatal():
+    backend = FakeBackend(
+        unsupported={KNOWN_METRIC: "no such counter"},
+        available=[KNOWN_METRIC, "memory.l2_hit_rate"],
+    )
+    with (
+        patch("metrix.cli.profile_cmd.detect_or_default", return_value="gfx942"),
+        patch("metrix.cli.profile_cmd.get_backend", return_value=backend),
+    ):
+        assert profile_command(Args()) == 0
+        assert KNOWN_METRIC not in backend.profile_calls[0]["metrics"]
+
+
+# --------------------------------------------------------------------------
+# profile_cmd — kernels, filtering, top-K
+# --------------------------------------------------------------------------
+
+
+def test_no_dispatches_returns_1():
+    backend = FakeBackend(dispatch_keys=[])
+    with (
+        patch("metrix.cli.profile_cmd.detect_or_default", return_value="gfx942"),
+        patch("metrix.cli.profile_cmd.get_backend", return_value=backend),
+    ):
+        assert profile_command(Args()) == 1
+
+
+def test_no_dispatches_with_filter_returns_1():
+    backend = FakeBackend(dispatch_keys=[])
+    with (
+        patch("metrix.cli.profile_cmd.detect_or_default", return_value="gfx942"),
+        patch("metrix.cli.profile_cmd.get_backend", return_value=backend),
+    ):
+        assert profile_command(Args(kernel="nomatch.*")) == 1
+
+
+def test_kernel_filter_is_passed_through(patched_backend):
+    profile_command(Args(kernel="gemm.*"))
+    assert patched_backend.profile_calls[0]["kernel_filter"] == "gemm.*"
+
+
+def test_absent_kernel_filter_is_none(patched_backend):
+    profile_command(Args())
+    assert patched_backend.profile_calls[0]["kernel_filter"] is None
+
+
+def test_top_k_keeps_only_the_slowest(capsys):
+    # Durations are 100/150/200us, so top=1 must keep only the 200us one.
+    # Keys deliberately contain no ':' so they print verbatim.
+    backend = FakeBackend(dispatch_keys=["alpha", "beta", "gamma"])
+    with (
+        patch("metrix.cli.profile_cmd.detect_or_default", return_value="gfx942"),
+        patch("metrix.cli.profile_cmd.get_backend", return_value=backend),
+    ):
+        assert profile_command(Args(top=1)) == 0
+    out = capsys.readouterr().out
+    assert "gamma" in out
+    assert "alpha" not in out
+    assert "beta" not in out
+
+
+def test_replays_and_aggregate_are_forwarded(patched_backend):
+    profile_command(Args(num_replays=5, aggregate=True))
+    call = patched_backend.profile_calls[0]
+    assert call["num_replays"] == 5
+    assert call["aggregate_by_kernel"] is True
+
+
+def test_backend_profile_exception_returns_1(patched_backend):
+    with patch.object(patched_backend, "profile", side_effect=RuntimeError("boom")):
+        assert profile_command(Args()) == 1
+
+
+def test_metric_computation_failure_is_warned_not_fatal(patched_backend):
+    with patch.object(
+        patched_backend, "compute_metric_stats", side_effect=ValueError("bad counter")
+    ):
+        # A single metric failing must not sink the whole run.
+        assert profile_command(Args()) == 0
+
+
+# --------------------------------------------------------------------------
+# profile_cmd — output formats
+# --------------------------------------------------------------------------
+
+
+def test_output_json_roundtrips(tmp_path, patched_backend):
+    out = tmp_path / "r.json"
+    assert profile_command(Args(output=str(out))) == 0
+    data = json.loads(out.read_text())
+    key = "dispatch_1:gemm_kernel"
+    assert data[key]["duration_us"]["avg"] == 100.0
+    assert data[key]["metrics"][KNOWN_METRIC]["unit"] == "%"
+
+
+def test_output_csv_has_header_and_one_row_per_dispatch(tmp_path, patched_backend):
+    out = tmp_path / "r.csv"
+    assert profile_command(Args(output=str(out))) == 0
+    rows = list(csv.reader(out.read_text().splitlines()))
+    assert rows[0][0] == "dispatch_key"
+    assert len(rows) == 2
+
+
+def test_unknown_extension_falls_back_to_text(tmp_path, patched_backend):
+    out = tmp_path / "r.weird"
+    assert profile_command(Args(output=str(out))) == 0
+    assert "gemm_kernel" in out.read_text()
+
+
+def test_json_writer_handles_missing_duration(tmp_path):
+    results = {"k": {"duration_us": None, "metrics": {KNOWN_METRIC: _stats()}}}
+    out = tmp_path / "r.json"
+    _write_json_output(out, results, [KNOWN_METRIC])
+    assert json.loads(out.read_text())["k"]["duration_us"] is None
+
+
+def test_csv_writer_zero_fills_missing_values(tmp_path):
+    results = {"k": {"duration_us": None, "metrics": {}}}
+    out = tmp_path / "r.csv"
+    _write_csv_output(out, results, [KNOWN_METRIC], aggregated=False)
+    row = list(csv.reader(out.read_text().splitlines()))[1]
+    assert row[1:4] == ["0", "0", "0"]
+
+
+def test_text_writer_restores_stdout(tmp_path, capsys):
+    results = {"k": {"duration_us": _stats(unit="us"), "metrics": {}}}
+    _write_text_output(tmp_path / "r.txt", results, [], aggregated=True)
+    # If sys.stdout were left pointing at the buffer this would not be captured.
+    print("still working")
+    assert "still working" in capsys.readouterr().out
+
+
+def test_aggregated_output_prints_kernel_not_dispatch(capsys, patched_backend):
+    profile_command(Args(aggregate=True))
+    assert "Kernel: dispatch_1:gemm_kernel" in capsys.readouterr().out
+
+
+def test_unaggregated_output_splits_dispatch_id(capsys, patched_backend):
+    profile_command(Args())
+    assert "Dispatch #1: gemm_kernel" in capsys.readouterr().out
+
+
+def test_dispatch_key_without_colon_prints_as_kernel(capsys):
+    backend = FakeBackend(dispatch_keys=["bare_name"])
+    with (
+        patch("metrix.cli.profile_cmd.detect_or_default", return_value="gfx942"),
+        patch("metrix.cli.profile_cmd.get_backend", return_value=backend),
+    ):
+        profile_command(Args())
+    assert "Kernel: bare_name" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------
+# list_cmd
+# --------------------------------------------------------------------------
+
+
+def test_list_metrics_prints_every_catalog_entry(capsys):
+    list_metrics()
+    out = capsys.readouterr().out
+    assert f"Total: {len(METRIC_CATALOG)} metrics" in out
+
+
+def test_list_metrics_by_category_is_a_subset(capsys):
+    category = METRIC_CATALOG[KNOWN_METRIC]["category"].value
+    list_metrics(category)
+    out = capsys.readouterr().out
+    assert f"Category: {category}" in out
+
+
+def test_list_profiles_prints_each_profile(capsys):
+    list_profiles()
+    out = capsys.readouterr().out
+    for name in METRIC_PROFILES:
+        assert name.upper() in out
+
+
+def test_list_devices_discovers_backends_from_disk(capsys):
+    list_devices()
+    out = capsys.readouterr().out
+    # gfx942 has a backend module, so discovery must surface it.
+    assert "gfx942" in out
+    assert "AMD Instinct MI300" in out
+
+
+def test_list_devices_handles_no_backend_modules(capsys, tmp_path):
+    class _EmptyDir:
+        def glob(self, _pat):
+            return iter(())
+
+        def __truediv__(self, _other):
+            return self
+
+    with patch("pathlib.Path.glob", return_value=iter(())):
+        list_devices()
+    assert "no backend modules found" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "item_type,needle",
+    [
+        ("metrics", "AVAILABLE METRICS"),
+        ("profiles", "AVAILABLE PROFILES"),
+        ("counters", "not yet implemented"),
+        ("devices", "SUPPORTED DEVICES"),
+    ],
+)
+def test_list_command_dispatches(item_type, needle, capsys):
+    args = Args(item_type=item_type, category=None)
+    assert list_command(args) == 0
+    assert needle in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------
+# info_cmd
+# --------------------------------------------------------------------------
+
+
+def test_show_metric_info_prints_counters_from_backend(capsys):
+    with patch("metrix.cli.info_cmd.get_backend", return_value=FakeBackend()):
+        show_metric_info(KNOWN_METRIC, "gfx942")
+    out = capsys.readouterr().out
+    assert "TCC_HIT_sum" in out
+    assert "gfx942" in out
+
+
+def test_show_metric_info_unknown_metric_returns_1(capsys):
+    assert show_metric_info("memory.not_a_metric") == 1
+    assert "Unknown metric" in capsys.readouterr().out
+
+
+def test_show_metric_info_unimplemented_on_arch_is_handled(capsys):
+    backend = FakeBackend()
+    with (
+        patch("metrix.cli.info_cmd.get_backend", return_value=backend),
+        patch.object(backend, "get_metric_counters", side_effect=ValueError),
+    ):
+        show_metric_info(KNOWN_METRIC, "gfx1030")
+    assert "not implemented" in capsys.readouterr().out
+
+
+def test_show_profile_info_lists_metrics(capsys):
+    name = next(iter(METRIC_PROFILES))
+    show_profile_info(name)
+    out = capsys.readouterr().out
+    assert name.upper() in out
+    assert f"metrix profile --profile {name}" in out
+
+
+def test_show_profile_info_unknown_returns_1(capsys):
+    assert show_profile_info("nope") == 1
+    assert "Unknown profile" in capsys.readouterr().out
+
+
+def test_info_command_metric_autodetects_arch(capsys):
+    with (
+        patch("metrix.cli.info_cmd.detect_or_default", return_value="gfx942") as det,
+        patch("metrix.cli.info_cmd.get_backend", return_value=FakeBackend()),
+    ):
+        args = Args(info_type="metric", name=KNOWN_METRIC)
+        assert info_command(args) == 0
+        det.assert_called_once()
+
+
+def test_info_command_metric_honours_explicit_arch():
+    with (
+        patch("metrix.cli.info_cmd.detect_or_default") as det,
+        patch("metrix.cli.info_cmd.get_backend", return_value=FakeBackend()),
+    ):
+        args = Args(info_type="metric", name=KNOWN_METRIC, arch="gfx950")
+        info_command(args)
+        det.assert_not_called()
+
+
+def test_info_command_profile(capsys):
+    name = next(iter(METRIC_PROFILES))
+    assert info_command(Args(info_type="profile", name=name)) == 0
+    assert name.upper() in capsys.readouterr().out
+
+
+def test_info_command_counter_not_implemented(capsys):
+    assert info_command(Args(info_type="counter", name="TCC_HIT")) == 0
+    assert "not yet implemented" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------
+# main / parser
+# --------------------------------------------------------------------------
+
+
+def test_parser_builds_and_exposes_subcommands():
+    parser = create_parser()
+    args = parser.parse_args(["profile", "./app"])
+    assert args.command == "profile"
+    assert args.target == "./app"
+
+
+def test_bare_invocation_prints_help(capsys):
+    with patch("sys.argv", ["metrix"]):
+        assert main() == 0
+    assert "usage:" in capsys.readouterr().out.lower()
+
+
+def test_implicit_profile_subcommand_is_inserted():
+    # `metrix ./app` must behave as `metrix profile ./app`.
+    with (
+        patch("sys.argv", ["metrix", "./app"]),
+        patch("metrix.cli.main.profile_command", return_value=0) as cmd,
+    ):
+        assert main() == 0
+    assert cmd.call_args[0][0].target == "./app"
+
+
+def test_explicit_profile_subcommand_is_not_double_inserted():
+    with (
+        patch("sys.argv", ["metrix", "profile", "./app"]),
+        patch("metrix.cli.main.profile_command", return_value=0) as cmd,
+    ):
+        main()
+    assert cmd.call_args[0][0].target == "./app"
+
+
+def test_main_routes_list():
+    with (
+        patch("sys.argv", ["metrix", "list", "metrics"]),
+        patch("metrix.cli.main.list_command", return_value=0) as cmd,
+    ):
+        assert main() == 0
+    cmd.assert_called_once()
+
+
+def test_main_routes_info():
+    with (
+        patch("sys.argv", ["metrix", "info", "metric", KNOWN_METRIC]),
+        patch("metrix.cli.main.info_command", return_value=0) as cmd,
+    ):
+        assert main() == 0
+    cmd.assert_called_once()
+
+
+def test_main_keyboard_interrupt_returns_130(capsys):
+    with (
+        patch("sys.argv", ["metrix", "profile", "./app"]),
+        patch("metrix.cli.main.profile_command", side_effect=KeyboardInterrupt),
+    ):
+        assert main() == 130
+    assert "Interrupted" in capsys.readouterr().out
+
+
+def test_main_exception_returns_1(capsys):
+    with (
+        patch("sys.argv", ["metrix", "profile", "./app"]),
+        patch("metrix.cli.main.profile_command", side_effect=RuntimeError("kaboom")),
+    ):
+        assert main() == 1
+    assert "kaboom" in capsys.readouterr().err
+
+
+def test_main_debug_log_prints_traceback(capsys):
+    with (
+        patch("sys.argv", ["metrix", "profile", "./app", "--log", "debug"]),
+        patch("metrix.cli.main.profile_command", side_effect=RuntimeError("kaboom")),
+    ):
+        assert main() == 1
+    assert "Traceback" in capsys.readouterr().err
+
+
+def test_version_flag_exits_zero(capsys):
+    with patch("sys.argv", ["metrix", "--version"]), pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 0

--- a/metrix/tests/unit/test_mcp_server_tools.py
+++ b/metrix/tests/unit/test_mcp_server_tools.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for the Metrix MCP server tool bodies and entry point.
+
+The existing ``test_mcp_server.py`` checks that the catalog the tools expose is
+sane. These cover the code paths themselves — result marshalling, the
+no-GPU fallback, and ``main()`` — none of which need a GPU.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from metrix.mcp import server as mcp_server
+from metrix.metrics import METRIC_CATALOG
+
+KNOWN_METRIC = "memory.hbm_bandwidth_utilization"
+
+
+def _unwrap(tool):
+    """Return the underlying function.
+
+    ``@mcp.tool()`` yields a ``FunctionTool`` in some fastmcp versions and the
+    bare function in others; ``.fn`` is the escape hatch when it is wrapped.
+    """
+    return getattr(tool, "fn", tool)
+
+
+profile_metrics = _unwrap(mcp_server.profile_metrics)
+list_available_metrics = _unwrap(mcp_server.list_available_metrics)
+
+
+class FakeStat:
+    def __init__(self, avg, unit=""):
+        self.avg = avg
+        self.unit = unit
+
+
+class FakeKernel:
+    def __init__(self, name, duration_avg=None, metrics=None, with_metrics=True):
+        self.name = name
+        # An object with no .avg exercises the hasattr fallback to 0.0.
+        self.duration_us = FakeStat(duration_avg) if duration_avg is not None else object()
+        if with_metrics:
+            self.metrics = metrics or {}
+
+
+class FakeResults:
+    def __init__(self, kernels):
+        self.kernels = kernels
+
+
+class FakeProfiler:
+    def __init__(self, kernels=None, available=None):
+        self._kernels = kernels if kernels is not None else []
+        self._available = available or [KNOWN_METRIC]
+        self.profile_calls = []
+
+    def list_metrics(self):
+        return list(self._available)
+
+    def profile(self, command, metrics=None):
+        self.profile_calls.append({"command": command, "metrics": metrics})
+        return FakeResults(self._kernels)
+
+
+# --------------------------------------------------------------------------
+# profile_metrics
+# --------------------------------------------------------------------------
+
+
+def test_profile_metrics_marshals_kernel_fields():
+    kernel = FakeKernel("gemm", 12.5, {KNOWN_METRIC: FakeStat(87.5, "%")})
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler([kernel])):
+        out = profile_metrics("./app", [KNOWN_METRIC])
+
+    assert len(out["kernels"]) == 1
+    entry = out["kernels"][0]
+    assert entry["name"] == "gemm"
+    assert entry["duration_us_avg"] == 12.5
+    assert entry["metrics"][KNOWN_METRIC] == {"avg": 87.5, "unit": "%"}
+
+
+def test_profile_metrics_defaults_to_all_available_metrics():
+    profiler = FakeProfiler([], available=[KNOWN_METRIC, "memory.l2_hit_rate"])
+    with patch.object(mcp_server, "Metrix", return_value=profiler):
+        profile_metrics("./app")
+    # metrics=None must be resolved via list_metrics before profiling.
+    assert profiler.profile_calls[0]["metrics"] == [KNOWN_METRIC, "memory.l2_hit_rate"]
+
+
+def test_profile_metrics_passes_command_through():
+    profiler = FakeProfiler([])
+    with patch.object(mcp_server, "Metrix", return_value=profiler):
+        profile_metrics("python train.py --size 1024", [KNOWN_METRIC])
+    assert profiler.profile_calls[0]["command"] == "python train.py --size 1024"
+
+
+def test_profile_metrics_duration_without_avg_becomes_zero():
+    kernel = FakeKernel("nodur", duration_avg=None)
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler([kernel])):
+        out = profile_metrics("./app", [KNOWN_METRIC])
+    assert out["kernels"][0]["duration_us_avg"] == 0.0
+
+
+def test_profile_metrics_skips_metrics_absent_from_kernel():
+    kernel = FakeKernel("gemm", 1.0, {})
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler([kernel])):
+        out = profile_metrics("./app", [KNOWN_METRIC])
+    assert out["kernels"][0]["metrics"] == {}
+
+
+def test_profile_metrics_handles_kernel_without_metrics_attr():
+    kernel = FakeKernel("bare", 1.0, with_metrics=False)
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler([kernel])):
+        out = profile_metrics("./app", [KNOWN_METRIC])
+    assert out["kernels"][0]["metrics"] == {}
+
+
+def test_profile_metrics_metric_without_avg_becomes_zero():
+    class NoAvg:
+        unit = "%"
+
+    kernel = FakeKernel("gemm", 1.0, {KNOWN_METRIC: NoAvg()})
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler([kernel])):
+        out = profile_metrics("./app", [KNOWN_METRIC])
+    assert out["kernels"][0]["metrics"][KNOWN_METRIC]["avg"] == 0.0
+
+
+def test_profile_metrics_empty_result_is_empty_list():
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler([])):
+        assert profile_metrics("./app", [KNOWN_METRIC]) == {"kernels": []}
+
+
+def test_profile_metrics_handles_multiple_kernels():
+    kernels = [FakeKernel("a", 1.0, {}), FakeKernel("b", 2.0, {})]
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler(kernels)):
+        out = profile_metrics("./app", [KNOWN_METRIC])
+    assert [k["name"] for k in out["kernels"]] == ["a", "b"]
+
+
+# --------------------------------------------------------------------------
+# list_available_metrics
+# --------------------------------------------------------------------------
+
+
+def test_list_metrics_falls_back_to_catalog_without_a_gpu():
+    # Backend construction failing must not break discovery.
+    with patch.object(mcp_server, "Metrix", side_effect=RuntimeError("no GPU")):
+        out = list_available_metrics()
+    assert out["metrics"] == sorted(METRIC_CATALOG.keys())
+
+
+def test_list_metrics_prefers_backend_over_catalog():
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler(available=["z.b", "a.a"])):
+        out = list_available_metrics()
+    assert out["metrics"] == ["a.a", "z.b"]
+
+
+def test_yaml_only_metric_is_categorised_by_prefix():
+    # Not in METRIC_CATALOG, so the category comes from the name prefix.
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler(available=["custom.thing"])):
+        out = list_available_metrics()
+    assert out["by_category"]["custom"] == ["custom.thing"]
+
+
+def test_undotted_unknown_metric_falls_into_other():
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler(available=["weird"])):
+        out = list_available_metrics()
+    assert out["by_category"]["other"] == ["weird"]
+
+
+def test_catalog_metric_uses_its_declared_category():
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler(available=[KNOWN_METRIC])):
+        out = list_available_metrics()
+    expected = METRIC_CATALOG[KNOWN_METRIC]["category"].value
+    assert out["by_category"][expected] == [KNOWN_METRIC]
+
+
+def test_list_metrics_includes_usage_note():
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler(available=[KNOWN_METRIC])):
+        assert "profile_metrics" in list_available_metrics()["note"]
+
+
+# --------------------------------------------------------------------------
+# main()
+# --------------------------------------------------------------------------
+
+
+def test_main_defaults_to_stdio():
+    with (
+        patch("sys.argv", ["metrix-mcp"]),
+        patch.object(mcp_server.mcp, "run") as run,
+    ):
+        mcp_server.main()
+    run.assert_called_once_with(transport="stdio")
+
+
+def test_main_explicit_stdio():
+    with (
+        patch("sys.argv", ["metrix-mcp", "--transport", "stdio"]),
+        patch.object(mcp_server.mcp, "run") as run,
+    ):
+        mcp_server.main()
+    run.assert_called_once_with(transport="stdio")
+
+
+def test_main_http_uses_documented_defaults():
+    with (
+        patch("sys.argv", ["metrix-mcp", "--transport", "http"]),
+        patch.object(mcp_server.mcp, "run") as run,
+    ):
+        mcp_server.main()
+    run.assert_called_once_with(
+        transport="streamable-http", host="127.0.0.1", port=8000, path="/metrix"
+    )
+
+
+def test_main_http_honours_overrides():
+    with (
+        patch(
+            "sys.argv",
+            [
+                "metrix-mcp",
+                "--transport",
+                "http",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "9001",
+                "--path",
+                "/custom",
+            ],
+        ),
+        patch.object(mcp_server.mcp, "run") as run,
+    ):
+        mcp_server.main()
+    run.assert_called_once_with(
+        transport="streamable-http", host="0.0.0.0", port=9001, path="/custom"
+    )
+
+
+def test_main_rejects_unknown_transport():
+    with (
+        patch("sys.argv", ["metrix-mcp", "--transport", "carrier-pigeon"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        mcp_server.main()
+    assert exc.value.code == 2
+
+
+def test_port_is_parsed_as_int():
+    with (
+        patch("sys.argv", ["metrix-mcp", "--transport", "http", "--port", "1234"]),
+        patch.object(mcp_server.mcp, "run") as run,
+    ):
+        mcp_server.main()
+    assert run.call_args.kwargs["port"] == 1234
+
+
+# --------------------------------------------------------------------------
+# registration
+# --------------------------------------------------------------------------
+
+
+def test_both_tools_are_registered():
+    """Guard against a tool silently failing to register.
+
+    Driven with ``asyncio.run`` rather than a pytest async plugin so it needs
+    no extra test dependency. Fails loudly rather than skipping if the fastmcp
+    listing API moves — a permanently-skipped test contributes nothing while
+    looking green.
+    """
+    import asyncio
+    import inspect
+
+    lister = getattr(mcp_server.mcp, "list_tools", None) or getattr(
+        mcp_server.mcp, "get_tools", None
+    )
+    if lister is None:
+        pytest.fail("fastmcp exposes neither list_tools() nor get_tools()")
+
+    tools = lister()
+    if inspect.isawaitable(tools):
+        tools = asyncio.run(tools)
+
+    # dict keyed by name in some versions, iterable of tool objects in others
+    names = set(tools) if isinstance(tools, dict) else {getattr(t, "name", t) for t in tools}
+    assert {"profile_metrics", "list_available_metrics"} <= names


### PR DESCRIPTION
Raises metrix source coverage from **61% to 90%**. Four new test files, no source changes.
The gap was concentrated in files with no tests at all:

| file | before | after |
| --- | --- | --- |
| `cli/profile_cmd.py` | 0% | 99% |
| `cli/list_cmd.py` | 0% | 100% |
| `cli/main.py` | 0% | 96% |
| `cli/info_cmd.py` | 0% | 93% |
| `cli/__init__.py` | 0% | 100% |
| `mcp/server.py` | 44% | 98% |
| `backends/detect.py` | 65% | 100% |
| `backends/gfx*.py` (all 7) | 63–88% | 100% |
| `backends/device_info.py` | 71% | 87% |
| `utils/common.py` | 78% | 96% |
| `metrics/catalog.py` | 57% | 100% |
| `profiler/engine.py` | 60% | 100% |
| `profiler/result.py` | 83% | 100% |
| **TOTAL** | **61%** | **90%** |

## Approach

No GPU required — the hardware is stubbed at its boundaries (`get_backend`, `query_device_specs`, `rocminfo`, `hipcc`, `ROCProfV3Wrapper`), which is what makes the error paths reachable at all. The whole suite runs in about a second.

Fakes are built from the **real `DeviceSpecs` and `Statistics` dataclasses**, not `MagicMock`. This is load-bearing: `base.py` calls `dataclasses.fields()` on `device_specs`, so a mock cannot satisfy it — and more usefully, renaming a field now breaks these tests instead of passing silently.

## Behaviours pinned down

- **The two unsupported-metric branches genuinely differ.** A metric named explicitly via `--metrics` must *fail*; the same metric arriving through a profile must be *filtered with a warning*. Both are now covered, so collapsing them would be caught.
- **`_write_text_output` swaps `sys.stdout` for a buffer and restores it.** There is a test that fails if the restore is ever dropped.
- **The bin-packer must not drop or duplicate counters.** Checked across several block-limit configurations.
- **Both MCP tools stay registered.** Driven via `asyncio.run` rather than a pytest async plugin so it needs no new test dependency, and it `pytest.fail`s rather than skipping if the fastmcp listing API moves — a permanently-skipped test contributes nothing while looking green.

## Deliberately left uncovered

- `profiler/rocprof_wrapper.py` at 88% — the remainder is real subprocess handling, where mocking would mostly test the mock.
- `if __name__ == "__main__"` guards, unreachable under pytest.

## Verification

- 378 passed, 30 skipped, on MI325X inside a full-ROCm container (`rocm7.2.4`).
- `ruff check` and `ruff format --check` clean at **0.15.22**, the version pinned in the lint workflow.

Measured in a container deliberately: on bare metal these nodes have a partial ROCm without HIP headers, which fails tests for environmental reasons and understates coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)