### PR TITLE
Hook hsa_amd_queue_create so kerncap captures on ROCm 10

### DIFF
--- a/kerncap/src/CMakeLists.txt
+++ b/kerncap/src/CMakeLists.txt
@@ -33,6 +33,52 @@ target_link_libraries(kerncap PRIVATE
 
 target_compile_definitions(kerncap PRIVATE AMD_INTERNAL_BUILD)
 
+#
+# ROCm 10 added hsa_amd_queue_create and HIP creates its compute queue through
+# it. The slot is absent from earlier headers, so probe for the AmdExtTable
+# member we actually write rather than keying off a ROCm version.
+#
+# Two probes, not one. Asking only "does the member exist" answers no both when
+# the header lacks it and when the header could not be included at all, and the
+# second is a broken configuration wearing the first one's clothes.
+#
+include(CheckCXXSourceCompiles)
+get_target_property(_kerncap_hsa_inc hsa-runtime64::hsa-runtime64
+                    INTERFACE_INCLUDE_DIRECTORIES)
+set(CMAKE_REQUIRED_INCLUDES ${_kerncap_hsa_inc})
+set(CMAKE_REQUIRED_DEFINITIONS -DAMD_INTERNAL_BUILD)
+
+check_cxx_source_compiles("
+#include <hsa/hsa_api_trace.h>
+int main() { AmdExtTable t{}; (void)t; return 0; }
+" KERNCAP_HSA_API_TRACE_USABLE)
+
+if(NOT KERNCAP_HSA_API_TRACE_USABLE)
+    message(FATAL_ERROR
+        "kerncap: cannot compile against <hsa/hsa_api_trace.h> from "
+        "'${_kerncap_hsa_inc}'. Queue interception cannot be configured. "
+        "Set ROCM_PATH to the ROCm tree you intend to build against.")
+endif()
+
+check_cxx_source_compiles("
+#include <hsa/hsa_api_trace.h>
+int main() {
+  AmdExtTable t{};
+  return t.hsa_amd_queue_create_fn == nullptr ? 0 : 1;
+}
+" KERNCAP_HAVE_HSA_AMD_QUEUE_CREATE)
+
+unset(CMAKE_REQUIRED_INCLUDES)
+unset(CMAKE_REQUIRED_DEFINITIONS)
+unset(_kerncap_hsa_inc)
+
+if(KERNCAP_HAVE_HSA_AMD_QUEUE_CREATE)
+    target_compile_definitions(kerncap PRIVATE KERNCAP_HAVE_HSA_AMD_QUEUE_CREATE)
+    message(STATUS "kerncap: hooking hsa_amd_queue_create (ROCm 10+ compute queue path)")
+else()
+    message(STATUS "kerncap: hsa_amd_queue_create absent, hooking hsa_queue_create only")
+endif()
+
 target_compile_options(kerncap PRIVATE
     -Wall -Wextra
     $<$<CONFIG:Debug>:-O0 -ggdb>

--- a/kerncap/src/kerncap.hip
+++ b/kerncap/src/kerncap.hip
@@ -325,6 +325,12 @@ void CaptureState::hook_api() {
         CaptureState::hsa_queue_create;
     api_table_->core_->hsa_queue_destroy_fn =
         CaptureState::hsa_queue_destroy;
+#ifdef KERNCAP_HAVE_HSA_AMD_QUEUE_CREATE
+    // ROCm 10 moved HIP's compute queue onto hsa_amd_queue_create. Without this
+    // the hook above is never entered and no dispatch packet is ever seen.
+    api_table_->amd_ext_->hsa_amd_queue_create_fn =
+        CaptureState::hsa_amd_queue_create;
+#endif
     api_table_->amd_ext_->hsa_amd_memory_pool_allocate_fn =
         CaptureState::hsa_amd_memory_pool_allocate;
     api_table_->amd_ext_->hsa_amd_memory_pool_free_fn =
@@ -646,29 +652,30 @@ hsa_status_t CaptureState::hsa_amd_vmem_unmap(
 // ---------------------------------------------------------------------------
 // Queue interception
 // ---------------------------------------------------------------------------
+bool CaptureState::should_intercept_queue(CaptureState* inst, const char* api_name) {
+    if (!inst->is_active_process()) {
+        KERNCAP_INFO("Passive mode (pid=%d): passing through %s", getpid(), api_name);
+        return false;
+    }
+    if (inst->intercept_first_queue_only_) {
+        std::shared_lock g(mutex_);
+        if (!inst->queue_agents_.empty()) {
+            KERNCAP_INFO("First-queue-only mode (pid=%d): passing through %s",
+                         getpid(), api_name);
+            return false;
+        }
+    }
+    return true;
+}
+
 hsa_status_t CaptureState::hsa_queue_create(
         hsa_agent_t agent, uint32_t size, hsa_queue_type32_t type,
         void (*callback)(hsa_status_t, hsa_queue_t*, void*),
         void* data, uint32_t private_segment_size,
         uint32_t group_segment_size, hsa_queue_t** queue) {
     auto* inst = get_instance();
-    bool intercept_queue = true;
 
-    if (!inst->is_active_process()) {
-        KERNCAP_INFO("Passive mode (pid=%d): passing through hsa_queue_create",
-                     getpid());
-        return hsa_core_call(inst, hsa_queue_create, agent, size, type,
-                             callback, data, private_segment_size,
-                             group_segment_size, queue);
-    }
-
-    if (inst->intercept_first_queue_only_) {
-        std::shared_lock g(mutex_);
-        intercept_queue = inst->queue_agents_.empty();
-    }
-    if (!intercept_queue) {
-        KERNCAP_INFO("First-queue-only mode (pid=%d): passing through hsa_queue_create",
-                     getpid());
+    if (!should_intercept_queue(inst, "hsa_queue_create")) {
         return hsa_core_call(inst, hsa_queue_create, agent, size, type,
                              callback, data, private_segment_size,
                              group_segment_size, queue);
@@ -677,6 +684,17 @@ hsa_status_t CaptureState::hsa_queue_create(
     KERNCAP_INFO("Active mode (pid=%d): intercepting hsa_queue_create "
                  "(size=%u, type=%u)", getpid(), size, type);
 
+    return intercept_and_register(inst, agent, size, type, callback, data,
+                                  private_segment_size, group_segment_size,
+                                  queue);
+}
+
+hsa_status_t CaptureState::intercept_and_register(
+        CaptureState* inst, hsa_agent_t agent, uint32_t size,
+        hsa_queue_type32_t type,
+        void (*callback)(hsa_status_t, hsa_queue_t*, void*),
+        void* data, uint32_t private_segment_size,
+        uint32_t group_segment_size, hsa_queue_t** queue) {
     auto result = hsa_ext_call(inst, hsa_amd_queue_intercept_create,
                                agent, size, type, callback, data,
                                private_segment_size, group_segment_size, queue);
@@ -700,6 +718,70 @@ hsa_status_t CaptureState::hsa_queue_create(
     }
     return result;
 }
+
+#ifdef KERNCAP_HAVE_HSA_AMD_QUEUE_CREATE
+hsa_status_t CaptureState::hsa_amd_queue_create(
+        hsa_agent_t agent, hsa_amd_queue_create_desc_t* descs,
+        uint32_t num_descs) {
+    auto* inst = get_instance();
+
+    // The runtime does not stop at the first failure: queues that succeed stay
+    // valid, a failed descriptor is left with a NULL queue, and the caller gets
+    // the first error. Returning early would abandon descriptors the runtime
+    // would have created.
+    hsa_status_t first_error = HSA_STATUS_SUCCESS;
+    auto record = [&first_error](hsa_status_t status) {
+        if (status != HSA_STATUS_SUCCESS && first_error == HSA_STATUS_SUCCESS) {
+            first_error = status;
+        }
+    };
+
+    for (uint32_t i = 0; i < num_descs; ++i) {
+        hsa_amd_queue_create_desc_t* desc = &descs[i];
+
+        // Only compute queues carry AQL dispatch packets. SDMA and AIE go to
+        // the runtime untouched; AIE is not implemented by the runtime yet.
+        const bool compute = desc->engine_type == HSA_AMD_QUEUE_ENGINE_COMPUTE;
+
+        // queue_size_bytes must be a power of two and a multiple of the 64-byte
+        // AQL packet. Dividing an illegal size down to a packet count would
+        // launder it into a legal one, so those go to the runtime for the real
+        // error rather than silently succeeding here.
+        constexpr uint32_t kPacketSize =
+            static_cast<uint32_t>(sizeof(hsa_kernel_dispatch_packet_t));
+        const uint32_t bytes = desc->queue_size_bytes;
+        const bool valid_size = bytes != 0 && (bytes & (bytes - 1)) == 0 &&
+                                bytes % kPacketSize == 0;
+
+        if (!compute || !valid_size ||
+            !should_intercept_queue(inst, "hsa_amd_queue_create")) {
+            record(hsa_ext_call(inst, hsa_amd_queue_create, agent, desc, 1));
+            continue;
+        }
+
+        KERNCAP_INFO("Active mode (pid=%d): intercepting hsa_amd_queue_create "
+                     "(bytes=%u, type=%u)", getpid(), bytes,
+                     desc->engine.compute.type);
+
+        hsa_queue_t* queue = nullptr;
+        const auto result = intercept_and_register(
+            inst, agent, bytes / kPacketSize, desc->engine.compute.type,
+            desc->callback, desc->callback_data,
+            desc->engine.compute.private_segment_size, 0, &queue);
+        if (result == HSA_STATUS_SUCCESS) {
+            desc->queue = queue;
+            continue;
+        }
+
+        // Capture is best-effort: fall back so the application still runs,
+        // uninstrumented. The runtime writes desc->queue itself.
+        KERNCAP_ERROR("Intercept queue create failed: %d, falling back",
+                      static_cast<int>(result));
+        record(hsa_ext_call(inst, hsa_amd_queue_create, agent, desc, 1));
+    }
+    return first_error;
+}
+#endif
 
 hsa_status_t CaptureState::hsa_queue_destroy(hsa_queue_t* queue) {
     auto* inst = get_instance();

--- a/kerncap/src/kerncap.hpp
+++ b/kerncap/src/kerncap.hpp
@@ -102,6 +102,29 @@ private:
         void* data, uint32_t private_segment_size,
         uint32_t group_segment_size, hsa_queue_t** queue);
 
+    // Shared by both queue-creation hooks. Returns false when kerncap should
+    // leave this queue alone -- passive process, or first-queue-only mode with
+    // a queue already taken. api_name only labels the log line.
+    static bool should_intercept_queue(CaptureState* inst, const char* api_name);
+
+    // Swaps the runtime's queue for an intercept queue and registers the
+    // packet callback on it.
+    static hsa_status_t intercept_and_register(
+        CaptureState* inst, hsa_agent_t agent, uint32_t size,
+        hsa_queue_type32_t type,
+        void (*callback)(hsa_status_t, hsa_queue_t*, void*),
+        void* data, uint32_t private_segment_size,
+        uint32_t group_segment_size, hsa_queue_t** queue);
+
+#ifdef KERNCAP_HAVE_HSA_AMD_QUEUE_CREATE
+    // ROCm 10 added this entry point and HIP creates its compute queue through
+    // it. hsa_queue_create is still exported and still used, so both slots stay
+    // hooked rather than one replacing the other.
+    static hsa_status_t hsa_amd_queue_create(
+        hsa_agent_t agent, hsa_amd_queue_create_desc_t* descs,
+        uint32_t num_descs);
+#endif
+
     static hsa_status_t hsa_queue_destroy(hsa_queue_t* queue);
 
     static hsa_status_t hsa_amd_memory_pool_allocate(


### PR DESCRIPTION
kerncap captures nothing on ROCm 10, silently. Same root cause already fixed in Accordo and Nexus.

ROCm 10 added `hsa_amd_queue_create` and HIP creates its compute queue through it. kerncap hooks only `core_->hsa_queue_create_fn` (`kerncap.hip:324`), so the hook is installed correctly and never entered — and `hsa_amd_queue_intercept_create` is called from *inside* it, so interception is unreachable by construction. The library loads, the app runs, capture returns nothing, no error.

### Measured on MI355X (gfx950)

Fresh build per row, `tests/integration/test_vector_add.py` (real interception on GPU):

| arm | ROCm | hook in `.so` | result |
|---|---|---|---|
| baseline | 7.2.2 | 0 | 4 passed |
| patched | 7.2.2 | 0 | 4 passed |
| baseline | **10.1.0a** | 0 | **2 failed**, 2 passed |
| patched | **10.1.0a** | 1 | **4 passed** |

The two failures are `test_capture` and `test_full_pipeline` — the tests that capture. ROCm 7 is unchanged, and the hook correctly compiles out there.

Note the unit tests are not evidence for this change: all 200 pass on every arm, because they test Python logic and this change is entirely C++.

### What the change does

- **Hooks both slots**, never swaps. `hsa_queue_create` is still exported and still used by ROCm ≤ 7.
- **Preserves kerncap's gating.** Passive processes and first-queue-only mode pass through untouched; that logic is now shared by both hooks instead of duplicated.
- **Compute only.** SDMA and AIE descriptors go to the runtime; AIE is not implemented by the runtime yet.
- **Does not launder invalid sizes.** `queue_size_bytes` must be a power of two and a multiple of the 64-byte AQL packet. Dividing an illegal size down to a packet count turns it into a legal one — 65537 becomes 1024 packets and succeeds where the runtime returns `HSA_STATUS_ERROR_INVALID_ARGUMENT`. Those are handed to the runtime instead.
- **Continues past a failed descriptor.** The API specifies that queues which succeed stay valid and the caller gets the first error; returning early would abandon descriptors the runtime would have created.

### Feature detection

Two CMake probes, not one. Asking only "does the member exist" answers no both when the header lacks it and when the header could not be included at all — the second is a broken configuration wearing the first one's clothes, and it is how a mixed-header build went unnoticed earlier. A header that cannot be included is now a configure-time error.

Companion to `muhaawad/accordo-rocm10` and `muhaawad/nexus-rocm10`.