### PR TITLE
Prefer the ROCm-provided trace decoder and parse commands with shlex

### DIFF
--- a/linex/src/linex/api.py
+++ b/linex/src/linex/api.py
@@ -6,6 +6,8 @@ Linex API - Source-level GPU performance profiling
 """
 
 import json
+import os
+import shlex
 import subprocess
 import urllib.request
 from dataclasses import dataclass
@@ -120,6 +122,8 @@ class Linex:
     # Default rocprofv3 parameters
     DEFAULT_DECODER_URL = "https://raw.githubusercontent.com/ROCm/rocprof-trace-decoder/12c9d5871b3f803937ef92f1adce9294dfc549a7/releases/linux_glibc_2_28_x86_64/librocprof-trace-decoder.so"
     DEFAULT_DECODER_PATH = Path.home() / ".cache" / "linex" / "librocprof-trace-decoder.so"
+    # rocprofv3 looks for exactly this filename under --att-library-path.
+    DECODER_SONAME = "librocprof-trace-decoder.so"
 
     def __init__(
         self,
@@ -144,8 +148,44 @@ class Linex:
         self._instructions: List[InstructionData] = []
         self._source_lines: Dict[str, SourceLine] = {}
 
+    @classmethod
+    def _find_rocm_decoder(cls) -> Optional[Path]:
+        """Locate a decoder shipped with ROCm, if one is installed.
+
+        ROCm 7.13 and newer bundle the trace decoder, so there is no need to
+        fetch a copy.  Returns None on older ROCm, where it must be downloaded.
+        """
+        roots = [os.environ.get("ROCM_PATH"), "/opt/rocm"]
+        for root in roots:
+            if not root:
+                continue
+            base = Path(root)
+            if not base.is_dir():
+                continue
+            # Layout varies: <root>/lib on classic installs, <root>/core-X.Y/lib
+            # on versioned ones.
+            for pattern in (f"lib/{cls.DECODER_SONAME}", f"*/lib/{cls.DECODER_SONAME}"):
+                for candidate in sorted(base.glob(pattern)):
+                    if candidate.is_file():
+                        return candidate
+        return None
+
     def _ensure_decoder(self) -> Path:
-        """Ensure decoder library is available, download if needed."""
+        """Locate the decoder library, downloading a copy only if ROCm has none.
+
+        Preference order:
+          1. the decoder shipped with the installed ROCm (7.13+)
+          2. a previously downloaded copy in the local cache
+          3. a fresh download
+
+        The download exists for ROCm older than 7.13.  It pins a build from a
+        repository that upstream has deprecated, so the ROCm-provided library is
+        preferred whenever one is present.
+        """
+        shipped = self._find_rocm_decoder()
+        if shipped is not None:
+            return shipped
+
         if self.DEFAULT_DECODER_PATH.exists():
             return self.DEFAULT_DECODER_PATH
 
@@ -180,7 +220,6 @@ class Linex:
         Returns:
             self for chaining
         """
-        import os
         import tempfile
 
         # Use temp directory if not specified
@@ -205,7 +244,15 @@ class Linex:
         if kernel_filter:
             cmd.extend(["--kernel-include-regex", kernel_filter])
 
-        cmd.extend(["--", *command.split()])
+        # shlex.split so quoted argument groups survive as single argv tokens;
+        # rocprofv3 execs the target directly without a shell.
+        try:
+            target_argv = shlex.split(command)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Failed to parse command for rocprofv3: {command!r}. Check for unmatched quotes."
+            ) from exc
+        cmd.extend(["--", *target_argv])
 
         env = os.environ.copy()
         if force_cu_mask:


### PR DESCRIPTION
Two independent fixes to `linex/src/linex/api.py`, verified across ROCm 7.1.1, 7.14, and a ROCm 10.1.0a nightly.

## 1. Use the decoder ROCm already ships

`_ensure_decoder()` unconditionally used a downloaded copy of the trace decoder, pinned to commit `12c9d587` (2025-12-29) of `ROCm/rocprof-trace-decoder`.

That repository was **deprecated in April 2026**; its README now reads:

> This repository is deprecated. The source for rocprof-trace-decoder is now in ROCm/rocm-systems.
> **Users on ROCm >= 7.13 do not need to install this package separately — it is included by default.**

So on any modern ROCm we were fetching an 8-month-old binary over `raw.githubusercontent.com`, from a dead repo, while the runtime already provided one.

New preference order:
1. decoder shipped with the installed ROCm (`$ROCM_PATH`, then `/opt/rocm`)
2. previously downloaded copy in the cache
3. fresh download

**The download path is retained deliberately.** The minimum supported ROCm is 7.2.x, which predates 7.13, so 7.2–7.12 still need it.

## 2. Parse the target command with `shlex`

```python
cmd.extend(["--", *command.split()])   # before
```

Naive whitespace splitting shreds quoted arguments — `linex.profile('python -c "import torch; ..."')` reaches `rocprofv3` as separate tokens, and rocprofv3 `exec`s the target without a shell, so the quoting is never restored. This is the same defect fixed in metrix by #115; linex never received it.

Now uses `shlex.split`, and an unmatched quote raises a `RuntimeError` naming the offending command rather than failing obscurely downstream.

## Test plan

Full SQTT suite, fresh clone of `main` per run, single MI325X, both sides of the 7.13 boundary:

| image | ROCm ships decoder? | linex selects | downloaded? | result |
|---|---|---|---|---|
| `rocm/dev-ubuntu-24.04:7.14.0-full` | yes | `/opt/rocm/lib/librocprof-trace-decoder.so` | no | **8 passed** |
| `rocm/dev-ubuntu-24.04:7.1.1-complete` | no | `~/.cache/linex/librocprof-trace-decoder.so` | yes | **8 passed** |

Both branches of the new lookup are exercised — it returns a path on 7.14 and `None` on 7.1.1.

Separately, the ATT interface was checked for forward compatibility across **rocprofv3 1.0.0 → 1.3.5** (ROCm 7.1.1 → ROCm 10.1.0a nightly from TheRock). All five flags linex passes still exist and are undeprecated upstream, and `ui_output_*` / `code.json` remain the output contract, with upstream tests asserting it. No compatibility change was required for ROCm 10.

`ruff check` and `ruff format --check` clean at 0.15.22.

> Note: the `[self-hosted, mi3xx]` CI jobs will queue — that runner is currently offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)