### PR TITLE
Drop the base image's dead ROCm apt repo before installing packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,13 @@ ENV LD_LIBRARY_PATH=$ROCM_PATH/lib:$LD_LIBRARY_PATH \
     PATH="$ROCM_PATH/bin:$PATH"
 ENV PYTHONPATH=$TRITON_PATH
 
-# Install system packages
-RUN apt-get update && \
+# Install system packages. The base image ships an AMD artifactory ROCm repo
+# in /etc/apt/sources.list.d/rocm.list whose path now 404s, which fails
+# apt-get update and makes the install exit 100. ROCm is already present in
+# the image; that repo is only needed to install ROCm packages, which this
+# file does not do.
+RUN rm -f /etc/apt/sources.list.d/rocm.list && \
+    apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     git wget ninja-build cmake python3-pip python3-dev build-essential jq \
     libhwloc-dev libhwloc15 hwloc-nox libnuma-dev libdwarf-dev libzstd-dev && \

--- a/metrix/src/metrix/cli/main.py
+++ b/metrix/src/metrix/cli/main.py
@@ -41,9 +41,7 @@ Examples:
 """,
     )
 
-    parser.add_argument(
-        "--version", action="version", version=f"Metrix {__version__}"
-    )
+    parser.add_argument("--version", action="version", version=f"Metrix {__version__}")
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 


### PR DESCRIPTION
A cold container build fails:

```
Err: http://compute-artifactory.amd.com/artifactory/list/rocm-osdb-24.04-deb compute-rocm-rel-7.1/20 amd64 Packages
E: Failed to fetch ... 404 Not Found
ERROR: process "/bin/bash -c apt-get update && ..." exit code: 100
```

`rocm/pytorch:rocm7.1_ubuntu24.04` ships `/etc/apt/sources.list.d/rocm.list` pointing at an artifactory path that no longer resolves. ROCm is already installed in the image and nothing installed here comes from that repo, so it is removed before `apt-get update`.

**Why #166 didn't catch it:** this only reproduces on a host with no layer cache. Where the layers are already cached apt never runs and the build looks fine — both hosts tested previously had a warm cache. Ubuntu's own archives are reachable from the failing host, so this is the base image, not the network.

Verified by rebuilding on a cold host: `apt-get` now completes and the build proceeds to the Triton step.