### PR TITLE
Add unit tests for the accordo CLI, IPC, result types and helpers

### DIFF
--- a/accordo/tests/test_capture_snapshot_errors.py
+++ b/accordo/tests/test_capture_snapshot_errors.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for capture_snapshot's error translation and CLI import guard.
+
+``capture_snapshot`` wraps the instrumented run in a SIGALRM timeout and maps
+three distinct failures onto Accordo's own exception types. That mapping is the
+contract callers depend on, and it is reachable without a GPU by substituting
+``_run_instrumented_app``. The instance is built with ``object.__new__`` to skip
+the hardware setup in ``__init__``.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from accordo.exceptions import AccordoProcessError, AccordoTimeoutError
+from accordo.validator import Accordo, _TimeoutException
+
+
+def _validator():
+    v = object.__new__(Accordo)
+    v.kernel_args = [("out", "float*")]
+    v.working_directory = "."
+    v.kernel_name = "k"
+    return v
+
+
+def _capture(side_effect=None, arrays=None, timeout=5):
+    v = _validator()
+    run = MagicMock()
+    if side_effect is not None:
+        run.side_effect = side_effect
+    else:
+        run.return_value = arrays if arrays is not None else [[]]
+    with patch.object(Accordo, "_run_instrumented_app", run):
+        return v, run, v.capture_snapshot(binary=["./app"], timeout_seconds=timeout)
+
+
+class TestErrorTranslation:
+    def test_internal_timeout_becomes_accordo_timeout(self):
+        v = _validator()
+        with patch.object(Accordo, "_run_instrumented_app", side_effect=_TimeoutException("boom")):
+            with pytest.raises(AccordoTimeoutError) as exc:
+                v.capture_snapshot(binary=["./app"], timeout_seconds=7)
+        assert "timed out after 7s" in str(exc.value)
+        assert exc.value.timeout_seconds == 7
+
+    def test_timeout_error_becomes_accordo_timeout(self):
+        v = _validator()
+        with patch.object(Accordo, "_run_instrumented_app", side_effect=TimeoutError("slow")):
+            with pytest.raises(AccordoTimeoutError) as exc:
+                v.capture_snapshot(binary=["./app"], timeout_seconds=3)
+        assert "slow" in str(exc.value)
+        assert exc.value.timeout_seconds == 3
+
+    def test_runtime_error_becomes_process_error(self):
+        v = _validator()
+        with patch.object(Accordo, "_run_instrumented_app", side_effect=RuntimeError("segfault")):
+            with pytest.raises(AccordoProcessError) as exc:
+                v.capture_snapshot(binary=["./app"], timeout_seconds=5)
+        assert "segfault" in str(exc.value)
+
+    def test_timeout_mentions_gpu_crash_as_likely_cause(self):
+        """The hint is the actionable part of the message for a hung dispatch."""
+        v = _validator()
+        with patch.object(Accordo, "_run_instrumented_app", side_effect=_TimeoutException("x")):
+            with pytest.raises(AccordoTimeoutError, match="GPU crash or hung process"):
+                v.capture_snapshot(binary=["./app"], timeout_seconds=1)
+
+
+class TestSnapshotConstruction:
+    def test_returns_snapshot_with_dispatch_arrays(self):
+        _, _, snap = _capture(arrays=[["A"], ["B"]])
+        assert snap.dispatch_arrays == [["A"], ["B"]]
+        assert snap.arrays == ["A"]  # first dispatch for backward compatibility
+
+    def test_empty_result_yields_empty_arrays(self):
+        _, _, snap = _capture(arrays=[])
+        assert snap.arrays == []
+
+    def test_binary_and_working_directory_recorded(self):
+        _, _, snap = _capture()
+        assert snap.binary == ["./app"]
+        assert snap.working_directory == "."
+
+    def test_execution_time_is_populated(self):
+        _, _, snap = _capture()
+        assert isinstance(snap.execution_time_ms, float)
+        assert snap.execution_time_ms >= 0.0
+
+    def test_missing_metadata_file_is_not_fatal(self):
+        """Grid/block come from a metadata file the C++ side may not have written."""
+        _, _, snap = _capture()
+        assert snap.grid_size is None
+        assert snap.block_size is None
+
+    def test_grid_and_block_read_from_metadata(self, tmp_path):
+        v = _validator()
+        meta = {"grid": {"x": 8, "y": 1, "z": 1}, "block": {"x": 64, "y": 1, "z": 1}}
+
+        real_open = open
+
+        def fake_open(path, *a, **kw):
+            if "accordo_dispatch_" in str(path):
+                import io
+
+                return io.StringIO(json.dumps(meta))
+            return real_open(path, *a, **kw)
+
+        with (
+            patch.object(Accordo, "_run_instrumented_app", return_value=[[]]),
+            patch("builtins.open", side_effect=fake_open),
+            patch("os.path.exists", return_value=True),
+        ):
+            snap = v.capture_snapshot(binary=["./app"], timeout_seconds=5)
+        assert snap.grid_size == {"x": 8, "y": 1, "z": 1}
+        assert snap.block_size == {"x": 64, "y": 1, "z": 1}
+
+    def test_malformed_metadata_is_swallowed(self, tmp_path):
+        """A corrupt metadata file must not fail an otherwise good capture."""
+        v = _validator()
+        real_open = open
+
+        def fake_open(path, *a, **kw):
+            if "accordo_dispatch_" in str(path):
+                import io
+
+                return io.StringIO("{not json")
+            return real_open(path, *a, **kw)
+
+        with (
+            patch.object(Accordo, "_run_instrumented_app", return_value=[[]]),
+            patch("builtins.open", side_effect=fake_open),
+            patch("os.path.exists", return_value=True),
+        ):
+            snap = v.capture_snapshot(binary=["./app"], timeout_seconds=5)
+        assert snap.grid_size is None
+
+
+class TestDispatchId:
+    def test_dispatch_id_forwarded_when_given(self):
+        v = _validator()
+        run = MagicMock(return_value=[[]])
+        with patch.object(Accordo, "_run_instrumented_app", run):
+            v.capture_snapshot(binary=["./app"], timeout_seconds=5, dispatch_id=3)
+        env = run.call_args.kwargs.get("extra_env", {})
+        assert env.get("ACCORDO_DISPATCH_ID") == "3"
+
+    def test_dispatch_id_absent_by_default(self):
+        v = _validator()
+        run = MagicMock(return_value=[[]])
+        with patch.object(Accordo, "_run_instrumented_app", run):
+            v.capture_snapshot(binary=["./app"], timeout_seconds=5)
+        env = run.call_args.kwargs.get("extra_env", {})
+        assert "ACCORDO_DISPATCH_ID" not in env
+
+    def test_metadata_file_path_always_provided(self):
+        v = _validator()
+        run = MagicMock(return_value=[[]])
+        with patch.object(Accordo, "_run_instrumented_app", run):
+            v.capture_snapshot(binary=["./app"], timeout_seconds=5)
+        env = run.call_args.kwargs.get("extra_env", {})
+        assert "ACCORDO_DISPATCH_METADATA_FILE" in env
+
+
+class TestCliImportGuard:
+    def test_import_failure_reported_as_json_error(self, capsys):
+        """cli._run_validate must emit JSON, not a traceback, if the package is broken."""
+        from accordo import cli
+
+        real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __import__
+
+        def boom(name, *args, **kwargs):
+            if name.endswith("validator") or name == "accordo.validator":
+                raise ImportError("libaccordo.so not found")
+            return real_import(name, *args, **kwargs)
+
+        args = MagicMock()
+        args.log_level = "WARNING"
+        with patch("builtins.__import__", side_effect=boom):
+            rc = cli._run_validate(args)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Failed to import accordo" in out

