### PR TITLE
Let CI build and run its container with Docker as well as Apptainer

### DIFF
--- a/.github/scripts/container_build.sh
+++ b/.github/scripts/container_build.sh
@@ -7,6 +7,15 @@
 
 set -e
 
+# Apptainer being installed does not mean it can build. Building runs %post as
+# root inside a user namespace: a setuid starter does that directly, otherwise
+# it needs a uid mapping, which AppArmor can refuse even when the userns
+# sysctls read permissive. Probe the operation rather than the binary.
+apptainer_can_build() {
+    [ -u /usr/libexec/apptainer/bin/starter-suid ] && return 0
+    unshare --user --map-root-user true 2>/dev/null
+}
+
 # CONTAINER_RUNTIME forces a runtime. This matters when apptainer is installed
 # but cannot build: on a host with kernel.apparmor_restrict_unprivileged_userns=1,
 # no setuid starter and no /etc/subuid entry, `apptainer build` fails in %post
@@ -17,12 +26,20 @@ if [ -n "$CONTAINER_RUNTIME" ]; then
         exit 1
     fi
     echo "[INFO] Using $CONTAINER_RUNTIME (forced via CONTAINER_RUNTIME)"
-elif command -v apptainer &> /dev/null; then
+elif command -v apptainer &> /dev/null && apptainer_can_build; then
     CONTAINER_RUNTIME="apptainer"
     echo "[INFO] Using Apptainer"
 elif command -v docker &> /dev/null; then
     CONTAINER_RUNTIME="docker"
-    echo "[INFO] Using Docker"
+    if command -v apptainer &> /dev/null; then
+        echo "[INFO] Using Docker (Apptainer is installed but cannot build:" \
+             "no setuid starter and no usable user namespace)"
+    else
+        echo "[INFO] Using Docker"
+    fi
+elif command -v apptainer &> /dev/null; then
+    CONTAINER_RUNTIME="apptainer"
+    echo "[WARN] Using Apptainer, which cannot build on this host, and Docker is absent"
 else
     echo "[ERROR] Neither Apptainer nor Docker is available"
     exit 1

--- a/.github/scripts/container_build.sh
+++ b/.github/scripts/container_build.sh
@@ -1,34 +1,69 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Build the IntelliKit dev container with whichever runtime is available.
+# Mirrors the dual-runtime selection iris uses in the same script.
 
 set -e
 
-# Check if Apptainer is available
-if ! command -v apptainer &> /dev/null; then
-    echo "[ERROR] Apptainer not found. Please install Apptainer to continue"
+# CONTAINER_RUNTIME forces a runtime. This matters when apptainer is installed
+# but cannot build: on a host with kernel.apparmor_restrict_unprivileged_userns=1,
+# no setuid starter and no /etc/subuid entry, `apptainer build` fails in %post
+# while docker works. Autodetection alone would pick apptainer and fail there.
+if [ -n "$CONTAINER_RUNTIME" ]; then
+    if ! command -v "$CONTAINER_RUNTIME" &> /dev/null; then
+        echo "[ERROR] CONTAINER_RUNTIME=$CONTAINER_RUNTIME but it is not installed"
+        exit 1
+    fi
+    echo "[INFO] Using $CONTAINER_RUNTIME (forced via CONTAINER_RUNTIME)"
+elif command -v apptainer &> /dev/null; then
+    CONTAINER_RUNTIME="apptainer"
+    echo "[INFO] Using Apptainer"
+elif command -v docker &> /dev/null; then
+    CONTAINER_RUNTIME="docker"
+    echo "[INFO] Using Docker"
+else
+    echo "[ERROR] Neither Apptainer nor Docker is available"
     exit 1
 fi
 
-# Paths
-DEF_FILE="apptainer/intellikit.def"
-IMAGE_FILE=~/apptainer/intellikit-dev.sif
-HASH_FILE=~/apptainer/intellikit.def.sha256
+if [ "$CONTAINER_RUNTIME" = "apptainer" ]; then
+    DEF_FILE="apptainer/intellikit.def"
+    IMAGE_FILE=~/apptainer/intellikit-dev.sif
+    HASH_FILE=~/apptainer/intellikit.def.sha256
 
