### PR TITLE
Add 0.1.1 release notes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,15 @@
 
 This topic summarizes the features included in each IntelliKit release.
 
+## IntelliKit 0.1.1
+
+- **ROCm 10 support** — Nexus, Accordo and Kerncap now hook `hsa_amd_queue_create`, the entry point HIP creates its compute queue through on ROCm 10. Previously all three attached to the runtime successfully and then captured no kernels, reporting no error while doing so. ROCm 7.2.x is unaffected and continues to work.
+- **Side-by-side ROCm installs** — `ROCM_PATH` is now honoured when locating the HSA runtime. Previously the build always took headers from `/opt/rocm`, so building against another ROCm tree produced a mixed build that ran but could not see newer APIs.
+- **Container runtime** — CI builds and runs its container with Docker as well as Apptainer, and no longer requires Apptainer on the runner.
+- **Metrix and Linex** — verified on ROCm 10. Neither uses the queue interception path, so no changes were needed.
+
+Validated on MI355X (gfx950).
+
 ## IntelliKit 0.1.0
 
 First release of IntelliKit — agent-first tooling that makes GPU kernel profiling, inspection, and validation programmatically accessible to both developers and LLM agents.


### PR DESCRIPTION
Initial 0.1.1 notes, to unblock the docs team. Docs-only — `docs/**` is not in the CI paths filter, so the GPU jobs skip and this is mergeable without the runner.

Describes work that is still in flight across separate PRs, so this should land after them:

| area | branch / PR |
|---|---|
| ROCm 10 — Accordo | `muhaawad/accordo-rocm10` |
| ROCm 10 — Nexus | `muhaawad/nexus-rocm10` |
| ROCm 10 — Kerncap | #169 |
| Container runtime | #166, #167 |

Wording is scoped deliberately: ROCm 10 support is stated for the three tools that intercept HSA queues and were measured on MI355X (gfx950), with Metrix and Linex noted separately as verified rather than changed. That avoids a bare version number being read as a blanket claim, which is what #163 ran into.

Open for revision at EOD as the remaining PRs land.