--- a/accordo/tests/test_cli.py
+++ b/accordo/tests/test_cli.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the Accordo CLI.
+
+``_run_validate`` ends in ``os._exit`` and rearranges file descriptors 1 and 2,
+neither of which a test can survive directly.  Both are patched here so the
+function can be driven to completion and its JSON payload inspected.
+"""
+
+import argparse
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from accordo import cli
+
+
+class _Exited(Exception):
+    """Stands in for os._exit so the call is observable instead of fatal."""
+
+    def __init__(self, code):
+        super().__init__(f"exit {code}")
+        self.code = code
+
+
+def _exit_raiser(code):
+    """side_effect for os._exit.
+
+    Passing the exception *class* as side_effect will not do: mock raises it
+    bare, losing the exit code. A callable receives the real argument.
+    """
+    raise _Exited(code)
+
+
+def _mismatch(idx=0, name="output", typ="float*", max_diff=1.0, mean_diff=0.5, dispatch=None):
+    m = MagicMock()
+    m.arg_index = idx
+    m.arg_name = name
+    m.arg_type = typ
+    m.max_difference = max_diff
+    m.mean_difference = mean_diff
+    m.dispatch_index = dispatch
+    return m
+
+
+def _result(is_valid=True, mismatches=None, matched=None, error=None):
+    r = MagicMock()
+    r.is_valid = is_valid
+    r.num_arrays_validated = 2
+    r.num_mismatches = len(mismatches or [])
+    r.summary.return_value = "PASS" if is_valid else "FAIL"
+    r.error_message = error
+    r.matched_arrays = matched if matched is not None else {"output": True}
+    r.mismatches = mismatches
+    return r
+
+
+def _args(**over):
+    base = dict(
+        kernel_name="reduce_sum",
+        ref_binary="./ref",
+        opt_binary="./opt",
+        tolerance=None,
+        atol=1e-08,
+        rtol=1e-05,
+        equal_nan=False,
+        timeout=30,
+        working_dir=".",
+        kernel_args=None,
+        log_level="WARNING",
+    )
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+def _drive(args, result=None, accordo_side_effect=None):
+    """Run _run_validate with fds and process exit neutralised; return (code, payload)."""
+    buf = io.StringIO()
+    validator = MagicMock()
+    validator.capture_snapshot.return_value = MagicMock()
+    if result is not None:
+        validator.compare_snapshots.return_value = result
+
+    accordo_cls = MagicMock(return_value=validator)
+    if accordo_side_effect is not None:
+        accordo_cls.side_effect = accordo_side_effect
+
+    with (
+        patch("accordo.validator.Accordo", accordo_cls),
+        patch("accordo.cli.os.dup", return_value=99),
+        patch("accordo.cli.os.dup2"),
+        patch("accordo.cli.os.close"),
+        patch("accordo.cli.os.fdopen", return_value=buf),
+        patch("accordo.cli.os._exit", side_effect=_exit_raiser),
+    ):
+        with pytest.raises(_Exited) as excinfo:
+            cli._run_validate(args)
+
+    return excinfo.value.code, json.loads(buf.getvalue()), validator
+
+
+class TestParseKernelArgs:
+    def test_single_pair(self):
+        assert cli._parse_kernel_args("input:const float*") == [("input", "const float*")]
+
+    def test_multiple_pairs(self):
+        assert cli._parse_kernel_args("a:int,b:float*") == [("a", "int"), ("b", "float*")]
+
+    def test_whitespace_is_stripped(self):
+        assert cli._parse_kernel_args("  a : int , b : float*  ") == [("a", "int"), ("b", "float*")]
+
+    def test_empty_items_skipped(self):
+        assert cli._parse_kernel_args("a:int,,b:float*,") == [("a", "int"), ("b", "float*")]
+
+    def test_empty_string_yields_nothing(self):
+        assert cli._parse_kernel_args("") == []
+
+    def test_type_may_contain_colons(self):
+        # split(":", 1) keeps the remainder intact
+        assert cli._parse_kernel_args("v:std::vector<int>") == [("v", "std::vector<int>")]
+
+    def test_missing_colon_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="Invalid kernel-arg format"):
+            cli._parse_kernel_args("noseparator")
+
+
+class TestRunValidate:
+    def test_success_payload(self):
+        code, out, _ = _drive(_args(), result=_result())
+        assert code == 0
+        assert out["is_valid"] is True
+        assert out["num_arrays_validated"] == 2
+        assert out["num_mismatches"] == 0
+        assert out["summary"] == "PASS"
+        assert out["mismatches"] == []
+        assert "error" not in out
+
+    def test_failure_still_exits_zero(self):
+        """A failed validation is a result, not a tool error."""
+        code, out, _ = _drive(_args(), result=_result(is_valid=False, mismatches=[_mismatch()]))
+        assert code == 0
+        assert out["is_valid"] is False
+        assert out["num_mismatches"] == 1
+
+    def test_mismatch_fields_serialized(self):
+        _, out, _ = _drive(
+            _args(),
+            result=_result(
+                is_valid=False, mismatches=[_mismatch(idx=3, name="acc", typ="double*")]
+            ),
+        )
+        m = out["mismatches"][0]
+        assert m["arg_index"] == 3
+        assert m["arg_name"] == "acc"
+        assert m["arg_type"] == "double*"
+        assert m["max_difference"] == 1.0
+        assert m["mean_difference"] == 0.5
+
+    def test_dispatch_index_omitted_when_none(self):
+        _, out, _ = _drive(
+            _args(), result=_result(is_valid=False, mismatches=[_mismatch(dispatch=None)])
+        )
+        assert "dispatch_index" not in out["mismatches"][0]
+
+    def test_dispatch_index_included_when_set(self):
+        _, out, _ = _drive(
+            _args(), result=_result(is_valid=False, mismatches=[_mismatch(dispatch=7)])
+        )
+        assert out["mismatches"][0]["dispatch_index"] == 7
+
+    def test_none_mismatches_treated_as_empty(self):
+        _, out, _ = _drive(_args(), result=_result(mismatches=None))
+        assert out["mismatches"] == []
+
+    def test_none_matched_arrays_becomes_empty_dict(self):
+        _, out, _ = _drive(_args(), result=_result(matched=None))
+        assert isinstance(out["matched_arrays"], dict)
+
+    def test_tolerance_and_flags_forwarded(self):
+        args = _args(tolerance=1e-3, atol=1e-9, rtol=1e-4, equal_nan=True)
+        _, _, validator = _drive(args, result=_result())
+        kwargs = validator.compare_snapshots.call_args.kwargs
+        assert kwargs["tolerance"] == 1e-3
+        assert kwargs["atol"] == 1e-9
+        assert kwargs["rtol"] == 1e-4
+        assert kwargs["equal_nan"] is True
+
+    def test_both_binaries_captured_with_timeout(self):
+        _, _, validator = _drive(_args(timeout=45), result=_result())
+        binaries = [c.kwargs["binary"] for c in validator.capture_snapshot.call_args_list]
+        assert binaries == ["./ref", "./opt"]
+        for call in validator.capture_snapshot.call_args_list:
+            assert call.kwargs["timeout_seconds"] == 45
+
+    def test_accordo_error_reported_and_exits_one(self):
+        from accordo.exceptions import AccordoError
+
+        code, out, _ = _drive(_args(), accordo_side_effect=AccordoError("kernel never dispatched"))
+        assert code == 1
+        assert out["error"] == "kernel never dispatched"
+
+    def test_unexpected_exception_is_labelled(self):
+        code, out, _ = _drive(_args(), accordo_side_effect=RuntimeError("boom"))
+        assert code == 1
+        assert out["error"].startswith("Unexpected error:")
+        assert "boom" in out["error"]
+
+    def test_stdout_is_restored_before_writing(self):
+        """The saved fd must be duplicated back over fd 1 before the JSON is emitted."""
+        validator = MagicMock()
+        validator.capture_snapshot.return_value = MagicMock()
+        validator.compare_snapshots.return_value = _result()
+
+        with (
+            patch("accordo.validator.Accordo", MagicMock(return_value=validator)),
+            patch("accordo.cli.os.dup", return_value=99) as dup,
+            patch("accordo.cli.os.dup2") as dup2,
+            patch("accordo.cli.os.close") as close,
+            patch("accordo.cli.os.fdopen", return_value=io.StringIO()),
+            patch("accordo.cli.os._exit", side_effect=_exit_raiser),
+        ):
+            with pytest.raises(_Exited):
+                cli._run_validate(_args())
+
+        dup.assert_called_once_with(1)
+        assert dup2.call_args_list[0].args == (2, 1)  # stdout -> stderr during run
+        assert dup2.call_args_list[-1].args == (99, 1)  # restored afterwards
+        close.assert_called_once_with(99)  # saved fd released
+
+
+class TestMain:
+    def test_no_subcommand_prints_help_and_exits_one(self, capsys):
+        with patch("sys.argv", ["accordo"]):
+            with pytest.raises(SystemExit) as exc:
+                cli.main()
+        assert exc.value.code == 1
+        assert "usage" in capsys.readouterr().out.lower()
+
+    def test_validate_dispatches_to_run_validate(self):
+        argv = [
+            "accordo",
+            "validate",
+            "--kernel-name",
+            "k",
+            "--ref-binary",
+            "r",
+            "--opt-binary",
+            "o",
+        ]
+        with patch("sys.argv", argv), patch.object(cli, "_run_validate", return_value=0) as run:
+            with pytest.raises(SystemExit) as exc:
+                cli.main()
+        assert exc.value.code == 0
+        run.assert_called_once()
+
+    def test_required_arguments_enforced(self):
+        with patch("sys.argv", ["accordo", "validate", "--kernel-name", "k"]):
+            with pytest.raises(SystemExit) as exc:
+                cli.main()
+        assert exc.value.code != 0
+
+    def test_parser_defaults(self):
+        argv = [
+            "accordo",
+            "validate",
+            "--kernel-name",
+            "k",
+            "--ref-binary",
+            "r",
+            "--opt-binary",
+            "o",
+        ]
+        captured = {}
+        with (
+            patch("sys.argv", argv),
+            patch.object(cli, "_run_validate", side_effect=lambda a: captured.update(vars(a)) or 0),
+        ):
+            with pytest.raises(SystemExit):
+                cli.main()
+        assert captured["atol"] == 1e-08
+        assert captured["rtol"] == 1e-05
+        assert captured["timeout"] == 30
+        assert captured["working_dir"] == "."
+        assert captured["log_level"] == "WARNING"
+        assert captured["equal_nan"] is False
+        assert captured["tolerance"] is None
+
+    def test_kernel_args_parsed_through_argparse(self):
+        argv = [
+            "accordo",
+            "validate",
+            "--kernel-name",
+            "k",
+            "--ref-binary",
+            "r",
+            "--opt-binary",
+            "o",
+            "--kernel-args",
+            "input:const float*,n:int",
+        ]
+        captured = {}
+        with (
+            patch("sys.argv", argv),
+            patch.object(cli, "_run_validate", side_effect=lambda a: captured.update(vars(a)) or 0),
+        ):
+            with pytest.raises(SystemExit):
+                cli.main()
+        assert captured["kernel_args"] == [("input", "const float*"), ("n", "int")]
+
+    def test_invalid_log_level_rejected(self):
+        argv = [
+            "accordo",
+            "validate",
+            "--kernel-name",
+            "k",
+            "--ref-binary",
+            "r",
+            "--opt-binary",
+            "o",
+            "--log-level",
+            "TRACE",
+        ]
+        with patch("sys.argv", argv):
+            with pytest.raises(SystemExit) as exc:
+                cli.main()
+        assert exc.value.code != 0

--- a/accordo/tests/test_exceptions.py
+++ b/accordo/tests/test_exceptions.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the Accordo exception hierarchy.
+
+The hierarchy is load-bearing: ``cli._run_validate`` distinguishes an
+``AccordoError`` (reported as a clean error payload) from any other exception
+(reported as "Unexpected error"), so every custom exception must remain a
+subclass of ``AccordoError``.
+"""
+
+import pytest
+
+from accordo.exceptions import (
+    AccordoBuildError,
+    AccordoError,
+    AccordoKernelNeverDispatched,
+    AccordoProcessError,
+    AccordoTimeoutError,
+    AccordoValidationError,
+)
+
+SUBCLASSES = [
+    AccordoBuildError,
+    AccordoTimeoutError,
+    AccordoProcessError,
+    AccordoValidationError,
+    AccordoKernelNeverDispatched,
+]
+
+
+class TestHierarchy:
+    def test_base_is_an_exception(self):
+        assert issubclass(AccordoError, Exception)
+
+    @pytest.mark.parametrize("cls", SUBCLASSES, ids=lambda c: c.__name__)
+    def test_every_error_derives_from_base(self, cls):
+        assert issubclass(cls, AccordoError)
+
+    @pytest.mark.parametrize("cls", SUBCLASSES, ids=lambda c: c.__name__)
+    def test_catchable_as_base(self, cls):
+        exc = cls("boom", 1) if cls in (AccordoTimeoutError, AccordoProcessError) else cls("boom")
+        with pytest.raises(AccordoError):
+            raise exc
+
+
+class TestTimeoutError:
+    def test_message_and_timeout_retained(self):
+        exc = AccordoTimeoutError("took too long", 30.0)
+        assert str(exc) == "took too long"
+        assert exc.timeout_seconds == 30.0
+
+    def test_timeout_requires_both_arguments(self):
+        with pytest.raises(TypeError):
+            AccordoTimeoutError("no timeout given")
+
+
+class TestProcessError:
+    def test_message_and_exit_code_retained(self):
+        exc = AccordoProcessError("crashed", 139)
+        assert str(exc) == "crashed"
+        assert exc.exit_code == 139
+
+    def test_exit_code_optional(self):
+        exc = AccordoProcessError("crashed")
+        assert exc.exit_code is None
+
+
+class TestPlainSubclasses:
+    @pytest.mark.parametrize(
+        "cls",
+        [AccordoBuildError, AccordoValidationError, AccordoKernelNeverDispatched],
+        ids=lambda c: c.__name__,
+    )
+    def test_message_preserved(self, cls):
+        assert str(cls("detail")) == "detail"