-# Create directory
-mkdir -p ~/apptainer
+    mkdir -p ~/apptainer
+    CURRENT_HASH=$(sha256sum "$DEF_FILE" | awk '{print $1}')
 
-# Calculate current hash
-CURRENT_HASH=$(sha256sum "$DEF_FILE" | awk '{print $1}')
+    if [ -f "$IMAGE_FILE" ] && [ -f "$HASH_FILE" ] && [ "$CURRENT_HASH" = "$(cat "$HASH_FILE")" ]; then
+        echo "[INFO] Definition unchanged (hash: $CURRENT_HASH), using cached image"
+        exit 0
+    fi
 
-# Check if rebuild is needed
-if [ -f "$IMAGE_FILE" ] && [ -f "$HASH_FILE" ] && [ "$CURRENT_HASH" = "$(cat "$HASH_FILE")" ]; then
-    echo "[INFO] Definition unchanged (hash: $CURRENT_HASH), using cached image"
-    exit 0
+    echo "[INFO] Building Apptainer image..."
+    apptainer build --force "$IMAGE_FILE" "$DEF_FILE"
+    echo "$CURRENT_HASH" > "$HASH_FILE"
+    echo "[INFO] Build completed (hash: $CURRENT_HASH)"
+
+elif [ "$CONTAINER_RUNTIME" = "docker" ]; then
+    IMAGE_NAME=${DOCKER_IMAGE_NAME:-"intellikit-dev"}
+    DOCKER_DIR="$(dirname "$(realpath "$0")")/../../docker"
+
+    # Rebuild when the Dockerfile changes, mirroring the def-hash check above.
+    CURRENT_HASH=$(sha256sum "$DOCKER_DIR/Dockerfile" | awk '{print $1}')
+    HASH_FILE=~/.intellikit-docker-image.sha256
+
+    if docker image inspect "$IMAGE_NAME" &> /dev/null \
+       && [ -f "$HASH_FILE" ] && [ "$CURRENT_HASH" = "$(cat "$HASH_FILE")" ]; then
+        echo "[INFO] Dockerfile unchanged (hash: $CURRENT_HASH), using existing image: $IMAGE_NAME"
+        exit 0
+    fi
+
+    echo "[INFO] Building Docker image: $IMAGE_NAME"
+    docker build -t "$IMAGE_NAME" "$DOCKER_DIR"
+    echo "$CURRENT_HASH" > "$HASH_FILE"
+    echo "[INFO] Build completed (hash: $CURRENT_HASH)"
 fi
 
-# Rebuild
-echo "[INFO] Building Apptainer image..."
-apptainer build --force "$IMAGE_FILE" "$DEF_FILE"
-echo "$CURRENT_HASH" > "$HASH_FILE"
-echo "[INFO] Build completed (hash: $CURRENT_HASH)"
+echo "[INFO] Container build completed successfully with $CONTAINER_RUNTIME"

--- a/.github/scripts/container_exec.sh
+++ b/.github/scripts/container_exec.sh
@@ -97,11 +97,18 @@ elif [ "$CONTAINER_RUNTIME" = "docker" ]; then
     # to delete those files when it checks out again, so hand them back before
     # exiting -- including when the command failed. Apptainer does not need
     # this: it runs as the invoking user.
-    OWNER="$(id -u):$(id -g)"
     EXIT_CODE=0
