### PR TITLE
Bump the docs version and stop hardcoding it in the metrix CLI

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-version_number = "0.1.0"
+version_number = "0.1.1"
 
 html_theme = "rocm_docs_theme"
 html_theme_options = {

--- a/metrix/src/metrix/cli/main.py
+++ b/metrix/src/metrix/cli/main.py
@@ -7,6 +7,7 @@ import sys
 import argparse
 from pathlib import Path
 
+from .. import __version__
 from ..metrics import METRIC_PROFILES, METRIC_CATALOG
 from ..metrics.catalog import list_all_metrics, list_all_profiles, get_metric_info
 from .profile_cmd import profile_command
@@ -40,7 +41,9 @@ Examples:
 """,
     )
 
-    parser.add_argument("--version", action="version", version="Metrix 0.1.0")
+    parser.add_argument(
+        "--version", action="version", version=f"Metrix {__version__}"
+    )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 


### PR DESCRIPTION
`docs/conf.py` drives the documentation site header and title and still said `0.1.0`.

While checking whether anything else was stale, `metrix --version` turned out to be a genuine bug rather than a stale string:

```python
parser.add_argument("--version", action="version", version="Metrix 0.1.0")
```

That is an unconditional literal, not a fallback — it prints `Metrix 0.1.0` regardless of the installed version, and would keep saying `0.1.0` through every future release. It now uses `__version__`, which `metrix/__init__.py` already resolves from package metadata.

### Deliberately not changed

| location | why |
|---|---|
| `fallback_version` in `*/pyproject.toml` | setuptools-scm fallback, only used without git metadata |
| `__version__ = "0.1.0"` in `*/__init__.py` | same — the `except PackageNotFoundError` branch |
| `project(... VERSION 0.1.0)` in CMake | build metadata, not user-visible |
| `docs/package-lock.json` | `is-extendable ^0.1.0`, an unrelated dependency |

Bumping the fallbacks would be cosmetic; they are only reached in a non-git checkout. Happy to include them if you would rather they track the release.