--- a/accordo/tests/test_interop_and_codegen.py
+++ b/accordo/tests/test_interop_and_codegen.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for HIP interop guards and codegen type sizing.
+
+Only the validation and error-translation branches are covered. The actual
+``hipIpcOpenMemHandle`` / ``hipMemcpy`` calls are left to the GPU tests -- a
+stubbed HIP runtime would prove nothing about them.
+"""
+
+import ctypes
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from accordo._internal import codegen
+from accordo._internal import hip_interop as hip
+
+
+class TestHipTry:
+    def test_zero_is_success_and_returns_none(self):
+        assert hip.hip_try(0) is None
+
+    def test_nonzero_raises_with_decoded_message(self):
+        runtime = MagicMock()
+        runtime.hipGetErrorString.return_value = b"out of memory"
+        with patch.object(hip, "hip_runtime", runtime):
+            with pytest.raises(RuntimeError, match="HIP error code 2: out of memory"):
+                hip.hip_try(2)
+
+    def test_error_string_restype_is_set_before_the_call(self):
+        """Without c_char_p the returned pointer would decode as an int."""
+        runtime = MagicMock()
+        runtime.hipGetErrorString.return_value = b"boom"
+        with patch.object(hip, "hip_runtime", runtime):
+            with pytest.raises(RuntimeError):
+                hip.hip_try(1)
+        assert runtime.hipGetErrorString.restype is ctypes.c_char_p
+
+
+class TestIpcMemHandleStruct:
+    def test_reserved_field_is_64_bytes(self):
+        assert ctypes.sizeof(hip.hipIpcMemHandle_t) == 64
+
+
+class TestOpenIpcHandleValidation:
+    def test_non_array_rejected(self):
+        with pytest.raises(TypeError, match="numpy.ndarray"):
+            hip.open_ipc_handle(b"\x00" * 64)
+
+    def test_list_rejected(self):
+        with pytest.raises(TypeError, match="numpy.ndarray"):
+            hip.open_ipc_handle([0] * 64)
+
+    def test_wrong_dtype_rejected(self):
+        with pytest.raises(ValueError, match="64-element uint8"):
+            hip.open_ipc_handle(np.zeros(64, dtype=np.float32))
+
+    def test_wrong_size_rejected(self):
+        with pytest.raises(ValueError, match="64-element uint8"):
+            hip.open_ipc_handle(np.zeros(32, dtype=np.uint8))
+
+    def test_oversized_array_rejected(self):
+        with pytest.raises(ValueError, match="64-element uint8"):
+            hip.open_ipc_handle(np.zeros(128, dtype=np.uint8))
+
+
+class TestGetTypeSize:
+    @pytest.mark.parametrize(
+        ("type_str", "expected"),
+        [("float", 4), ("double", 8), ("int", 4)],
+    )
+    def test_known_scalar_types(self, type_str, expected):
+        assert codegen._get_type_size(type_str) == expected
+
+    def test_const_qualifier_stripped(self):
+        assert codegen._get_type_size("const float") == codegen._get_type_size("float")
+
+    def test_volatile_qualifier_stripped(self):
+        assert codegen._get_type_size("volatile int") == codegen._get_type_size("int")
+
+    def test_surrounding_whitespace_ignored(self):
+        assert codegen._get_type_size("  float  ") == codegen._get_type_size("float")
+
+    def test_unknown_type_falls_back_to_eight_bytes(self):
+        assert codegen._get_type_size("struct MyOpaqueThing") == 8
+
+    def test_unknown_type_warns(self, caplog):
+        with caplog.at_level("WARNING"):
+            codegen._get_type_size("some_unknown_t")
+        assert "Unknown type size" in caplog.text
+
+
+class TestPackageVersion:
+    def test_version_is_exposed(self):
+        import accordo
+
+        assert isinstance(accordo.__version__, str)
+        assert accordo.__version__
+
+    def test_falls_back_when_distribution_missing(self):
+        """An in-tree checkout with no installed dist must still import."""
+        import importlib
+
+        from importlib.metadata import PackageNotFoundError
+
+        import accordo
+
+        with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
+            reloaded = importlib.reload(accordo)
+            assert reloaded.__version__ == "0.4.0"
+        importlib.reload(accordo)  # restore the real version for other tests

--- a/accordo/tests/test_ipc_communication.py
+++ b/accordo/tests/test_ipc_communication.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the IPC layer's file and process handling.
+
+Only the parts that are pure OS/file logic are covered here. ``get_kern_arg_data``
+copies device memory through ctypes and is deliberately left alone -- stubbing
+the GPU out of it would leave a test that only exercises the stub.
+"""
+
+import errno
+import os
+from unittest.mock import patch
+
+import pytest
+
+from accordo._internal.ipc import communication as comm
+from accordo.exceptions import AccordoKernelNeverDispatched
+
+RECORD_LEN = 72
+HANDLE_LEN = 64
+
+
+def _record(handle_byte=0xAB, size=4096):
+    """One well-formed 72-byte IPC record: 64-byte handle + 8-byte little-endian size."""
+    return bytes([handle_byte]) * HANDLE_LEN + size.to_bytes(8, "little")
+
+
+def _framed(*records):
+    return b"".join(b"BEGIN\n" + r + b"END\n" for r in records)
+
+
+def _write(path, payload):
+    path.write_bytes(payload)
+    return str(path)
+
+
+class TestProcessIsAlive:
+    def test_none_pid_treated_as_alive(self):
+        assert comm._process_is_alive(None) is True
+
+    def test_reaped_child_is_dead(self):
+        with patch("os.waitpid", return_value=(1234, 0)):
+            assert comm._process_is_alive(1234) is False
+
+    def test_child_process_error_is_dead(self):
+        with patch("os.waitpid", side_effect=ChildProcessError()):
+            assert comm._process_is_alive(1234) is False
+
+    def test_echild_is_dead(self):
+        with patch("os.waitpid", side_effect=OSError(errno.ECHILD, "no child")):
+            assert comm._process_is_alive(1234) is False
+
+    def test_other_oserror_falls_through_to_kill_probe(self):
+        """A non-ECHILD waitpid error must not itself decide liveness."""
+        with (
+            patch("os.waitpid", side_effect=OSError(errno.EPERM, "denied")),
+            patch("os.kill", return_value=None),
+        ):
+            assert comm._process_is_alive(1234) is True
+
+    def test_still_running_when_kill_probe_succeeds(self):
+        with patch("os.waitpid", return_value=(0, 0)), patch("os.kill", return_value=None):
+            assert comm._process_is_alive(1234) is True
+
+    def test_dead_when_kill_probe_fails(self):
+        with (
+            patch("os.waitpid", return_value=(0, 0)),
+            patch("os.kill", side_effect=OSError(errno.ESRCH, "no such process")),
+        ):
+            assert comm._process_is_alive(1234) is False
+
+    def test_kill_probe_uses_signal_zero(self):
+        with patch("os.waitpid", return_value=(0, 0)), patch("os.kill") as kill:
+            comm._process_is_alive(4321)
+        kill.assert_called_once_with(4321, 0)
+
+
+class TestReadIpcRecords:
+    def test_absent_file_yields_nothing(self, tmp_path):
+        assert comm._read_ipc_records(str(tmp_path / "missing")) == []
+
+    def test_single_record_parsed(self, tmp_path):
+        path = _write(tmp_path / "ipc", _framed(_record(0x01, 1024)))
+        records = comm._read_ipc_records(path)
+        assert len(records) == 1
+        handle, size = records[0]
+        assert size == 1024
+        assert len(handle) == HANDLE_LEN
+        assert set(handle.tolist()) == {0x01}
+
+    def test_records_returned_in_order(self, tmp_path):
+        path = _write(tmp_path / "ipc", _framed(_record(1, 10), _record(2, 20), _record(3, 30)))
+        assert [s for _, s in comm._read_ipc_records(path)] == [10, 20, 30]
+
+    def test_duplicates_are_preserved(self, tmp_path):
+        """Unlike read_ipc_handles, this reader does not de-duplicate."""
+        path = _write(tmp_path / "ipc", _framed(_record(7, 99), _record(7, 99)))
+        assert len(comm._read_ipc_records(path)) == 2
+
+    def test_unterminated_message_skipped(self, tmp_path):
+        path = _write(tmp_path / "ipc", b"BEGIN\n" + _record() + _framed(_record(2, 8)))
+        assert [s for _, s in comm._read_ipc_records(path)] == [8]
+
+    def test_wrong_length_content_skipped(self, tmp_path):
+        path = _write(tmp_path / "ipc", _framed(b"tooshort") + _framed(_record(9, 64)))
+        assert [s for _, s in comm._read_ipc_records(path)] == [64]
+
+    def test_empty_file_yields_nothing(self, tmp_path):
+        assert comm._read_ipc_records(_write(tmp_path / "ipc", b"")) == []
+
+    def test_size_decoded_little_endian(self, tmp_path):
+        path = _write(tmp_path / "ipc", _framed(_record(0, 0x0102030405060708)))
+        assert comm._read_ipc_records(path)[0][1] == 0x0102030405060708
+
+
+class TestReadIpcHandles:
+    def test_returns_immediately_when_no_pointers_expected(self, tmp_path):
+        """count==0 means the loop never runs, so a missing file is fine."""
+        handles, sizes = comm.read_ipc_handles(["int", "const float*"], str(tmp_path / "absent"))
+        assert handles == [] and sizes == []
+
+    def test_counts_only_non_const_pointers(self, tmp_path):
+        path = _write(tmp_path / "ipc", _framed(_record(1, 16)))
+        handles, sizes = comm.read_ipc_handles(["const float*", "float*", "int"], path)
+        assert len(handles) == 1
+        assert sizes == [16]
+
+    def test_collects_multiple_distinct_handles(self, tmp_path):
+        path = _write(tmp_path / "ipc", _framed(_record(1, 10), _record(2, 20)))
+        handles, sizes = comm.read_ipc_handles(["float*", "double*"], path)
+        assert len(handles) == 2
+        assert sizes == [10, 20]
+
+    def test_duplicate_handles_are_deduplicated(self, tmp_path):
+        """The same handle appearing twice must not satisfy two expected pointers."""
+        path = _write(tmp_path / "ipc", _framed(_record(5, 32), _record(5, 32), _record(6, 64)))
+        handles, sizes = comm.read_ipc_handles(["float*", "int*"], path)
+        assert len(handles) == 2
+        assert sizes == [32, 64]
+
+    def test_sentinel_raises_kernel_never_dispatched(self, tmp_path):
+        sentinel = tmp_path / "sentinel"
+        sentinel.touch()
+        with pytest.raises(AccordoKernelNeverDispatched, match="never dispatched"):
+            comm.read_ipc_handles(["float*"], str(tmp_path / "absent"), sentinel_file=str(sentinel))
+
+    def test_waits_for_missing_file_then_proceeds(self, tmp_path):
+        """Absent file must poll rather than fail; appearing later must be picked up."""
+        path = tmp_path / "ipc"
+        state = {"n": 0}
+        real_exists = os.path.exists
+
+        def fake_exists(p):
+            if str(p) == str(path):
+                state["n"] += 1
+                if state["n"] == 1:
+                    return False
+                path.write_bytes(_framed(_record(1, 8)))
+            return real_exists(p)
+
+        with patch("accordo._internal.ipc.communication.os.path.exists", side_effect=fake_exists):
+            with patch("accordo._internal.ipc.communication.time.sleep"):
+                handles, sizes = comm.read_ipc_handles(["float*"], str(path))
+        assert sizes == [8]
+        assert state["n"] >= 2  # polled at least twice
+
+    def test_polls_until_all_handles_present(self, tmp_path):
+        """Two pointers expected but only one available at first."""
+        path = tmp_path / "ipc"
+        path.write_bytes(_framed(_record(1, 10)))
+        calls = {"n": 0}
+
+        def grow(_seconds):
+            calls["n"] += 1
+            path.write_bytes(_framed(_record(1, 10), _record(2, 20)))
+
+        with patch("accordo._internal.ipc.communication.time.sleep", side_effect=grow):
+            handles, sizes = comm.read_ipc_handles(["float*", "float*"], str(path))
+        assert sizes == [10, 20]
+        assert calls["n"] >= 1
+
+
+class TestSendResponse:
+    def test_writes_done_to_the_pipe(self, tmp_path):
+        pipe = tmp_path / "fifo"
+        comm.send_response(str(pipe))
+        assert pipe.read_text() == "done\n"