-    $RUN_CMD "$IMAGE_NAME" -c \
-        "rc=0; { set -e; $COMMAND; } || rc=\$?; \
-         chown -R ${OWNER} /intellikit_workspace 2>/dev/null || true; \
-         exit \$rc" || EXIT_CODE=$?
+    $RUN_CMD "$IMAGE_NAME" -c "set -e; $COMMAND" || EXIT_CODE=$?
+
+    # The container runs as root, so anything it wrote into the bind-mounted
+    # workspace is root-owned, and actions/checkout -- running as an ordinary
+    # user -- cannot delete it on the next job. Hand ownership back in a
+    # separate invocation: wrapping the command instead would splice shell
+    # syntax into a caller-supplied, possibly multi-line, command string.
+    # Runs after failures too, since a failed job still leaves artifacts.
+    docker run --rm -v "${PWD}:/intellikit_workspace" \
+        --entrypoint chown "$IMAGE_NAME" \
+        -R "$(id -u):$(id -g)" /intellikit_workspace 2>/dev/null || true
+
     exit $EXIT_CODE
 fi

--- a/.github/scripts/container_exec.sh
+++ b/.github/scripts/container_exec.sh
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
-# Simple Apptainer container exec script
+# Execute a command inside the IntelliKit dev container, using whichever
+# runtime is available. Mirrors the dual-runtime selection iris uses.
+#
 # Usage: container_exec.sh <command>
 
 set -e
 
-# Command is all arguments
 COMMAND="$@"
 if [ -z "$COMMAND" ]; then
     echo "[ERROR] No command provided" >&2
@@ -15,35 +16,66 @@ if [ -z "$COMMAND" ]; then
     exit 1
 fi
 
-# Check if Apptainer is available
-if ! command -v apptainer &> /dev/null; then
-    echo "[ERROR] Apptainer not found" >&2
+# See container_build.sh for why an explicit override exists.
+if [ -n "$CONTAINER_RUNTIME" ]; then
+    if ! command -v "$CONTAINER_RUNTIME" &> /dev/null; then
+        echo "[ERROR] CONTAINER_RUNTIME=$CONTAINER_RUNTIME but it is not installed" >&2
+        exit 1
+    fi
+    echo "[INFO] Using $CONTAINER_RUNTIME (forced via CONTAINER_RUNTIME)"
+elif command -v apptainer &> /dev/null; then
+    CONTAINER_RUNTIME="apptainer"
+    echo "[INFO] Using Apptainer"
+elif command -v docker &> /dev/null; then
+    CONTAINER_RUNTIME="docker"
+    echo "[INFO] Using Docker"
+else
+    echo "[ERROR] Neither Apptainer nor Docker is available" >&2
     exit 1
 fi
 
-# Use fixed image path
-IMAGE=~/apptainer/intellikit-dev.sif
-if [ ! -f "$IMAGE" ]; then
-    echo "[ERROR] Apptainer image not found at $IMAGE" >&2
-    exit 1
+if [ "$CONTAINER_RUNTIME" = "apptainer" ]; then
+    IMAGE=~/apptainer/intellikit-dev.sif
+    if [ ! -f "$IMAGE" ]; then
+        echo "[ERROR] Apptainer image not found at $IMAGE" >&2
+        exit 1
+    fi
+
+    # Temporary overlay in the workspace (auto-cleaned below)
+    OVERLAY="./intellikit_overlay_$$_$(date +%s%N).img"
+    if ! apptainer overlay create --size 16384 --create-dir /var/cache/intellikit "${OVERLAY}" > /dev/null 2>&1; then
+        echo "[ERROR] Failed to create Apptainer overlay" >&2
+        exit 1
+    fi
+
+    EXEC_CMD="apptainer exec --overlay ${OVERLAY} --no-home --cleanenv"
+    EXEC_CMD="$EXEC_CMD --bind ${PWD}:/intellikit_workspace --cwd /intellikit_workspace"
+
+    EXIT_CODE=0
+    $EXEC_CMD "$IMAGE" bash -c "set -e; $COMMAND" || EXIT_CODE=$?
+
+    rm -f "${OVERLAY}" 2>/dev/null || true
+    exit $EXIT_CODE
+
+elif [ "$CONTAINER_RUNTIME" = "docker" ]; then
+    IMAGE_NAME=${DOCKER_IMAGE_NAME:-"intellikit-dev"}
+    if ! docker image inspect "$IMAGE_NAME" &> /dev/null; then
+        echo "[ERROR] Docker image $IMAGE_NAME not found; run container_build.sh first" >&2
+        exit 1
+    fi
+
+    # --device/--group-add give the container the GPUs; SYS_PTRACE and an
+    # unconfined seccomp profile are required by the profiling tools, which
+    # attach to and trace the processes they launch.
+    RUN_CMD="docker run --rm --network=host --device=/dev/kfd --device=/dev/dri"
+    RUN_CMD="$RUN_CMD --group-add video --group-add render"
+    RUN_CMD="$RUN_CMD --cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
+    RUN_CMD="$RUN_CMD --shm-size=16G --ulimit memlock=-1 --ulimit stack=67108864"
+    RUN_CMD="$RUN_CMD -v ${PWD}:/intellikit_workspace -w /intellikit_workspace"
+    RUN_CMD="$RUN_CMD -e HOME=/intellikit_workspace"
+    RUN_CMD="$RUN_CMD --entrypoint bash"
+
+    EXIT_CODE=0
+    $RUN_CMD "$IMAGE_NAME" -c "set -e; $COMMAND" || EXIT_CODE=$?
+    exit $EXIT_CODE
 fi
