### PR TITLE
Restore ROCm 7.2.x in the compatibility matrix

### DIFF
--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -6,7 +6,20 @@ Use the following matrix to view the compatibility and system requirements for I
 |-------------|-------------|-------|
 | Python| Metrix, Linex, Nexus, Accordo, Kerncap, ROCm MCP, uProf MCP | 3.10 or later. |
 | OS |  Metrix, Linex, Nexus, Accordo, Kerncap, ROCm MCP, uProf MCP | Ubuntu 22.04 and 24.04. |
-| ROCm  | Metrix, Linex, Nexus, Accordo, Kerncap, ROCm MCP | 10.0. Required for GPU profiling and kernel analysis. Not needed for host-only tools. |
+| ROCm  | Metrix, Linex, Nexus, Accordo, Kerncap, ROCm MCP | 7.2.x. Required for GPU profiling and kernel analysis. Not needed for host-only tools. See [ROCm 10](#rocm-10) below. |
 | GPU | Metrix, Linex, Nexus, Accordo, Kerncap, ROCm MCP | Both Instinct and Radeon GPUs are supported. Instinct MI300X, MI325X, and MI355X are recommended for full GPU functionality. |
 | uProf | uProf MCP only | AMD uProf on x86. |
 | cmake, libdwarf-dev, libzstd-dev | Accordo, Nexus | Required for C++ build via KernelDB. |
+
+## ROCm 10
+
+ROCm 10 is not yet supported. Use ROCm 7.2.x.
+
+ROCm 10 adds `hsa_amd_queue_create` and HIP creates its compute queue through
+it rather than through `hsa_queue_create`. Nexus and Accordo hook only the
+latter, so on ROCm 10 they attach successfully and then observe no dispatch
+packets at all: profiling returns no kernels, and reports no error while doing
+so. A fix is in progress.
+
+Metrix, Linex, Kerncap and ROCm MCP have not been tested on ROCm 10 and are
+neither known to work nor known to be broken there.


### PR DESCRIPTION
#163 replaced `7.2.x` with `10.0` in the ROCm row rather than adding it. That leaves the shipped matrix — now also on `release/v0.1.1` — telling users to move to a configuration where profiling silently returns nothing.

### What is wrong today

| Matrix says | Reality |
|---|---|
| ROCm 10 required for Nexus, Accordo | Both capture **zero kernels** on ROCm 10 |
| 7.2.x no longer listed | 7.2.x is the only working config, and what CI runs |
| Metrix, Linex, Kerncap, ROCm MCP on ROCm 10 | None of the four has been tested there |
| `10.0` | All validation has been against the `10.1.0a` nightly |

### Why the two profilers break

ROCm 10 adds `hsa_amd_queue_create` and HIP moved its compute queue onto it. Nexus and Accordo hook only `core_->hsa_queue_create_fn`, so the hook is installed correctly and then never entered. Measured on MI355X (gfx950), fresh clone per row:

```
tree                      ROCm 7      ROCm 10
main                          -     accordo 12 failed / 8 passed
                                    nexus    5 failed / 1 passed
muhaawad/accordo-rocm10  20 passed   20 passed
muhaawad/nexus-rocm10     6 passed    6 passed
```

Nothing was removed upstream — `hsa_queue_create` still exists and still works. It is simply no longer the entry point HIP uses.

### Scope of this PR

Docs only. It restores `7.2.x` and adds a short section saying plainly what is and is not known about ROCm 10, rather than a bare version number that will be read as a support claim.

The code fixes are on `muhaawad/accordo-rocm10` and `muhaawad/nexus-rocm10`, neither merged. When they land, the matrix should be updated to state ROCm 10 support with the hardware and version it was validated on.