--- a/accordo/tests/test_kernel_args.py
+++ b/accordo/tests/test_kernel_args.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for kernel argument extraction.
+
+KernelDB is substituted so these exercise Accordo's own path selection, error
+translation and match logic rather than the C++ library.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from accordo import kernel_args as ka
+from accordo.exceptions import AccordoError
+
+
+def _arg(name, type_name):
+    a = MagicMock()
+    a.name = name
+    a.type_name = type_name
+    return a
+
+
+def _kdb(kernels=("reduce_sum",), args=None):
+    inst = MagicMock()
+    inst.get_kernels.return_value = list(kernels)
+    inst.get_kernel_arguments.return_value = (
+        args if args is not None else [_arg("input", "const float*"), _arg("n", "int")]
+    )
+    return inst
+
+
+class TestExtractKernelArguments:
+    def test_returns_name_type_tuples(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.touch()
+        inst = _kdb()
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", return_value=inst),
+        ):
+            out = ka.extract_kernel_arguments(str(binary), "reduce_sum")
+        assert out == [("input", "const float*"), ("n", "int")]
+
+    def test_resolve_typedefs_requested(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.touch()
+        inst = _kdb()
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", return_value=inst),
+        ):
+            ka.extract_kernel_arguments(str(binary), "reduce_sum")
+        assert inst.get_kernel_arguments.call_args.kwargs["resolve_typedefs"] is True
+
+    def test_substring_match_selects_kernel(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.touch()
+        inst = _kdb(kernels=("_Z10reduce_sumPfS_i",))
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", return_value=inst),
+        ):
+            ka.extract_kernel_arguments(str(binary), "reduce_sum")
+        assert inst.get_kernel_arguments.call_args.args[0] == "_Z10reduce_sumPfS_i"
+
+    def test_first_match_wins_when_ambiguous(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.touch()
+        inst = _kdb(kernels=("reduce_sum_a", "reduce_sum_b"))
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", return_value=inst),
+        ):
+            ka.extract_kernel_arguments(str(binary), "reduce_sum")
+        assert inst.get_kernel_arguments.call_args.args[0] == "reduce_sum_a"
+
+    def test_relative_path_resolved_against_working_directory(self, tmp_path):
+        (tmp_path / "app").touch()
+        inst = _kdb()
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", return_value=inst) as cls,
+        ):
+            ka.extract_kernel_arguments("app", "reduce_sum", working_directory=str(tmp_path))
+        assert cls.call_args.args[0] == str(tmp_path / "app")
+
+    def test_absolute_path_left_alone(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.touch()
+        inst = _kdb()
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", return_value=inst) as cls,
+        ):
+            ka.extract_kernel_arguments(str(binary), "reduce_sum", working_directory="/elsewhere")
+        assert cls.call_args.args[0] == str(binary)
+
+    def test_missing_kerneldb_raises(self):
+        with patch.object(ka, "KERNELDB_AVAILABLE", False):
+            with pytest.raises(AccordoError, match="kernelDB not available"):
+                ka.extract_kernel_arguments("/nope", "k")
+
+    def test_missing_binary_raises(self, tmp_path):
+        with patch.object(ka, "KERNELDB_AVAILABLE", True):
+            with pytest.raises(AccordoError, match="Binary not found"):
+                ka.extract_kernel_arguments(str(tmp_path / "absent"), "k")
+
+    def test_kernel_not_found_lists_available(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.touch()
+        inst = _kdb(kernels=("alpha", "beta"))
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", return_value=inst),
+        ):
+            with pytest.raises(AccordoError, match="alpha, beta"):
+                ka.extract_kernel_arguments(str(binary), "gamma")
+
+    def test_no_argument_info_mentions_debug_symbols(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.touch()
+        inst = _kdb(args=[])
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", return_value=inst),
+        ):
+            with pytest.raises(AccordoError, match="debug symbols"):
+                ka.extract_kernel_arguments(str(binary), "reduce_sum")
+
+    def test_underlying_failure_wrapped(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.touch()
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", side_effect=RuntimeError("corrupt elf")),
+        ):
+            with pytest.raises(AccordoError, match="Failed to extract kernel arguments"):
+                ka.extract_kernel_arguments(str(binary), "k")
+
+    def test_accordo_error_not_double_wrapped(self, tmp_path):
+        """An AccordoError raised inside the try block must propagate unchanged."""
+        binary = tmp_path / "app"
+        binary.touch()
+        inst = _kdb(kernels=("other",))
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", return_value=inst),
+        ):
+            with pytest.raises(AccordoError) as exc:
+                ka.extract_kernel_arguments(str(binary), "missing")
+        assert "Failed to extract kernel arguments" not in str(exc.value)
+
+
+class TestListAvailableKernels:
+    def test_returns_kernel_names(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.touch()
+        inst = _kdb(kernels=("a", "b"))
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", return_value=inst),
+        ):
+            assert ka.list_available_kernels(str(binary)) == ["a", "b"]
+
+    def test_relative_path_resolved(self, tmp_path):
+        (tmp_path / "app").touch()
+        inst = _kdb()
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", return_value=inst) as cls,
+        ):
+            ka.list_available_kernels("app", working_directory=str(tmp_path))
+        assert cls.call_args.args[0] == str(tmp_path / "app")
+
+    def test_missing_kerneldb_raises(self):
+        with patch.object(ka, "KERNELDB_AVAILABLE", False):
+            with pytest.raises(AccordoError, match="kernelDB not available"):
+                ka.list_available_kernels("/nope")
+
+    def test_missing_binary_raises(self, tmp_path):
+        with patch.object(ka, "KERNELDB_AVAILABLE", True):
+            with pytest.raises(AccordoError, match="Binary not found"):
+                ka.list_available_kernels(str(tmp_path / "absent"))
+
+    def test_failure_wrapped(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.touch()
+        with (
+            patch.object(ka, "KERNELDB_AVAILABLE", True),
+            patch.object(ka, "KernelDB", side_effect=RuntimeError("bad")),
+        ):
+            with pytest.raises(AccordoError, match="Failed to list kernels"):
+                ka.list_available_kernels(str(binary))

--- a/accordo/tests/test_mcp_tool.py
+++ b/accordo/tests/test_mcp_tool.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the Accordo MCP tool body.
+
+``test_mcp_server.py`` covers ``main()`` and transport wiring.  This covers
+``run_validate_kernel_correctness`` — the logic the MCP tool actually delegates
+to — with the validator substituted so no GPU is required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from accordo.mcp import server as mcp_server
+
+
+def _result(is_valid=True, n=3, summary="3/3 arrays matched"):
+    r = MagicMock()
+    r.is_valid = is_valid
+    r.num_arrays_validated = n
+    r.summary.return_value = summary
+    return r
+
+
+def _patched(result=None, side_effect=None):
+    validator = MagicMock()
+    validator.capture_snapshot.side_effect = ["REF_SNAP", "OPT_SNAP"]
+    validator.compare_snapshots.return_value = result if result is not None else _result()
+    cls = MagicMock(return_value=validator)
+    if side_effect is not None:
+        cls.side_effect = side_effect
+    return cls, validator
+
+
+class TestRunValidateKernelCorrectness:
+    def test_returns_the_three_documented_keys(self):
+        cls, _ = _patched()
+        with patch.object(mcp_server, "Accordo", cls):
+            out = mcp_server.run_validate_kernel_correctness("k", ["./ref"], ["./opt"])
+        assert set(out) == {"is_valid", "num_arrays_validated", "summary"}
+
+    def test_values_come_from_the_comparison_result(self):
+        cls, _ = _patched(result=_result(is_valid=False, n=5, summary="2/5 mismatched"))
+        with patch.object(mcp_server, "Accordo", cls):
+            out = mcp_server.run_validate_kernel_correctness("k", ["./ref"], ["./opt"])
+        assert out == {
+            "is_valid": False,
+            "num_arrays_validated": 5,
+            "summary": "2/5 mismatched",
+        }
+
+    def test_validator_constructed_with_reference_command(self):
+        cls, _ = _patched()
+        with patch.object(mcp_server, "Accordo", cls):
+            mcp_server.run_validate_kernel_correctness("reduce", ["./ref", "--n", "8"], ["./opt"])
+        kwargs = cls.call_args.kwargs
+        assert kwargs["binary"] == ["./ref", "--n", "8"]
+        assert kwargs["kernel_name"] == "reduce"
+        assert kwargs["kernel_args"] is None
+        assert kwargs["working_directory"] == "."
+
+    def test_working_directory_forwarded(self):
+        cls, _ = _patched()
+        with patch.object(mcp_server, "Accordo", cls):
+            mcp_server.run_validate_kernel_correctness(
+                "k", ["./ref"], ["./opt"], working_directory="/build"
+            )
+        assert cls.call_args.kwargs["working_directory"] == "/build"
+
+    def test_reference_then_optimized_are_both_captured(self):
+        cls, validator = _patched()
+        with patch.object(mcp_server, "Accordo", cls):
+            mcp_server.run_validate_kernel_correctness("k", ["./ref"], ["./opt"])
+        captured = [c.kwargs["binary"] for c in validator.capture_snapshot.call_args_list]
+        assert captured == [["./ref"], ["./opt"]]
+
+    def test_snapshots_passed_to_compare_in_order(self):
+        cls, validator = _patched()
+        with patch.object(mcp_server, "Accordo", cls):
+            mcp_server.run_validate_kernel_correctness("k", ["./ref"], ["./opt"])
+        assert validator.compare_snapshots.call_args.args == ("REF_SNAP", "OPT_SNAP")
+
+    def test_tolerance_defaults(self):
+        cls, validator = _patched()
+        with patch.object(mcp_server, "Accordo", cls):
+            mcp_server.run_validate_kernel_correctness("k", ["./ref"], ["./opt"])
+        kwargs = validator.compare_snapshots.call_args.kwargs
+        assert kwargs["tolerance"] is None
+        assert kwargs["atol"] == 1e-08
+        assert kwargs["rtol"] == 1e-05
+        assert kwargs["equal_nan"] is False
+
+    def test_tolerance_overrides_forwarded(self):
+        cls, validator = _patched()
+        with patch.object(mcp_server, "Accordo", cls):
+            mcp_server.run_validate_kernel_correctness(
+                "k", ["./ref"], ["./opt"], tolerance=1e-3, atol=1e-9, rtol=1e-4, equal_nan=True
+            )
+        kwargs = validator.compare_snapshots.call_args.kwargs
+        assert kwargs["tolerance"] == 1e-3
+        assert kwargs["atol"] == 1e-9
+        assert kwargs["rtol"] == 1e-4
+        assert kwargs["equal_nan"] is True
+
+    def test_validator_errors_propagate(self):
+        from accordo.exceptions import AccordoError
+
+        cls, _ = _patched(side_effect=AccordoError("kernel never dispatched"))
+        with patch.object(mcp_server, "Accordo", cls):
+            with pytest.raises(AccordoError, match="kernel never dispatched"):
+                mcp_server.run_validate_kernel_correctness("k", ["./ref"], ["./opt"])
+
+
+class TestToolWrapper:
+    def _tool(self):
+        return getattr(
+            mcp_server.validate_kernel_correctness, "fn", mcp_server.validate_kernel_correctness
+        )
+
+    def test_tool_delegates_to_the_plain_function(self):
+        with patch.object(
+            mcp_server, "run_validate_kernel_correctness", return_value={"is_valid": True}
+        ) as run:
+            out = self._tool()("k", ["./ref"], ["./opt"])
+        assert out == {"is_valid": True}
+        assert run.call_args.kwargs["kernel_name"] == "k"
+
+    def test_tool_forwards_every_tolerance_argument(self):
+        with patch.object(mcp_server, "run_validate_kernel_correctness", return_value={}) as run:
+            self._tool()(
+                "k",
+                ["./ref"],
+                ["./opt"],
+                tolerance=1e-2,
+                atol=1e-7,
+                rtol=1e-3,
+                equal_nan=True,
+                working_directory="/w",
+            )
+        kwargs = run.call_args.kwargs
+        assert kwargs["tolerance"] == 1e-2
+        assert kwargs["atol"] == 1e-7
+        assert kwargs["rtol"] == 1e-3
+        assert kwargs["equal_nan"] is True
+        assert kwargs["working_directory"] == "/w"
+
+    def test_server_name(self):
+        assert mcp_server.mcp.name == "IntelliKit Accordo"

--- a/accordo/tests/test_result_and_validator_helpers.py
+++ b/accordo/tests/test_result_and_validator_helpers.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the result types and the module-level validator helpers.
+
+``Accordo`` itself drives real GPU processes and is exercised by
+``test_reduction_validation.py``. Covered here are the pieces that carry logic
+but no hardware: the result dataclasses, the tolerance comparison, the timeout
+signal handler, and the build wrapper's error translation.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from accordo import validator as V
+from accordo.exceptions import AccordoBuildError
+from accordo.result import ArrayMismatch, ValidationResult
+
+
+def _mismatch(**over):
+    base = dict(
+        arg_index=0,
+        arg_name="output",
+        arg_type="float*",
+        max_difference=1.5e-3,
+        mean_difference=2.5e-4,
+        reference_sample=np.zeros(3),
+        optimized_sample=np.ones(3),
+    )
+    base.update(over)
+    return ArrayMismatch(**base)
+
+
+class TestArrayMismatch:
+    def test_dispatch_index_defaults_to_none(self):
+        assert _mismatch().dispatch_index is None
+
+    def test_str_reports_name_type_and_diffs(self):
+        s = str(_mismatch())
+        assert "arg 'output'" in s
+        assert "(float*)" in s
+        assert "max_diff=1.50e-03" in s
+        assert "mean_diff=2.50e-04" in s
+
+    def test_str_omits_dispatch_prefix_when_absent(self):
+        assert "dispatch" not in str(_mismatch())
+
+    def test_str_includes_dispatch_prefix_when_set(self):
+        assert str(_mismatch(dispatch_index=4)).startswith("Mismatch in dispatch 4: arg")
+
+    def test_dispatch_index_zero_is_still_shown(self):
+        """0 is a valid dispatch index and must not be treated as absent."""
+        assert "dispatch 0:" in str(_mismatch(dispatch_index=0))
+
+
+class TestValidationResultDefaults:
+    def test_collections_default_to_empty_not_none(self):
+        r = ValidationResult(is_valid=True)
+        assert r.mismatches == []
+        assert r.matched_arrays == {}
+        assert r.execution_time_ms == {}
+
+    def test_supplied_collections_are_kept(self):
+        m = [_mismatch()]
+        r = ValidationResult(
+            is_valid=False, mismatches=m, matched_arrays={"a": {}}, execution_time_ms={"ref": 1.0}
+        )
+        assert r.mismatches is m
+        assert r.matched_arrays == {"a": {}}
+        assert r.execution_time_ms == {"ref": 1.0}
+
+    def test_optional_scalars_default_to_none(self):
+        r = ValidationResult(is_valid=True)
+        assert r.error_message is None
+        assert r.timeout_used is None
+
+
+class TestValidationResultCounts:
+    def test_num_arrays_counts_matched_and_mismatched(self):
+        r = ValidationResult(
+            is_valid=False, mismatches=[_mismatch(), _mismatch()], matched_arrays={"a": {}}
+        )
+        assert r.num_arrays_validated == 3
+        assert r.num_mismatches == 2
+
+    def test_empty_result_counts_zero(self):
+        r = ValidationResult(is_valid=True)
+        assert r.num_arrays_validated == 0
+        assert r.num_mismatches == 0
+
+    def test_success_rate_all_matched(self):
+        r = ValidationResult(is_valid=True, matched_arrays={"a": {}, "b": {}})
+        assert r.success_rate == 100.0
+
+    def test_success_rate_partial(self):
+        r = ValidationResult(is_valid=False, mismatches=[_mismatch()], matched_arrays={"a": {}})
+        assert r.success_rate == 50.0
+
+    def test_success_rate_none_matched(self):
+        r = ValidationResult(is_valid=False, mismatches=[_mismatch()])
+        assert r.success_rate == 0.0
+
+    def test_success_rate_zero_arrays_does_not_divide_by_zero(self):
+        assert ValidationResult(is_valid=True).success_rate == 0.0
+
+
+class TestValidationResultSummary:
+    def test_pass_summary_reports_count(self):
+        r = ValidationResult(is_valid=True, matched_arrays={"a": {}, "b": {}})
+        assert "Validation passed" in r.summary()
+        assert "2 arrays" in r.summary()
+
+    def test_fail_summary_includes_error_message(self):
+        r = ValidationResult(is_valid=False, error_message="tolerance exceeded")
+        assert "Validation failed" in r.summary()
+        assert "tolerance exceeded" in r.summary()
+
+    def test_fail_summary_lists_each_mismatch(self):
+        r = ValidationResult(
+            is_valid=False,
+            error_message="bad",
+            mismatches=[_mismatch(arg_name="a"), _mismatch(arg_name="b")],
+        )
+        out = r.summary()
+        assert "Mismatched arrays (2)" in out
+        assert "arg 'a'" in out
+        assert "arg 'b'" in out
+
+    def test_fail_summary_without_mismatches_omits_the_list(self):
+        r = ValidationResult(is_valid=False, error_message="crashed before comparison")
+        assert "Mismatched arrays" not in r.summary()
+
+    def test_str_delegates_to_summary(self):
+        r = ValidationResult(is_valid=True)
+        assert str(r) == r.summary()
+
+
+class TestValidateArrays:
+    def test_identical_arrays_match(self):
+        a = np.array([1.0, 2.0, 3.0])
+        assert V._validate_arrays(a, a.copy(), atol=0.0, rtol=0.0, equal_nan=False) is True
+
+    def test_difference_within_atol_matches(self):
+        a = np.array([1.0])
+        b = np.array([1.0 + 1e-9])
+        assert V._validate_arrays(a, b, atol=1e-8, rtol=0.0, equal_nan=False) is True
+
+    def test_difference_beyond_tolerance_fails(self):
+        a = np.array([1.0])
+        b = np.array([1.5])
+        assert V._validate_arrays(a, b, atol=1e-8, rtol=1e-8, equal_nan=False) is False
+
+    def test_rtol_scales_with_magnitude(self):
+        a = np.array([1000.0])
+        b = np.array([1000.1])
+        assert V._validate_arrays(a, b, atol=0.0, rtol=1e-3, equal_nan=False) is True
+        assert V._validate_arrays(a, b, atol=0.0, rtol=1e-9, equal_nan=False) is False
+
+    def test_nan_mismatch_unless_equal_nan(self):
+        a = np.array([np.nan])
+        b = np.array([np.nan])
+        assert V._validate_arrays(a, b, atol=0.0, rtol=0.0, equal_nan=False) is False
+        assert V._validate_arrays(a, b, atol=0.0, rtol=0.0, equal_nan=True) is True
+
+
+class TestTimeoutHandler:
+    def test_raises_timeout_exception(self):
+        with pytest.raises(V._TimeoutException, match="timed out"):
+            V._timeout_handler(14, None)
+
+    def test_timeout_exception_is_an_exception(self):
+        assert issubclass(V._TimeoutException, Exception)
+
+
+class TestBuildAccordo:
+    def _run_ok(self):
+        r = MagicMock()
+        r.stdout = "ok"
+        r.stderr = ""
+        return r
+
+    def test_returns_library_path_on_success(self, tmp_path):
+        lib = tmp_path / "build" / "lib" / "libaccordo.so"
+        lib.parent.mkdir(parents=True)
+        lib.touch()
+        with patch.object(V.subprocess, "run", return_value=self._run_ok()):
+            assert V._build_accordo(tmp_path) == lib
+
+    def test_configure_then_build_are_both_invoked(self, tmp_path):
+        lib = tmp_path / "build" / "lib" / "libaccordo.so"
+        lib.parent.mkdir(parents=True)
+        lib.touch()
+        with patch.object(V.subprocess, "run", return_value=self._run_ok()) as run:
+            V._build_accordo(tmp_path, parallel_jobs=4)
+        assert run.call_args_list[0].args[0] == ["cmake", "-B", "build"]
+        assert run.call_args_list[1].args[0] == [
+            "cmake",
+            "--build",
+            "build",
+            "--parallel",
+            "4",
+        ]
+
+    def test_missing_library_after_build_raises(self, tmp_path):
+        with patch.object(V.subprocess, "run", return_value=self._run_ok()):
+            with pytest.raises(AccordoBuildError, match="Library not found"):
+                V._build_accordo(tmp_path)
+
+    def test_cmake_failure_is_translated(self, tmp_path):
+        err = subprocess.CalledProcessError(1, "cmake", stderr="no CMAKE_CXX_COMPILER")
+        with patch.object(V.subprocess, "run", side_effect=err):
+            with pytest.raises(AccordoBuildError, match="no CMAKE_CXX_COMPILER"):
+                V._build_accordo(tmp_path)
+
+    def test_unexpected_error_is_translated(self, tmp_path):
+        with patch.object(V.subprocess, "run", side_effect=OSError("cmake not found")):
+            with pytest.raises(AccordoBuildError, match="cmake not found"):
+                V._build_accordo(tmp_path)
+
+    def test_build_runs_in_the_given_directory(self, tmp_path):
+        lib = tmp_path / "build" / "lib" / "libaccordo.so"
+        lib.parent.mkdir(parents=True)
+        lib.touch()
+        with patch.object(V.subprocess, "run", return_value=self._run_ok()) as run:
+            V._build_accordo(Path(tmp_path))
+        for call in run.call_args_list:
+            assert call.kwargs["cwd"] == Path(tmp_path)
+            assert call.kwargs["check"] is True

--- a/accordo/tests/test_snapshot.py
+++ b/accordo/tests/test_snapshot.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the Snapshot dataclass."""
+
+import numpy as np
+
+from accordo.snapshot import Snapshot
+
+
+def _snap(**over):
+    base = dict(
+        arrays=[np.zeros(4, dtype=np.float32), np.ones(2, dtype=np.int32)],
+        execution_time_ms=12.345,
+        binary=["./my_app"],
+        working_directory="/tmp/proj",
+    )
+    base.update(over)
+    return Snapshot(**base)
+
+
+class TestConstruction:
+    def test_optional_fields_default_to_none(self):
+        s = _snap()
+        assert s.grid_size is None
+        assert s.block_size is None
+        assert s.dispatch_arrays is None
+
+    def test_fields_round_trip(self):
+        s = _snap()
+        assert len(s.arrays) == 2
+        assert s.execution_time_ms == 12.345
+        assert s.binary == ["./my_app"]
+        assert s.working_directory == "/tmp/proj"
+
+
+class TestRepr:
+    def test_includes_binary_array_count_and_time(self):
+        r = repr(_snap())
+        assert "./my_app" in r
+        assert "arrays=2" in r
+        assert "12.35" in r  # formatted to 2dp
+
+    def test_joins_multi_token_binary(self):
+        assert "python run.py" in repr(_snap(binary=["python", "run.py"]))
+
+    def test_handles_no_arrays(self):
+        assert "arrays=0" in repr(_snap(arrays=[]))
+
+
+class TestSummary:
+    def test_core_lines_present(self):
+        out = _snap().summary()
+        assert "Snapshot Summary:" in out
+        assert "Binary: ./my_app" in out
+        assert "Working Directory: /tmp/proj" in out
+        assert "Execution Time: 12.35ms" in out
+        assert "Number of Arrays: 2" in out
+
+    def test_lists_every_array_with_shape_and_dtype(self):
+        out = _snap().summary()
+        assert "Array 0: shape=(4,), dtype=float32" in out
+        assert "Array 1: shape=(2,), dtype=int32" in out
+
+    def test_optional_sections_absent_by_default(self):
+        out = _snap().summary()
+        assert "Grid Size" not in out
+        assert "Block Size" not in out
+        assert "Number of Dispatches" not in out
+
+    def test_grid_size_rendered(self):
+        out = _snap(grid_size={"x": 8, "y": 2, "z": 1}).summary()
+        assert "Grid Size: x=8, y=2, z=1" in out
+
+    def test_block_size_rendered(self):
+        out = _snap(block_size={"x": 256, "y": 1, "z": 1}).summary()
+        assert "Block Size: x=256, y=1, z=1" in out
+
+    def test_missing_dimension_keys_render_as_none(self):
+        out = _snap(grid_size={"x": 4}).summary()
+        assert "Grid Size: x=4, y=None, z=None" in out
+
+    def test_dispatch_count_rendered(self):
+        out = _snap(dispatch_arrays=[[np.zeros(1)], [np.zeros(1)], [np.zeros(1)]]).summary()
+        assert "Number of Dispatches: 3" in out
+
+    def test_empty_dispatch_list_still_reported(self):
+        assert "Number of Dispatches: 0" in _snap(dispatch_arrays=[]).summary()
+
+    def test_no_arrays_produces_no_array_lines(self):
+        out = _snap(arrays=[]).summary()
+        assert "Number of Arrays: 0" in out
+        assert "Array 0" not in out

--- a/accordo/tests/test_validate_results.py
+++ b/accordo/tests/test_validate_results.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for snapshot comparison.
+
+``compare_snapshots`` and ``_validate_results`` are pure array logic -- the only
+attribute either reads from the instance is ``kernel_args``. They were reachable
+before only through a live GPU capture, so the instance is built with
+``object.__new__`` to skip the hardware setup in ``__init__``. The arrays and the
+comparison itself are real.
+"""
+
+import numpy as np
+import pytest
+
+from accordo.snapshot import Snapshot
+from accordo.validator import Accordo
+
+# Two outputs and one input; only the non-const pointers produce arrays.
+KERNEL_ARGS = [
+    ("input", "const float*"),
+    ("output", "float*"),
+    ("n", "int"),
+    ("acc", "double*"),
+]
+
+
+def _validator(kernel_args=None):
+    v = object.__new__(Accordo)
+    v.kernel_args = KERNEL_ARGS if kernel_args is None else kernel_args
+    return v
+
+
+def _snap(arrays=None, dispatch_arrays=None, exec_ms=1.0):
+    return Snapshot(
+        arrays=arrays if arrays is not None else [],
+        execution_time_ms=exec_ms,
+        binary=["./app"],
+        working_directory=".",
+        dispatch_arrays=dispatch_arrays,
+    )
+
+
+def _run(ref, opt, kernel_args=None, **kw):
+    return _validator(kernel_args).compare_snapshots(_snap(ref), _snap(opt), **kw)
+
+
+class TestMatching:
+    def test_identical_arrays_pass(self):
+        a = [np.ones(4), np.zeros(3)]
+        r = _run(a, [x.copy() for x in a])
+        assert r.is_valid is True
+        assert r.num_mismatches == 0
+        assert r.error_message is None
+
+    def test_matched_arrays_keyed_by_dispatch_and_argname(self):
+        a = [np.ones(4), np.zeros(3)]
+        r = _run(a, [x.copy() for x in a])
+        assert set(r.matched_arrays) == {"dispatch_0:output", "dispatch_0:acc"}
+
+    def test_matched_entry_carries_kernel_arg_index_not_array_index(self):
+        """Array 1 is kernel arg 3 -- the const input is skipped in the mapping."""
+        a = [np.ones(4), np.zeros(3)]
+        r = _run(a, [x.copy() for x in a])
+        assert r.matched_arrays["dispatch_0:output"]["index"] == 1
+        assert r.matched_arrays["dispatch_0:acc"]["index"] == 3
+
+    def test_matched_entry_records_type_size_and_dispatch(self):
+        a = [np.ones(4), np.zeros(3)]
+        entry = _run(a, [x.copy() for x in a]).matched_arrays["dispatch_0:output"]
+        assert entry["type"] == "float*"
+        assert entry["size"] == 4
+        assert entry["dispatch"] == 0
+        assert entry["arg_name"] == "output"
+
+    def test_execution_times_propagated(self):
+        v = _validator()
+        r = v.compare_snapshots(_snap([np.ones(2)], exec_ms=5.0), _snap([np.ones(2)], exec_ms=7.0))
+        assert r.execution_time_ms == {"reference": 5.0, "optimized": 7.0}
+
+
+class TestMismatches:
+    def test_differing_arrays_fail(self):
+        r = _run([np.zeros(4)], [np.ones(4)])
+        assert r.is_valid is False
+        assert r.num_mismatches == 1
+
+    def test_mismatch_carries_kernel_arg_metadata(self):
+        m = _run([np.zeros(4)], [np.ones(4)]).mismatches[0]
+        assert m.arg_index == 1
+        assert m.arg_name == "output"
+        assert m.arg_type == "float*"
+        assert m.dispatch_index == 0
+
+    def test_max_and_mean_difference_computed(self):
+        ref = np.array([0.0, 0.0, 0.0, 0.0])
+        opt = np.array([1.0, 3.0, 0.0, 0.0])
+        m = _run([ref], [opt]).mismatches[0]
+        assert m.max_difference == 3.0
+        assert m.mean_difference == 1.0
+
+    def test_all_nan_difference_falls_back_to_zero(self):
+        """Every diff is NaN, so there is no finite value to reduce over."""
+        ref = np.array([np.nan, np.nan])
+        opt = np.array([1.0, 2.0])
+        m = _run([ref], [opt]).mismatches[0]
+        assert m.max_difference == 0.0
+        assert m.mean_difference == 0.0
+
+    def test_samples_truncated_at_ten_elements(self):
+        ref = np.zeros(50)
+        opt = np.ones(50)
+        m = _run([ref], [opt]).mismatches[0]
+        assert len(m.reference_sample) == 10
+        assert len(m.optimized_sample) == 10
+
+    def test_short_arrays_are_not_truncated(self):
+        m = _run([np.zeros(3)], [np.ones(3)]).mismatches[0]
+        assert len(m.reference_sample) == 3
+
+    def test_error_message_lists_every_mismatch(self):
+        r = _run([np.zeros(2), np.zeros(2)], [np.ones(2), np.ones(2)])
+        assert "2 array(s) mismatched" in r.error_message
+        assert r.error_message.count("  - ") == 2
+
+    def test_partial_failure_reports_both_sides(self):
+        same = np.ones(3)
+        r = _run([same, np.zeros(2)], [same.copy(), np.ones(2)])
+        assert r.is_valid is False
+        assert r.num_mismatches == 1
+        assert set(r.matched_arrays) == {"dispatch_0:output"}
+
+
+class TestTolerance:
+    def test_within_atol_passes(self):
+        r = _run([np.array([1.0])], [np.array([1.0 + 1e-9])], atol=1e-8, rtol=0.0)
+        assert r.is_valid is True
+
+    def test_beyond_tolerance_fails(self):
+        r = _run([np.array([1.0])], [np.array([1.5])], atol=1e-8, rtol=1e-8)
+        assert r.is_valid is False
+
+    def test_tolerance_alias_overrides_atol(self):
+        """`tolerance` is the legacy name and must win when both are given."""
+        ref, opt = [np.array([1.0])], [np.array([1.1])]
+        assert _run(ref, opt, atol=1e-9).is_valid is False
+        assert _run(ref, opt, tolerance=1.0, atol=1e-9).is_valid is True
+
+    def test_equal_nan_toggle(self):
+        ref, opt = [np.array([np.nan])], [np.array([np.nan])]
+        assert _run(ref, opt).is_valid is False
+        assert _run(ref, opt, equal_nan=True).is_valid is True
+
+
+class TestDispatches:
+    def test_dispatch_arrays_preferred_over_arrays(self):
+        v = _validator()
+        ref = Snapshot(
+            arrays=[np.zeros(2)],
+            execution_time_ms=1.0,
+            binary=["./a"],
+            working_directory=".",
+            dispatch_arrays=[[np.ones(2)], [np.ones(2)]],
+        )
+        opt = Snapshot(
+            arrays=[np.zeros(2)],
+            execution_time_ms=1.0,
+            binary=["./a"],
+            working_directory=".",
+            dispatch_arrays=[[np.ones(2)], [np.ones(2)]],
+        )
+        r = v.compare_snapshots(ref, opt)
+        assert r.is_valid is True
+        assert set(r.matched_arrays) == {"dispatch_0:output", "dispatch_1:output"}
+
+    def test_second_dispatch_mismatch_detected(self):
+        v = _validator()
+        ref = _snap(dispatch_arrays=[[np.ones(2)], [np.ones(2)]])
+        opt = _snap(dispatch_arrays=[[np.ones(2)], [np.zeros(2)]])
+        r = v.compare_snapshots(ref, opt)
+        assert r.is_valid is False
+        assert r.mismatches[0].dispatch_index == 1
+
+    def test_dispatch_count_mismatch_reported(self):
+        v = _validator()
+        ref = _snap(dispatch_arrays=[[np.ones(2)], [np.ones(2)]])
+        opt = _snap(dispatch_arrays=[[np.ones(2)]])
+        r = v.compare_snapshots(ref, opt)
+        assert r.is_valid is False
+        assert "Dispatch count mismatch: 2 vs 1" in r.error_message
+        assert r.mismatches == []
+
+    def test_array_count_mismatch_reported(self):
+        r = _run([np.ones(2), np.ones(2)], [np.ones(2)])
+        assert r.is_valid is False
+        assert "Array count mismatch at dispatch 0: 2 vs 1" in r.error_message
+
+    def test_array_count_mismatch_names_the_dispatch(self):
+        v = _validator()
+        ref = _snap(dispatch_arrays=[[np.ones(2)], [np.ones(2), np.ones(2)]])
+        opt = _snap(dispatch_arrays=[[np.ones(2)], [np.ones(2)]])
+        r = v.compare_snapshots(ref, opt)
+        assert "at dispatch 1" in r.error_message
+
+
+class TestOutputArgMapping:
+    def test_const_pointers_excluded_from_mapping(self):
+        args = [("in", "const float*"), ("out", "float*")]
+        r = _run([np.ones(2)], [np.ones(2)], kernel_args=args)
+        assert r.matched_arrays["dispatch_0:out"]["index"] == 1
+
+    def test_scalars_excluded_from_mapping(self):
+        args = [("n", "int"), ("out", "float*")]
+        r = _run([np.ones(2)], [np.ones(2)], kernel_args=args)
+        assert "dispatch_0:out" in r.matched_arrays
+
+    def test_multiple_outputs_map_in_declaration_order(self):
+        args = [("a", "float*"), ("n", "int"), ("b", "double*")]
+        r = _run([np.ones(2), np.zeros(2)], [np.ones(2), np.zeros(2)], kernel_args=args)
+        assert r.matched_arrays["dispatch_0:a"]["index"] == 0
+        assert r.matched_arrays["dispatch_0:b"]["index"] == 2
+
+    def test_no_arrays_is_vacuously_valid(self):
+        r = _run([], [])
+        assert r.is_valid is True
+        assert r.matched_arrays == {}
+
+
+@pytest.mark.parametrize("n", [1, 10, 11, 100])
+def test_sample_length_never_exceeds_ten(n):
+    m = _run([np.zeros(n)], [np.ones(n)]).mismatches[0]
+    assert len(m.reference_sample) == min(n, 10)


### PR DESCRIPTION
Raises `accordo` coverage from **64% to 88%**. 161 new tests across 8 files, **no source changes**. 181 pass in ~31s.

| module | before | after |
|---|---:|---:|
| `cli.py` | **0%** | **95%** |
| `snapshot.py` | 52% | **100%** |
| `kernel_args.py` | 54% | 96% |
| `_internal/ipc/communication.py` | 57% | 77% |
| `mcp/server.py` | 74% | 96% |
| `exceptions.py` | 75% | **100%** |
| `validator.py` | 78% | 85% |
| `__init__.py` | 82% | **100%** |
| `_internal/hip_interop.py` | 85% | **100%** |
| `result.py` | 89% | **100%** |
| `_internal/codegen.py` | 93% | **100%** |
| **TOTAL** | **64%** | **88%** |

## Notes

**`cli.py` was entirely untested and needed care to reach.** `_run_validate` ends in `os._exit` and swaps file descriptors 1 and 2 around the validation run, so neither the return value nor the JSON payload is observable in-process. Both are patched, which also makes the fd choreography itself assertable — there is a test that the saved descriptor is restored *before* the JSON is written, which is the property the redirect exists to guarantee.

**Fixtures use real objects, not `MagicMock`, wherever a shape is asserted.** `ArrayMismatch`, `ValidationResult` and `Snapshot` are constructed for real, so renaming a field breaks these tests rather than passing silently.

**Two behaviours worth pinning down that the tests now cover:**
- a *failed* validation exits 0 — it is a result, not a tool error; only a fatal error exits 1
- `read_ipc_handles` de-duplicates handles, so the same handle appearing twice does not satisfy two expected pointer arguments, while `_read_ipc_records` deliberately does not

## What is deliberately not covered

89 statements remain, 82 of them in two modules:

- **`communication.py` (53)** — `get_kern_arg_data` copies device memory through `ctypes` against live IPC handles
- **`validator.py` (29)** — orchestration of instrumented subprocesses

Both are exercised by the existing `test_reduction_validation.py` on real hardware. Stubbing the GPU out of them would leave tests that only assert the behaviour of the stub, so they are left alone. That is what holds the total at 88% rather than 90%.

## Test plan

MI355X (`lux-mi355x-a9`), ROCm 7.2.2, in-container with `cmake`/`libdwarf-dev`/`libzstd-dev` so `kerneldb` builds. Baseline measured on unpatched `main` first:

```
before:  20 passed,  64%   (757 stmts, 270 missed)
after:  181 passed,  88%   (757 stmts,  89 missed)
```

`ruff check` and `ruff format --check` clean.

> Note: `[self-hosted, mi3xx]` jobs will queue — that runner is offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)