### PR TITLE
Pin CI to Docker and stop trying to install Apptainer

### DIFF
--- a/.github/scripts/container_build.sh
+++ b/.github/scripts/container_build.sh
@@ -20,6 +20,12 @@ apptainer_can_build() {
 # but cannot build: on a host with kernel.apparmor_restrict_unprivileged_userns=1,
 # no setuid starter and no /etc/subuid entry, `apptainer build` fails in %post
 # while docker works. Autodetection alone would pick apptainer and fail there.
+# Apptainer is disabled for now: the CI hosts either cannot build with it
+# (no setuid starter, no usable user namespace) or do not have it at all,
+# and the runner has no root to install it. Remove this line to restore
+# autodetection.
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+
 if [ -n "$CONTAINER_RUNTIME" ]; then
     if ! command -v "$CONTAINER_RUNTIME" &> /dev/null; then
         echo "[ERROR] CONTAINER_RUNTIME=$CONTAINER_RUNTIME but it is not installed"

--- a/.github/scripts/container_exec.sh
+++ b/.github/scripts/container_exec.sh
@@ -26,6 +26,12 @@ apptainer_can_build() {
 }
 
 # See container_build.sh for why an explicit override exists.
+# Apptainer is disabled for now: the CI hosts either cannot build with it
+# (no setuid starter, no usable user namespace) or do not have it at all,
+# and the runner has no root to install it. Remove this line to restore
+# autodetection.
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+
 if [ -n "$CONTAINER_RUNTIME" ]; then
     if ! command -v "$CONTAINER_RUNTIME" &> /dev/null; then
         echo "[ERROR] CONTAINER_RUNTIME=$CONTAINER_RUNTIME but it is not installed" >&2

--- a/.github/workflows/intellikit-ci-test.yml
+++ b/.github/workflows/intellikit-ci-test.yml
@@ -73,17 +73,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Apptainer (if not available)
-        run: |
-          if ! command -v apptainer &> /dev/null; then
-            echo "Apptainer not found, installing..."
-            apt-get update && apt-get install -y software-properties-common
-            add-apt-repository -y ppa:apptainer/ppa
-            apt-get update && apt-get install -y apptainer
-          else
-            echo "Apptainer already available"
-          fi
-
       - name: Build Intellikit container
         run: |
           bash .github/scripts/container_build.sh

--- a/.github/workflows/intellikit-pytest.yml
+++ b/.github/workflows/intellikit-pytest.yml
@@ -73,17 +73,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Apptainer (if not available)
-        run: |
-          if ! command -v apptainer &> /dev/null; then
-            echo "Apptainer not found, installing..."
-            apt-get update && apt-get install -y software-properties-common
-            add-apt-repository -y ppa:apptainer/ppa
-            apt-get update && apt-get install -y apptainer
-          else
-            echo "Apptainer already available"
-          fi
-
       - name: Build Intellikit container
         run: |
           bash .github/scripts/container_build.sh


### PR DESCRIPTION
The pytest and ci-test workflows tried to `apt-get install apptainer` whenever it was missing. The runner is not root, so on a host without apptainer this fails before any test runs:

```
E: Could not open lock file /var/lib/apt/lists/lock (13: Permission denied)
Error: must run as root
```

Making the container scripts runtime-agnostic in #166 was not enough by itself — the workflow still assumed apptainer had to exist and would install it if it did not. That step is removed; runtime selection belongs in the scripts.

`CONTAINER_RUNTIME` now defaults to `docker` instead of autodetecting. Every CI host today either cannot build with apptainer or does not have it at all, and none can install it. Deleting the default line restores autodetection.