-
-# Create temporary overlay in workspace (auto-cleaned when runner is removed)
-OVERLAY="./intellikit_overlay_$$_$(date +%s%N).img"
-if ! apptainer overlay create --size 16384 --create-dir /var/cache/intellikit "${OVERLAY}" > /dev/null 2>&1; then
-    echo "[ERROR] Failed to create Apptainer overlay"
-    exit 1
-fi
-
-# Build exec command
-EXEC_CMD="apptainer exec --overlay ${OVERLAY} --no-home --cleanenv"
-EXEC_CMD="$EXEC_CMD --bind ${PWD}:/intellikit_workspace --cwd /intellikit_workspace"
-
-# Execute with cleanup of overlay file
-EXIT_CODE=0
-$EXEC_CMD "$IMAGE" bash -c "set -e; $COMMAND" || EXIT_CODE=$?
-
-# Clean up overlay file (always cleanup, even on failure)
-rm -f "${OVERLAY}" 2>/dev/null || true
-
-exit $EXIT_CODE

--- a/.github/scripts/container_exec.sh
+++ b/.github/scripts/container_exec.sh
@@ -16,6 +16,15 @@ if [ -z "$COMMAND" ]; then
     exit 1
 fi
 
+# Apptainer being installed does not mean it can build. Building runs %post as
+# root inside a user namespace: a setuid starter does that directly, otherwise
+# it needs a uid mapping, which AppArmor can refuse even when the userns
+# sysctls read permissive. Probe the operation rather than the binary.
+apptainer_can_build() {
+    [ -u /usr/libexec/apptainer/bin/starter-suid ] && return 0
+    unshare --user --map-root-user true 2>/dev/null
+}
+
 # See container_build.sh for why an explicit override exists.
 if [ -n "$CONTAINER_RUNTIME" ]; then
     if ! command -v "$CONTAINER_RUNTIME" &> /dev/null; then
@@ -23,12 +32,20 @@ if [ -n "$CONTAINER_RUNTIME" ]; then
         exit 1
     fi
     echo "[INFO] Using $CONTAINER_RUNTIME (forced via CONTAINER_RUNTIME)"
-elif command -v apptainer &> /dev/null; then
+elif command -v apptainer &> /dev/null && apptainer_can_build; then
     CONTAINER_RUNTIME="apptainer"
     echo "[INFO] Using Apptainer"
 elif command -v docker &> /dev/null; then
     CONTAINER_RUNTIME="docker"
-    echo "[INFO] Using Docker"
+    if command -v apptainer &> /dev/null; then
+        echo "[INFO] Using Docker (Apptainer is installed but cannot build:" \
+             "no setuid starter and no usable user namespace)"
+    else
+        echo "[INFO] Using Docker"
+    fi
+elif command -v apptainer &> /dev/null; then
+    CONTAINER_RUNTIME="apptainer"
+    echo "[WARN] Using Apptainer, which cannot build on this host, and Docker is absent"
 else
     echo "[ERROR] Neither Apptainer nor Docker is available" >&2
     exit 1

