### PR TITLE
Pin the token to read-only in the pytest workflow

### DIFF
--- a/.github/workflows/intellikit-pytest.yml
+++ b/.github/workflows/intellikit-pytest.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The two GPU workflows disagree about what they hand their jobs:

| workflow | `permissions:` | effective token |
|---|---|---|
| `intellikit-ci-test.yml` | `contents: read` | read-only |
| `intellikit-pytest.yml` | *none* | repo default — **write** |

They do the same kind of work, so this makes `intellikit-pytest.yml` match.

### Why it is safe

`intellikit-pytest.yml` checks out the repo and builds an Apptainer image locally. No `docker/login`, no registry, no `secrets.*`, no `upload-artifact` — nothing that writes back to GitHub. The `packages:` line is a **job output name**, not a permission. And `intellikit-ci-test.yml` already runs the same `container_build.sh` under `contents: read`, so the configuration is proven by its sibling rather than by argument.

### What it does not do

It does not change fork-PR behaviour. GitHub already forces a read-only token and withholds secrets for `pull_request` from a fork, regardless of `default_workflow_permissions`. This closes the gap for **pushes and same-repo pull requests**, where the repository default does apply.

Found while reviewing the self-hosted runner exposure. Worth having independently of that.