--- a/.github/scripts/container_exec.sh
+++ b/.github/scripts/container_exec.sh
@@ -92,7 +92,16 @@ elif [ "$CONTAINER_RUNTIME" = "docker" ]; then
     RUN_CMD="$RUN_CMD -e HOME=/intellikit_workspace"
     RUN_CMD="$RUN_CMD --entrypoint bash"
 
+    # The container runs as root, so anything it writes into the bind-mounted
+    # workspace is root-owned. The runner is an ordinary user and must be able
+    # to delete those files when it checks out again, so hand them back before
+    # exiting -- including when the command failed. Apptainer does not need
+    # this: it runs as the invoking user.
+    OWNER="$(id -u):$(id -g)"
     EXIT_CODE=0
-    $RUN_CMD "$IMAGE_NAME" -c "set -e; $COMMAND" || EXIT_CODE=$?
+    $RUN_CMD "$IMAGE_NAME" -c \
+        "rc=0; { set -e; $COMMAND; } || rc=\$?; \
+         chown -R ${OWNER} /intellikit_workspace 2>/dev/null || true; \
+         exit \$rc" || EXIT_CODE=$?
     exit $EXIT_CODE
 fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,40 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Kept in step with apptainer/intellikit.def -- CI may run under either runtime,
+# so the two must describe the same environment. Change both together.
 
 FROM rocm/pytorch:rocm7.1_ubuntu24.04_py3.13_pytorch_release_2.9.1
 
-# Use bash shell for RUN commands
 SHELL ["/bin/bash", "-c"]
 
-# Set environment variables
+ENV TRITON_PATH=/opt/triton
 ENV ROCM_PATH=/opt/rocm
-
 ENV LD_LIBRARY_PATH=$ROCM_PATH/lib:$LD_LIBRARY_PATH \
     PATH="$ROCM_PATH/bin:$PATH"
+ENV PYTHONPATH=$TRITON_PATH
 
 # Install system packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    git wget ninja-build cmake python3-pip python3-dev build-essential libdwarf-dev libzstd-dev && \
+    git wget ninja-build cmake python3-pip python3-dev build-essential jq \
+    libhwloc-dev libhwloc15 hwloc-nox libnuma-dev libdwarf-dev libzstd-dev && \
     rm -rf /var/lib/apt/lists/*
 
+# Create groups if they don't exist
 RUN groupadd -r video 2>/dev/null || true && \
     groupadd -r render 2>/dev/null || true
+
+# Install Python packages with pip
+RUN pip3 install --upgrade pip && \
+    pip3 install wheel jupyter pytest
+
+# Clone and install Triton
+RUN cd /opt && \
+    git clone https://github.com/triton-lang/triton.git $TRITON_PATH && \
+    cd $TRITON_PATH && \
+    git checkout 715f6b1d442601436bf8d462db6ff8e17aec8cfb && \
+    pip3 install -e .
 
 # Set up workspace
 WORKDIR /workspace


### PR DESCRIPTION
`container_build.sh` and `container_exec.sh` required Apptainer and exited 1 without it, so a runner that has Docker and not Apptainer cannot run CI at all. iris selects a runtime in these same two scripts; this ports that over. The repo already ships `docker/Dockerfile` — nothing was using it from CI.

Selection probes whether Apptainer can actually build rather than whether it is installed, since an Apptainer without a setuid starter or a usable user namespace fails in `%post`. `CONTAINER_RUNTIME` forces a runtime when needed.

`docker/Dockerfile` was not equivalent to `apptainer/intellikit.def` — it was missing `jq`, hwloc, libnuma, the pip installs, and Triton. CI under Docker would have tested a weaker environment while reporting the same green tick. It now mirrors the def, including the pinned Triton commit.

Both paths cache on a file hash, so an unchanged Dockerfile or def does not rebuild.

Keeping the two files in step is currently enforced by a comment. A CI step that diffs the package list and Triton pin would make that a check.