### PR TITLE
Add unit tests for the kerncap extraction internals

### DIFF
--- a/kerncap/kerncap/extract.py
+++ b/kerncap/kerncap/extract.py
@@ -400,7 +400,7 @@ def _generate_reproducer(
                 "loop will not.",
                 e,
             )
-            return _generate_hsaco(
+            result = _generate_hsaco(
                 kernel_name,
                 capture_dir,
                 output_dir,
@@ -409,6 +409,20 @@ def _generate_reproducer(
                 defines,
                 metadata,
             )
+            # ``ExtractResult.language`` says how to *use* the reproducer, not
+            # what the kernel was written in, and what came out of the fallback
+            # is an HSACO-only HIP harness with no ``reproducer.py``.  Label it
+            # for what was produced.
+            #
+            # Without this the label depends on how the language was determined
+            # rather than on what was generated: ``_generate_hsaco`` returns
+            # ``language or "hip"``, so an explicit ``--language triton`` came
+            # back as "triton" while the same capture auto-detected from
+            # metadata came back as "hip".  The "triton" case then made
+            # ``cli._print_next_steps`` tell the user to run
+            # ``python3 reproducer.py``, a file this path never writes.
+            result.language = "hip"
+            return result
 
     if effective_lang == "triton":
         return _generate_triton(

--- a/kerncap/tests/unit/test_extract_helpers.py
+++ b/kerncap/tests/unit/test_extract_helpers.py
@@ -1,0 +1,981 @@
+"""Unit tests for kerncap.extract's source-failure classifier and Triton pipeline.
+
+The classifier is what the user reads when extraction cannot find source, and
+its whole purpose is to distinguish user error (wrong ``--source-dir``, wrong
+``--language``) from a code object that has no source trail at all. Getting
+that wrong sends people hunting for a file that does not exist, so the three
+branches are pinned separately here.
+
+``llvm-dwarfdump`` / ``llvm-readelf`` are stubbed at their call sites, so no
+ROCm and no GPU are needed.
+"""
+
+import logging
+import os
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from kerncap.extract import (
+    _explain_source_not_found,
+    _generate_hsaco,
+    _generate_reproducer,
+    _generate_triton,
+    _generate_triton_from_hsa,
+    _hsaco_has_debug_section,
+    _llvm_dwarfdump_paths,
+    _triton_kernel_in_tree,
+    _TritonHsaReproducerUnavailable,
+)
+
+
+@pytest.fixture(autouse=True)
+def allow_log_propagation():
+    """caplog reads through the root logger, so propagation must be on.
+
+    ``cli._setup_logging`` sets ``propagate = False`` on the ``kerncap``
+    logger; this keeps these tests independent of whether a CLI test ran
+    first.
+    """
+    log = logging.getLogger("kerncap")
+    saved = log.propagate
+    log.propagate = True
+    yield
+    log.propagate = saved
+
+
+def dwarfdump_stub(stdout="", returncode=0, fail_with=None):
+    """Stand in for the dwarfdump/readelf subprocess, recording the tools tried."""
+    tried = []
+
+    def _run(argv, **_kwargs):
+        tried.append(argv[0])
+        if fail_with is not None:
+            raise fail_with
+        return subprocess.CompletedProcess(argv, returncode, stdout=stdout, stderr="")
+
+    _run.tried = tried
+    return _run
+
+
+def dwarf_output(*names):
+    """Render dwarfdump --debug-line output containing the given name entries."""
+    return "\n".join(f'  name: "{n}"' for n in names)
+
+
+@pytest.fixture
+def hsaco(tmp_path):
+    path = tmp_path / "kernel.hsaco"
+    path.write_bytes(b"\x7fELF")
+    return str(path)
+
+
+def kernel_source(**overrides):
+    """A stand-in for ``KernelSource`` carrying only what extract.py reads."""
+    fields = {
+        "main_file": "attn.py",
+        "language": "triton",
+        "source_files": [],
+        "translation_unit": None,
+        "compile_command": "hipcc -c attn.hip",
+    }
+    fields.update(overrides)
+    return type("FakeKernelSource", (), fields)()
+
+
+# --------------------------------------------------------------------------
+# _llvm_dwarfdump_paths
+# --------------------------------------------------------------------------
+
+
+class TestLlvmDwarfdumpPaths:
+    def test_returns_none_when_no_tool_can_run(self, hsaco):
+        """None means 'could not run', which is distinct from 'found nothing'."""
+        with patch("subprocess.run", dwarfdump_stub(fail_with=FileNotFoundError())):
+            assert _llvm_dwarfdump_paths(hsaco) is None
+
+    def test_returns_none_when_every_tool_exits_nonzero(self, hsaco):
+        with patch("subprocess.run", dwarfdump_stub(returncode=1)):
+            assert _llvm_dwarfdump_paths(hsaco) is None
+
+    def test_returns_empty_list_when_there_is_no_debug_info(self, hsaco):
+        """[] means 'ran fine, no source trail' — the TYPE B signal."""
+        with patch("subprocess.run", dwarfdump_stub(stdout="no line table")):
+            assert _llvm_dwarfdump_paths(hsaco) == []
+
+    def test_extracts_source_paths(self, hsaco):
+        out = dwarf_output("/src/kernel.hip", "/src/util.cuh")
+        with patch("subprocess.run", dwarfdump_stub(stdout=out)):
+            assert _llvm_dwarfdump_paths(hsaco) == ["/src/kernel.hip", "/src/util.cuh"]
+
+    def test_filters_synthetic_entries(self, hsaco):
+        """The AMDGPU back-end emits <built-in> and friends; they aren't source."""
+        out = dwarf_output("<built-in>", "<command line>", "<unknown>", "/src/real.cpp")
+        with patch("subprocess.run", dwarfdump_stub(stdout=out)):
+            assert _llvm_dwarfdump_paths(hsaco) == ["/src/real.cpp"]
+
+    def test_filters_non_source_extensions(self, hsaco):
+        out = dwarf_output("/src/kernel.cpp", "/src/notes.txt", "/src/data.bin")
+        with patch("subprocess.run", dwarfdump_stub(stdout=out)):
+            assert _llvm_dwarfdump_paths(hsaco) == ["/src/kernel.cpp"]
+
+    @pytest.mark.parametrize(
+        "ext", [".cpp", ".hip", ".cu", ".cxx", ".cc", ".hpp", ".h", ".cuh", ".c"]
+    )
+    def test_every_documented_source_extension_is_accepted(self, hsaco, ext):
+        with patch("subprocess.run", dwarfdump_stub(stdout=dwarf_output(f"/src/k{ext}"))):
+            assert _llvm_dwarfdump_paths(hsaco) == [f"/src/k{ext}"]
+
+    def test_deduplicates_while_preserving_order(self, hsaco):
+        """A line table repeats the same file once per line; report it once."""
+        out = dwarf_output("/src/b.cpp", "/src/a.cpp", "/src/b.cpp", "/src/a.cpp")
+        with patch("subprocess.run", dwarfdump_stub(stdout=out)):
+            assert _llvm_dwarfdump_paths(hsaco) == ["/src/b.cpp", "/src/a.cpp"]
+
+    def test_prefers_the_rocm_path_tool(self, hsaco, monkeypatch):
+        monkeypatch.setenv("ROCM_PATH", "/custom/rocm")
+        stub = dwarfdump_stub(stdout=dwarf_output("/src/k.cpp"))
+        with patch("subprocess.run", stub):
+            _llvm_dwarfdump_paths(hsaco)
+
+        assert stub.tried[0] == "/custom/rocm/llvm/bin/llvm-dwarfdump"
+
+    def test_defaults_to_opt_rocm(self, hsaco, monkeypatch):
+        monkeypatch.delenv("ROCM_PATH", raising=False)
+        stub = dwarfdump_stub(stdout="")
+        with patch("subprocess.run", stub):
+            _llvm_dwarfdump_paths(hsaco)
+
+        assert stub.tried[0] == "/opt/rocm/llvm/bin/llvm-dwarfdump"
+
+    def test_falls_through_to_a_later_candidate(self, hsaco):
+        """A missing ROCm tool must not stop the PATH lookup."""
+        calls = []
+
+        def _run(argv, **_kwargs):
+            calls.append(argv[0])
+            if len(calls) < 3:
+                raise FileNotFoundError()
+            return subprocess.CompletedProcess(
+                argv, 0, stdout=dwarf_output("/src/k.cpp"), stderr=""
+            )
+
+        with patch("subprocess.run", _run):
+            assert _llvm_dwarfdump_paths(hsaco) == ["/src/k.cpp"]
+        assert calls[-1] == "llvm-dwarfdump"
+
+    @pytest.mark.parametrize(
+        "exc", [subprocess.TimeoutExpired("llvm-dwarfdump", 15), OSError("bad exec")]
+    )
+    def test_tool_exceptions_are_swallowed(self, hsaco, exc):
+        with patch("subprocess.run", dwarfdump_stub(fail_with=exc)):
+            assert _llvm_dwarfdump_paths(hsaco) is None
+
+    def test_passes_debug_line_and_a_timeout(self, hsaco):
+        seen = {}
+
+        def _run(argv, **kwargs):
+            seen["argv"] = list(argv)
+            seen["timeout"] = kwargs.get("timeout")
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        with patch("subprocess.run", _run):
+            _llvm_dwarfdump_paths(hsaco)
+
+        assert "--debug-line" in seen["argv"]
+        assert seen["argv"][-1] == hsaco
+        assert seen["timeout"] == 15
+
+
+# --------------------------------------------------------------------------
+# _hsaco_has_debug_section
+# --------------------------------------------------------------------------
+
+
+class TestHsacoHasDebugSection:
+    def test_true_when_debug_sections_present(self, hsaco):
+        out = "  [ 5] .debug_info  PROGBITS"
+        with patch("subprocess.run", dwarfdump_stub(stdout=out)):
+            assert _hsaco_has_debug_section(hsaco) is True
+
+    def test_false_when_absent(self, hsaco):
+        with patch("subprocess.run", dwarfdump_stub(stdout="  [ 1] .text PROGBITS")):
+            assert _hsaco_has_debug_section(hsaco) is False
+
+    def test_none_when_no_tool_runs(self, hsaco):
+        """None is 'could not tell', not 'no debug info'."""
+        with patch("subprocess.run", dwarfdump_stub(fail_with=FileNotFoundError())):
+            assert _hsaco_has_debug_section(hsaco) is None
+
+    def test_none_when_every_tool_exits_nonzero(self, hsaco):
+        with patch("subprocess.run", dwarfdump_stub(returncode=1)):
+            assert _hsaco_has_debug_section(hsaco) is None
+
+    def test_falls_back_to_system_readelf(self, hsaco):
+        calls = []
+
+        def _run(argv, **_kwargs):
+            calls.append(argv[0])
+            if argv[0] != "readelf":
+                raise FileNotFoundError()
+            return subprocess.CompletedProcess(argv, 0, stdout=".debug_line", stderr="")
+
+        with patch("subprocess.run", _run):
+            assert _hsaco_has_debug_section(hsaco) is True
+        assert calls[-1] == "readelf"
+
+
+# --------------------------------------------------------------------------
+# _triton_kernel_in_tree
+# --------------------------------------------------------------------------
+
+
+def write_py(tmp_path, name: str, body: str) -> None:
+    (tmp_path / name).write_text(body)
+
+
+class TestTritonKernelInTree:
+    def test_finds_a_jit_decorated_function(self, tmp_path):
+        write_py(tmp_path, "k.py", "import triton\n@triton.jit\ndef my_kernel(x):\n    pass\n")
+        assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is True
+
+    def test_matches_a_kernel_name_substring(self, tmp_path):
+        """Captured names are mangled, e.g. triton_poi_fused_my_kernel_0."""
+        write_py(tmp_path, "k.py", "import triton\n@triton.jit\ndef my_kernel(x):\n    pass\n")
+        assert _triton_kernel_in_tree("triton_poi_my_kernel_0", str(tmp_path)) is True
+
+    def test_matches_in_the_other_direction_too(self, tmp_path):
+        write_py(tmp_path, "k.py", "import triton\n@triton.jit\ndef attn_fwd_inner(x):\n    pass\n")
+        assert _triton_kernel_in_tree("attn_fwd", str(tmp_path)) is True
+
+    @pytest.mark.parametrize(
+        "decorator",
+        [
+            "@triton.jit",  # ast.Attribute
+            "@triton.autotune(configs=[], key=[])",  # ast.Call of ast.Attribute
+        ],
+    )
+    def test_dotted_decorator_forms_are_recognised(self, tmp_path, decorator):
+        write_py(tmp_path, "k.py", f"import triton\n{decorator}\ndef my_kernel(x):\n    pass\n")
+        assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is True
+
+    @pytest.mark.parametrize("decorator", ["@jit", "@autotune(configs=[], key=[])"])
+    def test_bare_decorator_forms_are_missed_by_the_text_prefilter(self, tmp_path, decorator):
+        """``from triton import jit`` + ``@jit`` is not detected.
+
+        The AST walk handles ``ast.Name`` and ``ast.Call``-of-``ast.Name``
+        decorators, but it is never reached: the function first requires the
+        literal text ``@triton.jit`` or ``@triton.autotune`` to appear in the
+        file, and a bare import form contains neither.
+
+        Consequence is limited to diagnostics — this only drives the TYPE T
+        "did you mean --language triton?" hint, so a miss degrades the message
+        rather than breaking extraction. Pinned as current behaviour, not
+        endorsed; the fix would be to widen the prefilter to ``"triton"``.
+        """
+        write_py(
+            tmp_path,
+            "k.py",
+            f"from triton import jit, autotune\n{decorator}\ndef my_kernel(x):\n    pass\n",
+        )
+        assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is False
+
+    @pytest.mark.parametrize("decorator", ["@jit", "@autotune(configs=[], key=[])"])
+    def test_bare_decorator_matches_once_the_prefilter_is_satisfied(self, tmp_path, decorator):
+        """The bare-name branches do work — it is only the gate that blocks them.
+
+        Here another function carries the dotted form, so the file passes the
+        text prefilter and the bare decorator on the target is then matched.
+        """
+        write_py(
+            tmp_path,
+            "k.py",
+            "import triton\nfrom triton import jit, autotune\n\n"
+            "@triton.jit\ndef unrelated():\n    pass\n\n"
+            f"{decorator}\ndef my_kernel(x):\n    pass\n",
+        )
+        assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is True
+
+    def test_searches_recursively(self, tmp_path):
+        nested = tmp_path / "pkg" / "kernels"
+        nested.mkdir(parents=True)
+        (nested / "k.py").write_text("import triton\n@triton.jit\ndef my_kernel():\n    pass\n")
+        assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is True
+
+    def test_non_python_files_are_ignored(self, tmp_path):
+        (tmp_path / "k.txt").write_text("@triton.jit\ndef my_kernel(): pass\n")
+        assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is False
+
+    def test_files_without_triton_markers_are_skipped(self, tmp_path):
+        write_py(tmp_path, "k.py", "def my_kernel(x):\n    pass\n")
+        assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is False
+
+    def test_undecorated_function_does_not_match(self, tmp_path):
+        """The marker text is present but the target function is plain."""
+        write_py(
+            tmp_path,
+            "k.py",
+            "import triton\n@triton.jit\ndef other(x):\n    pass\n\ndef my_kernel(y):\n    pass\n",
+        )
+        assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is False
+
+    def test_an_unparseable_file_is_skipped(self, tmp_path):
+        """Sole file in the tree, so the SyntaxError branch must be taken.
+
+        Deliberately not paired with a good file: ``os.walk`` yields entries
+        in filesystem order, so a two-file tree only reaches ``ast.parse`` on
+        the broken one when the OS happens to list it first. That made an
+        earlier version of this test cover the branch on one machine and not
+        another.
+        """
+        write_py(tmp_path, "broken.py", "@triton.jit\ndef ( bad syntax\n")
+        assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is False
+
+    def test_a_syntax_error_does_not_hide_a_later_match(self, tmp_path):
+        """Behavioural pair to the above, independent of walk order."""
+        write_py(tmp_path, "broken.py", "@triton.jit\ndef ( bad syntax\n")
+        write_py(tmp_path, "good.py", "import triton\n@triton.jit\ndef my_kernel():\n    pass\n")
+        assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is True
+
+    def test_an_unreadable_file_is_skipped(self, tmp_path):
+        """Sole file again, for the same walk-order reason."""
+        write_py(tmp_path, "bin.py", "@triton.jit\ndef my_kernel():\n    pass\n")
+
+        real_open = open
+
+        def _open(path, *args, **kwargs):
+            if str(path).endswith("bin.py"):
+                raise UnicodeDecodeError("utf-8", b"", 0, 1, "bad")
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", _open):
+            assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is False
+
+    def test_an_unreadable_file_does_not_hide_a_later_match(self, tmp_path):
+        write_py(tmp_path, "bin.py", "@triton.jit\n")
+        write_py(tmp_path, "good.py", "import triton\n@triton.jit\ndef my_kernel():\n    pass\n")
+
+        real_open = open
+
+        def _open(path, *args, **kwargs):
+            if str(path).endswith("bin.py"):
+                raise UnicodeDecodeError("utf-8", b"", 0, 1, "bad")
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", _open):
+            assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is True
+
+    def test_empty_tree_returns_false(self, tmp_path):
+        assert _triton_kernel_in_tree("my_kernel", str(tmp_path)) is False
+
+
+# --------------------------------------------------------------------------
+# _explain_source_not_found — the three classifications
+# --------------------------------------------------------------------------
+
+
+class TestExplainSourceNotFound:
+    def test_missing_hsaco_cannot_be_classified(self, tmp_path, caplog):
+        with caplog.at_level(logging.WARNING):
+            _explain_source_not_found("k", str(tmp_path), None, None)
+
+        assert "cannot classify" in caplog.text
+
+    def test_type_a_reports_the_dwarf_paths(self, tmp_path, caplog):
+        """Source trail exists — the user pointed --source-dir somewhere wrong."""
+        (tmp_path / "kernel.hsaco").write_bytes(b"\x7fELF")
+        paths = ["/real/src/kernel.hip", "/real/src/util.cuh"]
+
+        with (
+            patch("kerncap.extract._llvm_dwarfdump_paths", return_value=paths),
+            caplog.at_level(logging.WARNING),
+        ):
+            _explain_source_not_found("k", str(tmp_path), "/wrong/dir", "hip")
+
+        assert "a source trail DOES exist" in caplog.text
+        assert "/real/src/kernel.hip" in caplog.text
+
+    def test_type_a_lists_at_most_three_paths(self, tmp_path, caplog):
+        (tmp_path / "kernel.hsaco").write_bytes(b"\x7fELF")
+        paths = [f"/src/f{i}.cpp" for i in range(10)]
+
+        with (
+            patch("kerncap.extract._llvm_dwarfdump_paths", return_value=paths),
+            caplog.at_level(logging.WARNING),
+        ):
+            _explain_source_not_found("k", str(tmp_path), "/wrong", None)
+
+        assert "/src/f2.cpp" in caplog.text
+        assert "/src/f3.cpp" not in caplog.text
+
+    def test_type_t_suggests_the_triton_language(self, tmp_path, caplog):
+        (tmp_path / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap.extract._llvm_dwarfdump_paths", return_value=[]),
+            patch("kerncap.extract._triton_kernel_in_tree", return_value=True),
+            caplog.at_level(logging.WARNING),
+        ):
+            _explain_source_not_found("my_kernel", str(tmp_path), "/src", "hip")
+
+        assert "Re-run with --language triton" in caplog.text
+
+    def test_type_t_applies_when_language_was_omitted(self, tmp_path, caplog):
+        (tmp_path / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap.extract._llvm_dwarfdump_paths", return_value=[]),
+            patch("kerncap.extract._triton_kernel_in_tree", return_value=True),
+            caplog.at_level(logging.WARNING),
+        ):
+            _explain_source_not_found("my_kernel", str(tmp_path), "/src", None)
+
+        assert "--language triton" in caplog.text
+
+    def test_type_t_is_not_offered_when_already_triton(self, tmp_path, caplog):
+        """Suggesting --language triton to someone who passed it is noise."""
+        (tmp_path / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap.extract._llvm_dwarfdump_paths", return_value=[]),
+            patch("kerncap.extract._triton_kernel_in_tree", return_value=True),
+            patch("kerncap.extract._hsaco_has_debug_section", return_value=None),
+            caplog.at_level(logging.WARNING),
+        ):
+            _explain_source_not_found("my_kernel", str(tmp_path), "/src", "triton")
+
+        assert "Re-run with --language triton" not in caplog.text
+        assert "no source trail to walk" in caplog.text
+
+    def test_type_t_needs_a_source_dir(self, tmp_path, caplog):
+        (tmp_path / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap.extract._llvm_dwarfdump_paths", return_value=[]),
+            patch("kerncap.extract._triton_kernel_in_tree", return_value=True) as scan,
+            patch("kerncap.extract._hsaco_has_debug_section", return_value=None),
+            caplog.at_level(logging.WARNING),
+        ):
+            _explain_source_not_found("my_kernel", str(tmp_path), None, "hip")
+
+        scan.assert_not_called()
+        assert "no source trail to walk" in caplog.text
+
+    def test_type_b_when_no_trail_exists(self, tmp_path, caplog):
+        """Tensile / hand-written assembly / vendor blobs land here."""
+        (tmp_path / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap.extract._llvm_dwarfdump_paths", return_value=None),
+            patch("kerncap.extract._hsaco_has_debug_section", return_value=None),
+            caplog.at_level(logging.WARNING),
+        ):
+            _explain_source_not_found("Cijk_Ailk_Bljk", str(tmp_path), "/src", "hip")
+
+        assert "no source trail to walk" in caplog.text
+        assert "Tensile" in caplog.text
+        assert "make recompile' is not possible" in caplog.text
+
+    def test_type_b_notes_a_stripped_binary(self, tmp_path, caplog):
+        (tmp_path / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap.extract._llvm_dwarfdump_paths", return_value=[]),
+            patch("kerncap.extract._triton_kernel_in_tree", return_value=False),
+            patch("kerncap.extract._hsaco_has_debug_section", return_value=True),
+            caplog.at_level(logging.WARNING),
+        ):
+            _explain_source_not_found("k", str(tmp_path), "/src", "hip")
+
+        assert "built with -g but stripped" in caplog.text
+
+    def test_type_b_notes_an_undebuggable_binary(self, tmp_path, caplog):
+        (tmp_path / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap.extract._llvm_dwarfdump_paths", return_value=[]),
+            patch("kerncap.extract._triton_kernel_in_tree", return_value=False),
+            patch("kerncap.extract._hsaco_has_debug_section", return_value=False),
+            caplog.at_level(logging.WARNING),
+        ):
+            _explain_source_not_found("k", str(tmp_path), "/src", "hip")
+
+        assert "no .debug_* sections" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# _generate_triton_from_hsa — source resolution chain
+# --------------------------------------------------------------------------
+
+
+class TestGenerateTritonFromHsa:
+    def test_raises_when_there_is_no_source_anywhere(self, tmp_path):
+        """No --source-dir, no snapshot, no name_map — nothing to author from."""
+        capture = tmp_path / "capture"
+        capture.mkdir()
+
+        with pytest.raises(_TritonHsaReproducerUnavailable, match="no source directory"):
+            _generate_triton_from_hsa("k", str(capture), str(tmp_path / "out"), None, None, {})
+
+    def test_falls_back_to_the_compile_shim_snapshot(self, tmp_path):
+        """capture/triton_sources/ stands in when --source-dir was omitted."""
+        capture = tmp_path / "capture"
+        (capture / "triton_sources").mkdir(parents=True)
+
+        with patch("kerncap.source_finder.find_kernel_source", return_value=None) as find:
+            with pytest.raises(_TritonHsaReproducerUnavailable, match="not found under"):
+                _generate_triton_from_hsa("k", str(capture), str(tmp_path / "out"), None, None, {})
+
+        assert find.call_args.kwargs["source_dir"] == str(capture / "triton_sources")
+
+    def test_explicit_source_dir_wins_over_the_snapshot(self, tmp_path):
+        capture = tmp_path / "capture"
+        (capture / "triton_sources").mkdir(parents=True)
+
+        with patch("kerncap.source_finder.find_kernel_source", return_value=None) as find:
+            with pytest.raises(_TritonHsaReproducerUnavailable):
+                _generate_triton_from_hsa(
+                    "k", str(capture), str(tmp_path / "out"), "/my/src", None, {}
+                )
+
+        assert find.call_args.kwargs["source_dir"] == "/my/src"
+
+    def test_uses_the_source_file_recorded_in_name_map(self, tmp_path):
+        """name_map.json names the @triton.jit function's actual file."""
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        recorded = tmp_path / "real_src" / "attn.py"
+        recorded.parent.mkdir()
+        recorded.write_text("# kernel\n")
+        (capture / "name_map.json").write_text(
+            f'[{{"user_name": "attn_fwd", "source_file": "{recorded}"}}]'
+        )
+
+        with patch("kerncap.source_finder.find_kernel_source", return_value=None) as find:
+            with pytest.raises(_TritonHsaReproducerUnavailable):
+                _generate_triton_from_hsa(
+                    "attn_fwd", str(capture), str(tmp_path / "out"), None, None, {}
+                )
+
+        assert find.call_args.kwargs["source_dir"] == str(recorded.parent)
+
+    def test_source_snapshot_is_preferred_over_source_file(self, tmp_path):
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        snap = tmp_path / "snap" / "attn.py"
+        snap.parent.mkdir()
+        snap.write_text("# snapshot\n")
+        (capture / "name_map.json").write_text(
+            f'[{{"user_name": "attn_fwd", "source_file": "/orig/attn.py",'
+            f' "source_snapshot": "{snap}"}}]'
+        )
+
+        with patch("kerncap.source_finder.find_kernel_source", return_value=None) as find:
+            with pytest.raises(_TritonHsaReproducerUnavailable):
+                _generate_triton_from_hsa(
+                    "attn_fwd", str(capture), str(tmp_path / "out"), None, None, {}
+                )
+
+        assert find.call_args.kwargs["source_dir"] == str(snap.parent)
+
+    def test_malformed_name_map_is_tolerated(self, tmp_path):
+        """A corrupt name_map must not crash extraction outright."""
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "name_map.json").write_text("{not json")
+
+        with pytest.raises(_TritonHsaReproducerUnavailable, match="no source directory"):
+            _generate_triton_from_hsa("k", str(capture), str(tmp_path / "out"), None, None, {})
+
+    def test_missing_name_map_is_reported_distinctly(self, tmp_path):
+        """Source was found but the compile shim never fired — a cache hit."""
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+
+        fake_src = kernel_source()
+
+        with patch("kerncap.source_finder.find_kernel_source", return_value=fake_src):
+            with pytest.raises(_TritonHsaReproducerUnavailable, match="no name_map.json"):
+                _generate_triton_from_hsa(
+                    "k", str(capture), str(tmp_path / "out"), str(src), None, {}
+                )
+
+    def test_success_reports_kernel_variant_when_written(self, tmp_path):
+        """Package-source path: the reproducer writes a clean kernel_variant.py."""
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "name_map.json").write_text('[{"user_name": "k"}]')
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "kernel_variant.py").write_text("# variant\n")
+        src = tmp_path / "src"
+        src.mkdir()
+
+        with (
+            patch("kerncap.source_finder.find_kernel_source", return_value=kernel_source()),
+            patch("kerncap.reproducer.generate_triton_hsa_reproducer") as gen,
+        ):
+            result = _generate_triton_from_hsa("k", str(capture), str(out), str(src), None, {})
+
+        gen.assert_called_once()
+        assert result.language == "triton"
+        assert result.has_source is True
+        assert result.generated_files == [
+            "reproducer.py",
+            "kernel_variant.py",
+            "capture/",
+            "reference_output/",
+        ]
+
+    def test_success_lists_copied_sources_on_the_flat_file_path(self, tmp_path):
+        """Without kernel_variant.py the list must name what was really copied.
+
+        A hardcoded list would lie here — the flat-file path copies the user's
+        own source files instead of authoring a variant.
+        """
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "name_map.json").write_text('[{"user_name": "k"}]')
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "attn.py").write_text("# copied\n")
+        (out / "helpers.py").write_text("# copied\n")
+        src = tmp_path / "src"
+        src.mkdir()
+
+        ks = kernel_source(source_files=["/orig/attn.py", "/orig/helpers.py", "/orig/absent.py"])
+
+        with (
+            patch("kerncap.source_finder.find_kernel_source", return_value=ks),
+            patch("kerncap.reproducer.generate_triton_hsa_reproducer"),
+        ):
+            result = _generate_triton_from_hsa("k", str(capture), str(out), str(src), None, {})
+
+        # Only files that actually landed in output_dir are listed.
+        assert result.generated_files == [
+            "reproducer.py",
+            "attn.py",
+            "helpers.py",
+            "capture/",
+            "reference_output/",
+        ]
+
+
+# --------------------------------------------------------------------------
+# _generate_triton (legacy python backend)
+# --------------------------------------------------------------------------
+
+
+class TestGenerateTriton:
+    def test_requires_a_source_dir(self, tmp_path):
+        with pytest.raises(RuntimeError, match="requires located kernel source"):
+            _generate_triton("k", str(tmp_path), str(tmp_path / "out"), None, None)
+
+    def test_unlocatable_source_explains_before_raising(self, tmp_path, caplog):
+        """The user gets the classifier message, not just a bare RuntimeError."""
+        capture = tmp_path / "capture"
+        capture.mkdir()
+
+        with (
+            patch("kerncap.source_finder.find_kernel_source", return_value=None),
+            patch("kerncap.extract._explain_source_not_found") as explain,
+            pytest.raises(RuntimeError, match="requires located kernel source"),
+        ):
+            _generate_triton("k", str(capture), str(tmp_path / "out"), str(tmp_path), None)
+
+        explain.assert_called_once()
+
+    def test_success(self, tmp_path):
+        with (
+            patch("kerncap.source_finder.find_kernel_source", return_value=kernel_source()),
+            patch("kerncap.reproducer.generate_triton_reproducer") as gen,
+        ):
+            result = _generate_triton(
+                "k", str(tmp_path), str(tmp_path / "out"), str(tmp_path), "triton"
+            )
+
+        gen.assert_called_once()
+        assert result.language == "triton"
+        assert result.has_source is True
+        assert result.generated_files == ["reproducer.py", "capture/"]
+
+
+# --------------------------------------------------------------------------
+# _generate_hsaco
+# --------------------------------------------------------------------------
+
+
+class TestGenerateHsaco:
+    def test_warns_when_the_code_object_is_missing(self, tmp_path, caplog):
+        """Without a .hsaco the reproducer cannot replay at all."""
+        capture = tmp_path / "capture"
+        capture.mkdir()
+
+        with (
+            patch("kerncap.reproducer.generate_hsaco_reproducer"),
+            caplog.at_level(logging.WARNING),
+        ):
+            _generate_hsaco("k", str(capture), str(tmp_path / "out"), None, None, [], {})
+
+        assert "Replay will not work" in caplog.text
+
+    def test_without_source_dir_the_result_is_hsaco_only(self, tmp_path):
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with patch("kerncap.reproducer.generate_hsaco_reproducer"):
+            result = _generate_hsaco("k", str(capture), str(tmp_path / "out"), None, None, [], {})
+
+        assert result.has_source is False
+        assert result.generated_files == ["capture/", "Makefile"]
+        assert result.language == "hip"
+
+    def test_language_is_echoed_when_given(self, tmp_path):
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with patch("kerncap.reproducer.generate_hsaco_reproducer"):
+            result = _generate_hsaco(
+                "k", str(capture), str(tmp_path / "out"), None, "triton", [], {}
+            )
+
+        assert result.language == "triton"
+
+    def test_lists_the_copied_hsaco(self, tmp_path):
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "kernel.hsaco").write_bytes(b"\x7fELF")
+        out = tmp_path / "out"
+        (out / "capture").mkdir(parents=True)
+        (out / "capture" / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with patch("kerncap.reproducer.generate_hsaco_reproducer"):
+            result = _generate_hsaco("k", str(capture), str(out), None, None, [], {})
+
+        assert "kernel.hsaco" in result.generated_files
+
+    def test_located_source_adds_the_editable_files(self, tmp_path):
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        ks = kernel_source(language="hip", main_file="k.hip", translation_unit="k.cu")
+
+        with (
+            patch("kerncap.source_finder.find_kernel_source", return_value=ks),
+            patch("kerncap.reproducer.generate_hsaco_reproducer"),
+        ):
+            result = _generate_hsaco(
+                "k", str(capture), str(tmp_path / "out"), str(tmp_path), "hip", [], {}
+            )
+
+        assert result.has_source is True
+        assert "kernel_variant.cpp" in result.generated_files
+        assert "vfs.yaml" in result.generated_files
+
+    def test_forwards_defines_and_mangled_name(self, tmp_path):
+        """Both are needed to pick the right templated instantiation."""
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap.source_finder.find_kernel_source", return_value=kernel_source()) as find,
+            patch("kerncap.reproducer.generate_hsaco_reproducer"),
+        ):
+            _generate_hsaco(
+                "k",
+                str(capture),
+                str(tmp_path / "out"),
+                str(tmp_path),
+                "hip",
+                ["GGML_USE_HIP"],
+                {"mangled_name": "_Z3mulIiEvPT_"},
+            )
+
+        assert find.call_args.kwargs["extra_defines"] == ["GGML_USE_HIP"]
+        assert find.call_args.kwargs["mangled_name"] == "_Z3mulIiEvPT_"
+
+    def test_empty_defines_become_none(self, tmp_path):
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap.source_finder.find_kernel_source", return_value=kernel_source()) as find,
+            patch("kerncap.reproducer.generate_hsaco_reproducer"),
+        ):
+            _generate_hsaco("k", str(capture), str(tmp_path / "out"), str(tmp_path), "hip", [], {})
+
+        assert find.call_args.kwargs["extra_defines"] is None
+
+    def test_warns_when_no_compile_command_for_a_hip_source(self, tmp_path, caplog):
+        """Without a compile command there is no 'make recompile' target."""
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "kernel.hsaco").write_bytes(b"\x7fELF")
+        ks = kernel_source(language="hip", compile_command=None)
+
+        with (
+            patch("kerncap.source_finder.find_kernel_source", return_value=ks),
+            patch("kerncap.reproducer.generate_hsaco_reproducer"),
+            caplog.at_level(logging.WARNING),
+        ):
+            _generate_hsaco("k", str(capture), str(tmp_path / "out"), str(tmp_path), "hip", [], {})
+
+        assert "make recompile' target will not be available" in caplog.text
+
+    def test_no_recompile_warning_for_triton(self, tmp_path, caplog):
+        """Triton is JIT-compiled, so a missing compile command is expected."""
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "kernel.hsaco").write_bytes(b"\x7fELF")
+        ks = kernel_source(language="triton", compile_command=None)
+
+        with (
+            patch("kerncap.source_finder.find_kernel_source", return_value=ks),
+            patch("kerncap.reproducer.generate_hsaco_reproducer"),
+            caplog.at_level(logging.WARNING),
+        ):
+            _generate_hsaco(
+                "k", str(capture), str(tmp_path / "out"), str(tmp_path), "triton", [], {}
+            )
+
+        assert "make recompile" not in caplog.text
+
+    def test_unlocatable_source_is_explained(self, tmp_path):
+        capture = tmp_path / "capture"
+        capture.mkdir()
+        (capture / "kernel.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap.source_finder.find_kernel_source", return_value=None),
+            patch("kerncap.extract._explain_source_not_found") as explain,
+            patch("kerncap.reproducer.generate_hsaco_reproducer"),
+        ):
+            result = _generate_hsaco(
+                "k", str(capture), str(tmp_path / "out"), str(tmp_path), "hip", [], {}
+            )
+
+        explain.assert_called_once()
+        assert result.has_source is False
+
+
+# --------------------------------------------------------------------------
+# _generate_reproducer — routing and the HSA-Triton fallback
+# --------------------------------------------------------------------------
+
+
+def write_capture(tmp_path, metadata: dict, filename="dispatch.json") -> str:
+    import json as _json
+
+    capture = tmp_path / "capture"
+    capture.mkdir(exist_ok=True)
+    (capture / filename).write_text(_json.dumps(metadata))
+    (capture / "kernel.hsaco").write_bytes(b"\x7fELF")
+    return str(capture)
+
+
+class TestGenerateReproducerRouting:
+    def test_requires_dispatch_or_metadata_json(self, tmp_path):
+        capture = tmp_path / "capture"
+        capture.mkdir()
+
+        with pytest.raises(FileNotFoundError, match="No dispatch.json or metadata.json"):
+            _generate_reproducer("k", str(capture), str(tmp_path / "out"), None, None, [])
+
+    def test_falls_back_to_metadata_json(self, tmp_path):
+        capture = write_capture(tmp_path, {"language": "hip"}, filename="metadata.json")
+
+        with patch("kerncap.reproducer.generate_hsaco_reproducer"):
+            result = _generate_reproducer("k", capture, str(tmp_path / "out"), None, None, [])
+
+        assert result.language == "hip"
+
+    def test_language_from_metadata_routes_to_triton(self, tmp_path):
+        capture = write_capture(tmp_path, {"language": "triton"})
+
+        with patch("kerncap.extract._generate_triton_from_hsa") as gen:
+            _generate_reproducer("k", capture, str(tmp_path / "out"), None, None, [])
+
+        gen.assert_called_once()
+
+    def test_explicit_language_overrides_metadata(self, tmp_path):
+        capture = write_capture(tmp_path, {"language": "triton"})
+
+        with patch("kerncap.reproducer.generate_hsaco_reproducer") as gen:
+            _generate_reproducer("k", capture, str(tmp_path / "out"), None, "hip", [])
+
+        gen.assert_called_once()
+
+    def test_python_backend_routes_to_legacy_triton(self, tmp_path):
+        capture = write_capture(tmp_path, {"language": "triton"})
+
+        with patch("kerncap.extract._generate_triton") as gen:
+            _generate_reproducer(
+                "k", capture, str(tmp_path / "out"), None, None, [], triton_backend="python"
+            )
+
+        gen.assert_called_once()
+
+    def test_unavailable_triton_reproducer_falls_back_to_the_hip_harness(self, tmp_path, caplog):
+        """Losing the edit loop is better than producing nothing replayable."""
+        capture = write_capture(tmp_path, {"language": "triton"})
+
+        with (
+            patch(
+                "kerncap.extract._generate_triton_from_hsa",
+                side_effect=_TritonHsaReproducerUnavailable("no name_map.json"),
+            ),
+            patch("kerncap.reproducer.generate_hsaco_reproducer") as gen,
+            caplog.at_level(logging.WARNING),
+        ):
+            result = _generate_reproducer("k", capture, str(tmp_path / "out"), None, None, [])
+
+        gen.assert_called_once()
+        assert "falling back to HIP harness" in caplog.text
+        assert "no name_map.json" in caplog.text
+
+    def test_the_fallback_result_is_labelled_hip_not_triton(self, tmp_path):
+        """A fallen-back Triton capture reports ``language="hip"``.
+
+        ``_generate_reproducer`` hands ``_generate_hsaco`` the *user's*
+        ``language`` argument rather than the language detected from
+        metadata, so an auto-detected Triton kernel that falls back is
+        labelled by what was actually produced — a HIP harness — not by what
+        the kernel was. That is what the CLI keys off in
+        ``_print_next_steps``, so it decides which instructions the user is
+        shown.
+        """
+        capture = write_capture(tmp_path, {"language": "triton"})
+
+        with (
+            patch(
+                "kerncap.extract._generate_triton_from_hsa",
+                side_effect=_TritonHsaReproducerUnavailable("no name_map.json"),
+            ),
+            patch("kerncap.reproducer.generate_hsaco_reproducer"),
+        ):
+            result = _generate_reproducer("k", capture, str(tmp_path / "out"), None, None, [])
+
+        assert result.language == "hip"
+
+    def test_an_explicit_triton_language_survives_the_fallback(self, tmp_path):
+        """Passing --language triton keeps the label, since it is echoed back."""
+        capture = write_capture(tmp_path, {"language": "triton"})
+
+        with (
+            patch(
+                "kerncap.extract._generate_triton_from_hsa",
+                side_effect=_TritonHsaReproducerUnavailable("no name_map.json"),
+            ),
+            patch("kerncap.reproducer.generate_hsaco_reproducer"),
+        ):
+            result = _generate_reproducer("k", capture, str(tmp_path / "out"), None, "triton", [])
+
+        assert result.language == "triton"

--- a/kerncap/tests/unit/test_extract_helpers.py
+++ b/kerncap/tests/unit/test_extract_helpers.py
@@ -71,6 +71,14 @@ def hsaco(tmp_path):
     return str(path)
 
 
+@pytest.fixture
+def runner():
+    """Only used to capture click's echo output when driving _print_next_steps."""
+    from click.testing import CliRunner
+
+    return CliRunner()
+
+
 def kernel_source(**overrides):
     """A stand-in for ``KernelSource`` carrying only what extract.py reads."""
     fields = {
@@ -941,16 +949,20 @@ class TestGenerateReproducerRouting:
         assert "falling back to HIP harness" in caplog.text
         assert "no name_map.json" in caplog.text
 
-    def test_the_fallback_result_is_labelled_hip_not_triton(self, tmp_path):
-        """A fallen-back Triton capture reports ``language="hip"``.
+    @pytest.mark.parametrize("user_language", [None, "triton"])
+    def test_the_fallback_is_always_labelled_hip(self, tmp_path, user_language):
+        """The fallback produces an HSACO-only HIP harness, so it says "hip".
 
-        ``_generate_reproducer`` hands ``_generate_hsaco`` the *user's*
-        ``language`` argument rather than the language detected from
-        metadata, so an auto-detected Triton kernel that falls back is
-        labelled by what was actually produced — a HIP harness — not by what
-        the kernel was. That is what the CLI keys off in
-        ``_print_next_steps``, so it decides which instructions the user is
-        shown.
+        ``ExtractResult.language`` drives how the CLI tells the user to *use*
+        the reproducer, and this path writes no ``reproducer.py`` — so the
+        label has to describe what was generated, not what the kernel was
+        written in.
+
+        Parametrised over both ways the language can be determined because
+        that used to change the answer: ``_generate_hsaco`` returns
+        ``language or "hip"``, so an explicit ``--language triton`` came back
+        as "triton" while the same capture auto-detected from metadata came
+        back as "hip".
         """
         capture = write_capture(tmp_path, {"language": "triton"})
 
@@ -961,13 +973,23 @@ class TestGenerateReproducerRouting:
             ),
             patch("kerncap.reproducer.generate_hsaco_reproducer"),
         ):
-            result = _generate_reproducer("k", capture, str(tmp_path / "out"), None, None, [])
+            result = _generate_reproducer(
+                "k", capture, str(tmp_path / "out"), None, user_language, []
+            )
 
         assert result.language == "hip"
 
-    def test_an_explicit_triton_language_survives_the_fallback(self, tmp_path):
-        """Passing --language triton keeps the label, since it is echoed back."""
+    def test_the_fallback_tells_the_user_to_use_make_not_reproducer_py(self, tmp_path, runner):
+        """End to end: the label must not produce instructions for a missing file.
+
+        This is the reason the label matters. With ``language="triton"`` the
+        CLI would print ``python3 reproducer.py`` for a directory that has no
+        such file.
+        """
+        from kerncap import cli
+
         capture = write_capture(tmp_path, {"language": "triton"})
+        out = tmp_path / "out"
 
         with (
             patch(
@@ -976,6 +998,28 @@ class TestGenerateReproducerRouting:
             ),
             patch("kerncap.reproducer.generate_hsaco_reproducer"),
         ):
-            result = _generate_reproducer("k", capture, str(tmp_path / "out"), None, "triton", [])
+            result = _generate_reproducer("k", capture, str(out), None, "triton", [])
+
+        with runner.isolation() as streams:
+            cli._print_next_steps(result)
+        printed = streams[0].getvalue().decode()
+
+        assert "make recompile" in printed
+        assert "reproducer.py" not in printed
+
+    def test_a_successful_triton_reproducer_is_still_labelled_triton(self, tmp_path):
+        """The normalisation must not leak into the path that does write one."""
+        capture = write_capture(tmp_path, {"language": "triton"})
+        (tmp_path / "out").mkdir()
+        (tmp_path / "out" / "kernel_variant.py").write_text("# variant\n")
+        (tmp_path / "capture" / "name_map.json").write_text('[{"user_name": "k"}]')
+        src = tmp_path / "src"
+        src.mkdir()
+
+        with (
+            patch("kerncap.source_finder.find_kernel_source", return_value=kernel_source()),
+            patch("kerncap.reproducer.generate_triton_hsa_reproducer"),
+        ):
+            result = _generate_reproducer("k", capture, str(tmp_path / "out"), str(src), None, [])
 
         assert result.language == "triton"

--- a/kerncap/tests/unit/test_hsaco_extractor.py
+++ b/kerncap/tests/unit/test_hsaco_extractor.py
@@ -1,0 +1,387 @@
+"""Unit tests for kerncap.hsaco_extractor — the roc-obj-extract fallback path.
+
+This module is the fallback used when libkerncap.so did not capture the
+.hsaco blob at runtime.  Every external tool it reaches for
+(``roc-obj-extract``, ``llvm-nm``/``nm``) is stubbed at its call site, so
+these tests need neither ROCm nor a GPU.
+
+``roc-obj-extract`` writes into a ``TemporaryDirectory`` created inside the
+function under test, so the stub reads the destination out of the argv it is
+handed and materialises real files there.  That keeps the directory-scanning
+and file-copying logic under test rather than mocked away.
+"""
+
+import os
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from kerncap.hsaco_extractor import _find_matching_code_object, extract_hsaco_from_binary
+
+
+def which_stub(**available):
+    """Build a ``shutil.which`` replacement from name -> path/None."""
+
+    def _which(name):
+        return available.get(name)
+
+    return _which
+
+
+def writes_co_files(*names, returncode=0):
+    """A ``subprocess.run`` stub that materialises *names* in the -o directory."""
+
+    def _run(argv, **_kwargs):
+        outdir = argv[argv.index("-o") + 1]
+        for name in names:
+            with open(os.path.join(outdir, name), "wb") as fh:
+                fh.write(b"\x7fELF fake code object")
+        return subprocess.CompletedProcess(argv, returncode, stdout="", stderr="")
+
+    return _run
+
+
+@pytest.fixture
+def binary(tmp_path):
+    """A real file standing in for the compiled ELF."""
+    path = tmp_path / "my_app"
+    path.write_bytes(b"\x7fELF")
+    return str(path)
+
+
+# --------------------------------------------------------------------------
+# extract_hsaco_from_binary — guards
+# --------------------------------------------------------------------------
+
+
+class TestGuards:
+    def test_missing_roc_obj_extract_returns_false(self, binary, tmp_path):
+        """No tool on PATH is a normal outcome, not an exception."""
+        with (
+            patch("shutil.which", which_stub()),
+            patch("subprocess.run") as run,
+        ):
+            ok = extract_hsaco_from_binary(binary, "kern", "gfx90a", str(tmp_path / "out.hsaco"))
+
+        assert ok is False
+        run.assert_not_called()
+
+    def test_missing_binary_returns_false(self, tmp_path):
+        with (
+            patch("shutil.which", which_stub(**{"roc-obj-extract": "/usr/bin/roc-obj-extract"})),
+            patch("subprocess.run") as run,
+        ):
+            ok = extract_hsaco_from_binary(
+                str(tmp_path / "nope"), "kern", "gfx90a", str(tmp_path / "out.hsaco")
+            )
+
+        assert ok is False
+        run.assert_not_called()
+
+    def test_directory_is_not_a_valid_binary(self, tmp_path):
+        """``os.path.isfile`` must reject a directory, not just a missing path."""
+        with patch("shutil.which", which_stub(**{"roc-obj-extract": "/x"})):
+            ok = extract_hsaco_from_binary(
+                str(tmp_path), "kern", "gfx90a", str(tmp_path / "out.hsaco")
+            )
+        assert ok is False
+
+
+# --------------------------------------------------------------------------
+# extract_hsaco_from_binary — roc-obj-extract failures
+# --------------------------------------------------------------------------
+
+
+class TestExtractFailures:
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            subprocess.TimeoutExpired("roc-obj-extract", 60),
+            FileNotFoundError("roc-obj-extract"),
+        ],
+    )
+    def test_subprocess_exceptions_are_caught(self, binary, tmp_path, exc):
+        """Both documented failure modes return False rather than propagating."""
+        with (
+            patch("shutil.which", which_stub(**{"roc-obj-extract": "/x"})),
+            patch("subprocess.run", side_effect=exc),
+        ):
+            ok = extract_hsaco_from_binary(binary, "kern", "gfx90a", str(tmp_path / "out.hsaco"))
+
+        assert ok is False
+
+    def test_nonzero_exit_returns_false(self, binary, tmp_path):
+        with (
+            patch("shutil.which", which_stub(**{"roc-obj-extract": "/x"})),
+            patch("subprocess.run", writes_co_files(returncode=2)),
+        ):
+            ok = extract_hsaco_from_binary(binary, "kern", "gfx90a", str(tmp_path / "out.hsaco"))
+
+        assert ok is False
+
+    def test_no_code_objects_produced_returns_false(self, binary, tmp_path):
+        """Exit 0 but an empty output directory is still a failure."""
+        with (
+            patch("shutil.which", which_stub(**{"roc-obj-extract": "/x"})),
+            patch("subprocess.run", writes_co_files()),
+        ):
+            ok = extract_hsaco_from_binary(binary, "kern", "gfx90a", str(tmp_path / "out.hsaco"))
+
+        assert ok is False
+
+    def test_unrelated_files_are_not_treated_as_code_objects(self, binary, tmp_path):
+        """Only .co / .hsaco count; roc-obj-extract may drop other files."""
+        with (
+            patch("shutil.which", which_stub(**{"roc-obj-extract": "/x"})),
+            patch("subprocess.run", writes_co_files("notes.txt", "manifest.json")),
+        ):
+            ok = extract_hsaco_from_binary(binary, "kern", "gfx90a", str(tmp_path / "out.hsaco"))
+
+        assert ok is False
+
+    def test_no_symbol_match_returns_false(self, binary, tmp_path):
+        """When the matcher finds nothing, nothing is written."""
+        out = tmp_path / "out.hsaco"
+        with (
+            patch("shutil.which", which_stub(**{"roc-obj-extract": "/x"})),
+            patch("subprocess.run", writes_co_files("a.co")),
+            patch("kerncap.hsaco_extractor._find_matching_code_object", return_value=None),
+        ):
+            ok = extract_hsaco_from_binary(binary, "kern", "gfx90a", str(out))
+
+        assert ok is False
+        assert not out.exists()
+
+
+# --------------------------------------------------------------------------
+# extract_hsaco_from_binary — success
+# --------------------------------------------------------------------------
+
+
+class TestExtractSuccess:
+    def test_copies_the_matched_object_to_output(self, binary, tmp_path):
+        out = tmp_path / "out.hsaco"
+        with (
+            patch("shutil.which", which_stub(**{"roc-obj-extract": "/x"})),
+            patch("subprocess.run", writes_co_files("kernel_gfx90a.co")),
+        ):
+            ok = extract_hsaco_from_binary(binary, "kern", "gfx90a", str(out))
+
+        assert ok is True
+        assert out.exists()
+        assert out.read_bytes() == b"\x7fELF fake code object"
+
+    def test_accepts_hsaco_extension_too(self, binary, tmp_path):
+        out = tmp_path / "out.hsaco"
+        with (
+            patch("shutil.which", which_stub(**{"roc-obj-extract": "/x"})),
+            patch("subprocess.run", writes_co_files("kernel_gfx90a.hsaco")),
+        ):
+            ok = extract_hsaco_from_binary(binary, "kern", "gfx90a", str(out))
+
+        assert ok is True
+        assert out.exists()
+
+    def test_invokes_roc_obj_extract_with_a_temp_output_dir(self, binary, tmp_path):
+        """The -o directory must be a scratch dir, not the caller's output path."""
+        seen = {}
+
+        def _run(argv, **kwargs):
+            seen["argv"] = list(argv)
+            seen["timeout"] = kwargs.get("timeout")
+            return writes_co_files("k.co")(argv, **kwargs)
+
+        out = tmp_path / "out.hsaco"
+        with (
+            patch("shutil.which", which_stub(**{"roc-obj-extract": "/x"})),
+            patch("subprocess.run", _run),
+        ):
+            extract_hsaco_from_binary(binary, "kern", "gfx90a", str(out))
+
+        argv = seen["argv"]
+        assert argv[0] == "roc-obj-extract"
+        assert argv[-1] == binary
+        outdir = argv[argv.index("-o") + 1]
+        assert outdir != str(out)
+        assert "kerncap_hsaco_" in outdir
+        assert seen["timeout"] == 60
+
+    def test_temp_directory_is_cleaned_up(self, binary, tmp_path):
+        """The scratch dir must not outlive the call."""
+        captured = {}
+
+        def _run(argv, **kwargs):
+            captured["outdir"] = argv[argv.index("-o") + 1]
+            return writes_co_files("k.co")(argv, **kwargs)
+
+        with (
+            patch("shutil.which", which_stub(**{"roc-obj-extract": "/x"})),
+            patch("subprocess.run", _run),
+        ):
+            extract_hsaco_from_binary(binary, "kern", "gfx90a", str(tmp_path / "out.hsaco"))
+
+        assert not os.path.exists(captured["outdir"])
+
+
+# --------------------------------------------------------------------------
+# _find_matching_code_object
+# --------------------------------------------------------------------------
+
+
+def make_co(tmp_path, name: str) -> str:
+    path = tmp_path / name
+    path.write_bytes(b"\x7fELF")
+    return str(path)
+
+
+class TestFindMatchingWithoutNm:
+    """No symbol inspector available — selection falls back to filenames."""
+
+    def test_prefers_an_arch_matching_filename(self, tmp_path):
+        files = [make_co(tmp_path, "other_gfx942.co"), make_co(tmp_path, "kern_gfx90a.co")]
+        with patch("shutil.which", which_stub()):
+            assert _find_matching_code_object(files, "kern", "gfx90a") == files[1]
+
+    def test_falls_back_to_the_first_file(self, tmp_path):
+        files = [make_co(tmp_path, "a.co"), make_co(tmp_path, "b.co")]
+        with patch("shutil.which", which_stub()):
+            assert _find_matching_code_object(files, "kern", "gfx90a") == files[0]
+
+    def test_empty_list_returns_none(self):
+        with patch("shutil.which", which_stub()):
+            assert _find_matching_code_object([], "kern", "gfx90a") is None
+
+
+class TestFindMatchingWithNm:
+    def test_returns_the_object_whose_symbols_contain_the_kernel(self, tmp_path):
+        a = make_co(tmp_path, "a.co")
+        b = make_co(tmp_path, "b.co")
+
+        def _nm(argv, **_kwargs):
+            target = argv[1]
+            out = "T my_kernel\n" if target == b else "T something_else\n"
+            return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+        with (
+            patch("shutil.which", which_stub(**{"llvm-nm": "/usr/bin/llvm-nm"})),
+            patch("subprocess.run", _nm),
+        ):
+            assert _find_matching_code_object([a, b], "my_kernel", "gfx90a") == b
+
+    def test_prefers_llvm_nm_over_nm(self, tmp_path):
+        co = make_co(tmp_path, "a.co")
+        seen = {}
+
+        def _nm(argv, **_kwargs):
+            seen["tool"] = argv[0]
+            return subprocess.CompletedProcess(argv, 0, stdout="T k\n", stderr="")
+
+        with (
+            patch(
+                "shutil.which", which_stub(**{"llvm-nm": "/usr/bin/llvm-nm", "nm": "/usr/bin/nm"})
+            ),
+            patch("subprocess.run", _nm),
+        ):
+            _find_matching_code_object([co], "k", "gfx90a")
+
+        assert seen["tool"] == "/usr/bin/llvm-nm"
+
+    def test_falls_back_to_plain_nm(self, tmp_path):
+        co = make_co(tmp_path, "a.co")
+        seen = {}
+
+        def _nm(argv, **_kwargs):
+            seen["tool"] = argv[0]
+            return subprocess.CompletedProcess(argv, 0, stdout="T k\n", stderr="")
+
+        with (
+            patch("shutil.which", which_stub(**{"nm": "/usr/bin/nm"})),
+            patch("subprocess.run", _nm),
+        ):
+            _find_matching_code_object([co], "k", "gfx90a")
+
+        assert seen["tool"] == "/usr/bin/nm"
+
+    def test_arch_matching_files_are_inspected_first(self, tmp_path):
+        """Ordering matters: the arch-matching object should win a tie."""
+        wrong = make_co(tmp_path, "kern_gfx942.co")
+        right = make_co(tmp_path, "kern_gfx90a.co")
+        order = []
+
+        def _nm(argv, **_kwargs):
+            order.append(os.path.basename(argv[1]))
+            return subprocess.CompletedProcess(argv, 0, stdout="T my_kernel\n", stderr="")
+
+        with (
+            patch("shutil.which", which_stub(**{"nm": "/usr/bin/nm"})),
+            patch("subprocess.run", _nm),
+        ):
+            chosen = _find_matching_code_object([wrong, right], "my_kernel", "gfx90a")
+
+        assert order[0] == "kern_gfx90a.co"
+        assert chosen == right
+
+    def test_nonzero_nm_exit_is_skipped(self, tmp_path):
+        a = make_co(tmp_path, "a.co")
+        b = make_co(tmp_path, "b.co")
+
+        def _nm(argv, **_kwargs):
+            if argv[1] == a:
+                return subprocess.CompletedProcess(argv, 1, stdout="T my_kernel\n", stderr="")
+            return subprocess.CompletedProcess(argv, 0, stdout="T my_kernel\n", stderr="")
+
+        with (
+            patch("shutil.which", which_stub(**{"nm": "/usr/bin/nm"})),
+            patch("subprocess.run", _nm),
+        ):
+            assert _find_matching_code_object([a, b], "my_kernel", "gfx90a") == b
+
+    @pytest.mark.parametrize(
+        "exc", [subprocess.TimeoutExpired("nm", 10), OSError("exec format error")]
+    )
+    def test_nm_exceptions_skip_that_object(self, tmp_path, exc):
+        a = make_co(tmp_path, "a.co")
+        b = make_co(tmp_path, "b.co")
+
+        def _nm(argv, **_kwargs):
+            if argv[1] == a:
+                raise exc
+            return subprocess.CompletedProcess(argv, 0, stdout="T my_kernel\n", stderr="")
+
+        with (
+            patch("shutil.which", which_stub(**{"nm": "/usr/bin/nm"})),
+            patch("subprocess.run", _nm),
+        ):
+            assert _find_matching_code_object([a, b], "my_kernel", "gfx90a") == b
+
+    def test_no_symbol_match_falls_back_to_arch(self, tmp_path):
+        """A best guess is still returned — the caller decides what to do."""
+        other = make_co(tmp_path, "other_gfx942.co")
+        arch = make_co(tmp_path, "other_gfx90a.co")
+
+        def _nm(argv, **_kwargs):
+            return subprocess.CompletedProcess(argv, 0, stdout="T unrelated\n", stderr="")
+
+        with (
+            patch("shutil.which", which_stub(**{"nm": "/usr/bin/nm"})),
+            patch("subprocess.run", _nm),
+        ):
+            assert _find_matching_code_object([other, arch], "missing", "gfx90a") == arch
+
+    def test_no_symbol_and_no_arch_match_returns_first(self, tmp_path):
+        a = make_co(tmp_path, "a.co")
+        b = make_co(tmp_path, "b.co")
+
+        def _nm(argv, **_kwargs):
+            return subprocess.CompletedProcess(argv, 0, stdout="T unrelated\n", stderr="")
+
+        with (
+            patch("shutil.which", which_stub(**{"nm": "/usr/bin/nm"})),
+            patch("subprocess.run", _nm),
+        ):
+            assert _find_matching_code_object([a, b], "missing", "gfx90a") == a
+
+    def test_empty_list_with_nm_returns_none(self):
+        with patch("shutil.which", which_stub(**{"nm": "/usr/bin/nm"})):
+            assert _find_matching_code_object([], "k", "gfx90a") is None

--- a/kerncap/tests/unit/test_profiler.py
+++ b/kerncap/tests/unit/test_profiler.py
@@ -1,13 +1,57 @@
-"""Unit tests for kerncap.profiler — rocprofv3 CSV parsing logic."""
+"""Unit tests for kerncap.profiler — rocprofv3 invocation and CSV parsing.
 
+``run_streaming`` and ``shutil.which`` are stubbed at their call sites so
+``run_profile`` runs with no ROCm and no GPU.  The ``run_streaming`` stub
+reads the ``--output-directory`` out of the argv it is handed and writes a
+real CSV there, which keeps the file-discovery and parsing logic under test
+rather than mocked away.
+"""
+
+import json
 import os
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from kerncap.profiler import parse_kernel_trace_stats
+from kerncap.profiler import (
+    KernelStat,
+    _find_stats_csv,
+    _list_tree,
+    _write_profile_json,
+    parse_kernel_trace_stats,
+    run_profile,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+STATS_CSV = (
+    '"Name","Calls","TotalDurationNs","AverageNs","Percentage","MinNs","MaxNs","StdDev"\n'
+    '"matmul_kernel",1024,580000000,566406,42.3,480000,720000,45000.0\n'
+    '"add_kernel",64,1500000,23437,0.1,20000,30000,1500.0\n'
+)
+
+
+def fake_run_streaming(returncode=0, csv_text=STATS_CSV, subdir="myhost", write_csv=True):
+    """Stand in for ``run_streaming``, materialising rocprofv3's CSV output.
+
+    rocprofv3 writes to ``<output-dir>/<hostname>/<pid>_kernel_stats.csv``,
+    so the stub reproduces that nesting to exercise the rglob in
+    ``_find_stats_csv``.
+    """
+
+    def _run(argv, **kwargs):
+        outdir = argv[argv.index("--output-directory") + 1]
+        if write_csv:
+            nested = Path(outdir) / subdir
+            nested.mkdir(parents=True, exist_ok=True)
+            (nested / "4242_kernel_stats.csv").write_text(csv_text)
+        return subprocess.CompletedProcess(
+            args=list(argv), returncode=returncode, stdout="app output", stderr="app errors"
+        )
+
+    return _run
 
 
 class TestParseKernelTraceStats:
@@ -61,3 +105,248 @@ class TestParseKernelTraceStats:
         csv_file.write_text("foo,bar\n1,2\n")
         with pytest.raises(ValueError, match="kernel name column"):
             parse_kernel_trace_stats(str(csv_file))
+
+    def test_comment_lines_are_stripped(self, tmp_path):
+        """rocprofv3 may prefix the CSV with '#' banner lines."""
+        csv_file = tmp_path / "commented.csv"
+        csv_file.write_text("# rocprofv3 v1\n# generated\n" + STATS_CSV)
+        kernels = parse_kernel_trace_stats(str(csv_file))
+        assert [k.name for k in kernels] == ["matmul_kernel", "add_kernel"]
+
+    def test_rows_without_a_name_are_skipped(self, tmp_path):
+        """Trailing blank rows must not become nameless kernels."""
+        csv_file = tmp_path / "blank.csv"
+        csv_file.write_text(STATS_CSV + '"",0,0,0,0.0,0,0,0.0\n')
+        assert len(parse_kernel_trace_stats(str(csv_file))) == 2
+
+    def test_avg_is_derived_when_the_column_is_absent(self, tmp_path):
+        """Without AverageNs, avg falls back to total // calls."""
+        csv_file = tmp_path / "noavg.csv"
+        csv_file.write_text('"Name","Calls","TotalDurationNs"\n"k",4,1000\n')
+        (kernel,) = parse_kernel_trace_stats(str(csv_file))
+        assert kernel.avg_duration_ns == 250
+
+    def test_derived_avg_does_not_divide_by_zero(self, tmp_path):
+        csv_file = tmp_path / "zero.csv"
+        csv_file.write_text('"Name","Calls","TotalDurationNs"\n"k",0,1000\n')
+        (kernel,) = parse_kernel_trace_stats(str(csv_file))
+        assert kernel.avg_duration_ns == 0
+
+    def test_column_names_are_matched_case_and_space_insensitively(self, tmp_path):
+        csv_file = tmp_path / "loose.csv"
+        csv_file.write_text('  name , Calls , TotalDurationNs \n"k",2,100\n')
+        (kernel,) = parse_kernel_trace_stats(str(csv_file))
+        assert kernel.name == "k"
+        assert kernel.calls == 2
+
+
+# --------------------------------------------------------------------------
+# run_profile
+# --------------------------------------------------------------------------
+
+
+class TestRunProfile:
+    def test_returns_parsed_kernels(self, tmp_path):
+        with (
+            patch("shutil.which", return_value="/opt/rocm/bin/rocprofv3"),
+            patch("kerncap.profiler.run_streaming", fake_run_streaming()),
+        ):
+            kernels = run_profile(["./my_app", "--flag"])
+
+        assert [k.name for k in kernels] == ["matmul_kernel", "add_kernel"]
+        assert kernels[0].total_duration_ns == 580000000
+
+    def test_builds_the_rocprofv3_command(self, tmp_path):
+        """The app command must sit after ``--`` so its flags aren't eaten."""
+        seen = {}
+
+        def _run(argv, **kwargs):
+            seen["argv"] = list(argv)
+            seen["timeout"] = kwargs.get("timeout")
+            return fake_run_streaming()(argv, **kwargs)
+
+        with (
+            patch("shutil.which", return_value="/opt/rocm/bin/rocprofv3"),
+            patch("kerncap.profiler.run_streaming", _run),
+        ):
+            run_profile(["./my_app", "--flag"], timeout=90)
+
+        argv = seen["argv"]
+        assert argv[0] == "/opt/rocm/bin/rocprofv3"
+        assert "--kernel-trace" in argv
+        assert "--stats" in argv
+        assert argv[argv.index("--output-format") + 1] == "csv"
+        assert argv[argv.index("--") + 1 :] == ["./my_app", "--flag"]
+        assert seen["timeout"] == 90
+
+    def test_explicit_rocprof_bin_skips_lookup(self, tmp_path):
+        with (
+            patch("shutil.which") as which,
+            patch("kerncap.profiler.run_streaming", fake_run_streaming()) as _,
+        ):
+            run_profile(["./app"], rocprof_bin="/custom/rocprofv3")
+
+        which.assert_not_called()
+
+    def test_missing_rocprofv3_raises_with_guidance(self):
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(FileNotFoundError, match="rocprofv3 not found on PATH"):
+                run_profile(["./app"])
+
+    def test_timeout_is_translated(self):
+        """subprocess.TimeoutExpired becomes a TimeoutError naming the limit."""
+        with (
+            patch("shutil.which", return_value="/x/rocprofv3"),
+            patch(
+                "kerncap.profiler.run_streaming",
+                side_effect=subprocess.TimeoutExpired("rocprofv3", 30),
+            ),
+        ):
+            with pytest.raises(TimeoutError, match="did not complete within 30s"):
+                run_profile(["./app"], timeout=30)
+
+    def test_nonzero_exit_without_output_raises(self):
+        """No CSV and a bad exit code is a hard failure, with both streams."""
+        with (
+            patch("shutil.which", return_value="/x/rocprofv3"),
+            patch(
+                "kerncap.profiler.run_streaming",
+                fake_run_streaming(returncode=1, write_csv=False),
+            ),
+        ):
+            with pytest.raises(RuntimeError) as exc:
+                run_profile(["./app"])
+
+        assert "exited with code 1" in str(exc.value)
+        assert "app output" in str(exc.value)
+        assert "app errors" in str(exc.value)
+
+    def test_nonzero_exit_with_output_still_succeeds(self):
+        """A crashing app that still produced stats is usable, not fatal.
+
+        This is a distinct branch from the failure above; collapsing the two
+        would throw away a perfectly good profile whenever the workload
+        exits non-zero after the kernels have already run.
+        """
+        with (
+            patch("shutil.which", return_value="/x/rocprofv3"),
+            patch("kerncap.profiler.run_streaming", fake_run_streaming(returncode=139)),
+        ):
+            kernels = run_profile(["./app"])
+
+        assert len(kernels) == 2
+
+    def test_clean_exit_without_csv_raises(self):
+        """Exit 0 but no stats file means rocprofv3 traced nothing."""
+        with (
+            patch("shutil.which", return_value="/x/rocprofv3"),
+            patch("kerncap.profiler.run_streaming", fake_run_streaming(write_csv=False)),
+        ):
+            with pytest.raises(FileNotFoundError, match="did not produce a kernel_stats.csv"):
+                run_profile(["./app"])
+
+    def test_writes_json_when_output_path_given(self, tmp_path):
+        out = tmp_path / "profile.json"
+        with (
+            patch("shutil.which", return_value="/x/rocprofv3"),
+            patch("kerncap.profiler.run_streaming", fake_run_streaming()),
+        ):
+            run_profile(["./my_app", "--flag"], output_path=str(out))
+
+        data = json.loads(out.read_text())
+        assert data["cmd"] == "./my_app --flag"
+        assert [k["name"] for k in data["kernels"]] == ["matmul_kernel", "add_kernel"]
+
+    def test_no_json_written_without_output_path(self, tmp_path):
+        with (
+            patch("shutil.which", return_value="/x/rocprofv3"),
+            patch("kerncap.profiler.run_streaming", fake_run_streaming()),
+        ):
+            run_profile(["./app"])
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_temp_directory_is_cleaned_up(self):
+        captured = {}
+
+        def _run(argv, **kwargs):
+            captured["outdir"] = argv[argv.index("--output-directory") + 1]
+            return fake_run_streaming()(argv, **kwargs)
+
+        with (
+            patch("shutil.which", return_value="/x/rocprofv3"),
+            patch("kerncap.profiler.run_streaming", _run),
+        ):
+            run_profile(["./app"])
+
+        assert "kerncap_prof_" in captured["outdir"]
+        assert not os.path.exists(captured["outdir"])
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+
+class TestFindStatsCsv:
+    def test_finds_a_nested_stats_file(self, tmp_path):
+        """rocprofv3 nests output under <hostname>/<pid>_kernel_stats.csv."""
+        nested = tmp_path / "myhost"
+        nested.mkdir()
+        target = nested / "123_kernel_stats.csv"
+        target.write_text(STATS_CSV)
+
+        assert _find_stats_csv(str(tmp_path)) == str(target)
+
+    def test_returns_none_when_absent(self, tmp_path):
+        (tmp_path / "other.csv").write_text("x")
+        assert _find_stats_csv(str(tmp_path)) is None
+
+
+class TestListTree:
+    def test_lists_files_relative_to_base(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "a.txt").write_text("a")
+        (tmp_path / "b.txt").write_text("b")
+
+        assert sorted(_list_tree(str(tmp_path))) == ["b.txt", os.path.join("sub", "a.txt")]
+
+    def test_directories_are_omitted(self, tmp_path):
+        (tmp_path / "emptydir").mkdir()
+        assert _list_tree(str(tmp_path)) == []
+
+
+class TestWriteProfileJson:
+    def test_writes_every_field(self, tmp_path):
+        out = tmp_path / "p.json"
+        stat = KernelStat(
+            name="k",
+            calls=2,
+            total_duration_ns=100,
+            avg_duration_ns=50,
+            percentage=12.5,
+            min_duration_ns=40,
+            max_duration_ns=60,
+            stddev_ns=7.5,
+        )
+        _write_profile_json([stat], str(out), ["./app", "--x"])
+
+        data = json.loads(out.read_text())
+        assert data["kernels"][0] == {
+            "name": "k",
+            "calls": 2,
+            "total_duration_ns": 100,
+            "avg_duration_ns": 50,
+            "percentage": 12.5,
+            "min_duration_ns": 40,
+            "max_duration_ns": 60,
+            "stddev_ns": 7.5,
+        }
+        assert "timestamp" in data
+
+    def test_command_is_shell_quoted(self, tmp_path):
+        """shlex.join keeps the record copy-pasteable for an argument with spaces."""
+        out = tmp_path / "p.json"
+        _write_profile_json([], str(out), ["./app", "--msg", "hello world"])
+
+        assert json.loads(out.read_text())["cmd"] == "./app --msg 'hello world'"

--- a/kerncap/tests/unit/test_subprocess.py
+++ b/kerncap/tests/unit/test_subprocess.py
@@ -1,0 +1,464 @@
+"""Unit tests for kerncap._subprocess — streaming child output with a bounded tail.
+
+These drive **real** child processes (``/bin/sh``) rather than mocks. What is
+under test here is process and thread behaviour — bounded ring buffers filled
+from pump threads, process-group signalling, a polling watchdog — and a mocked
+``Popen`` would mostly assert the behaviour of the mock.
+
+The children are all sub-second. The two that exercise the watchdog's polling
+loop cost about a second each, which is the price of testing the real thing.
+"""
+
+import collections
+import io
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+from kerncap._subprocess import (
+    _DEFAULT_TAIL_BYTES,
+    _pump,
+    _resolve_sink,
+    _terminate_process_group,
+    _watch_sentinel,
+    run_streaming,
+)
+
+
+def sh(script: str) -> list:
+    """A shell command list, so tests read as the shell they are."""
+    return ["/bin/sh", "-c", script]
+
+
+@pytest.fixture
+def sinks():
+    """Binary stdout/stderr sinks standing in for the parent's terminal."""
+    return io.BytesIO(), io.BytesIO()
+
+
+# --------------------------------------------------------------------------
+# _resolve_sink
+# --------------------------------------------------------------------------
+
+
+class TestResolveSink:
+    def test_explicit_sink_wins(self):
+        explicit = io.BytesIO()
+        assert _resolve_sink(explicit, sys.stdout) is explicit
+
+    def test_prefers_the_binary_buffer_of_a_text_stream(self):
+        class TextStream:
+            buffer = io.BytesIO()
+
+        stream = TextStream()
+        assert _resolve_sink(None, stream) is stream.buffer
+
+    def test_falls_back_to_the_stream_itself(self):
+        """Under pytest capture the replacement stdout may have no .buffer."""
+
+        class NoBuffer:
+            pass
+
+        stream = NoBuffer()
+        assert _resolve_sink(None, stream) is stream
+
+
+# --------------------------------------------------------------------------
+# _pump
+# --------------------------------------------------------------------------
+
+
+class TestPump:
+    def test_copies_to_sink_and_tail(self):
+        src = io.BytesIO(b"hello world")
+        sink = io.BytesIO()
+        tail: collections.deque = collections.deque(maxlen=1024)
+
+        _pump(src, sink, tail)
+
+        assert sink.getvalue() == b"hello world"
+        assert bytes(tail) == b"hello world"
+
+    def test_tail_is_bounded_but_sink_is_not(self):
+        """The ring buffer drops old bytes; the live stream still sees them all."""
+        src = io.BytesIO(b"0123456789")
+        sink = io.BytesIO()
+        tail: collections.deque = collections.deque(maxlen=4)
+
+        _pump(src, sink, tail)
+
+        assert sink.getvalue() == b"0123456789"
+        assert bytes(tail) == b"6789"
+
+    def test_source_is_closed(self):
+        src = io.BytesIO(b"x")
+        _pump(src, io.BytesIO(), collections.deque(maxlen=8))
+        assert src.closed
+
+    def test_a_broken_sink_does_not_lose_the_tail(self):
+        """If the terminal goes away the diagnostics must still be captured."""
+
+        class BrokenSink:
+            def write(self, _chunk):
+                raise BrokenPipeError("gone")
+
+            def flush(self):
+                pass
+
+        src = io.BytesIO(b"important diagnostics")
+        tail: collections.deque = collections.deque(maxlen=1024)
+
+        _pump(src, BrokenSink(), tail)
+
+        assert bytes(tail) == b"important diagnostics"
+
+    def test_a_closed_sink_does_not_raise(self):
+        sink = io.BytesIO()
+        sink.close()
+        tail: collections.deque = collections.deque(maxlen=64)
+
+        _pump(io.BytesIO(b"data"), sink, tail)
+
+        assert bytes(tail) == b"data"
+
+
+# --------------------------------------------------------------------------
+# run_streaming — basics
+# --------------------------------------------------------------------------
+
+
+class TestRunStreamingBasics:
+    def test_captures_stdout_stderr_and_returncode(self, sinks):
+        out, err = sinks
+        proc = run_streaming(
+            sh("printf out; printf err >&2; exit 3"), stdout_sink=out, stderr_sink=err
+        )
+
+        assert proc.returncode == 3
+        assert proc.stdout == "out"
+        assert proc.stderr == "err"
+
+    def test_is_shape_compatible_with_completedprocess(self, sinks):
+        out, err = sinks
+        cmd = sh("true")
+        proc = run_streaming(cmd, stdout_sink=out, stderr_sink=err)
+
+        assert isinstance(proc, subprocess.CompletedProcess)
+        assert proc.args == cmd
+
+    def test_streams_live_to_the_sinks(self, sinks):
+        """The whole point: the user sees output as it happens, not at exit."""
+        out, err = sinks
+        run_streaming(sh("printf hello; printf oops >&2"), stdout_sink=out, stderr_sink=err)
+
+        assert out.getvalue() == b"hello"
+        assert err.getvalue() == b"oops"
+
+    def test_undecodable_bytes_do_not_raise(self, sinks):
+        """A chatty child may emit binary junk; it must not kill the run.
+
+        Octal escapes, not ``\\x``: POSIX ``printf`` in dash does not accept
+        hex escapes and would emit them literally.
+        """
+        out, err = sinks
+        proc = run_streaming(sh(r"printf '\377\376'"), stdout_sink=out, stderr_sink=err)
+
+        assert proc.returncode == 0
+        assert out.getvalue() == b"\xff\xfe"
+        # errors="replace" — the tail is decoded lossily rather than raising.
+        assert proc.stdout == "��"
+
+    def test_env_replaces_the_inherited_environment(self, sinks):
+        out, err = sinks
+        proc = run_streaming(
+            sh('printf %s "$KERNCAP_TEST_VAR"'),
+            env={"KERNCAP_TEST_VAR": "injected"},
+            stdout_sink=out,
+            stderr_sink=err,
+        )
+
+        assert proc.stdout == "injected"
+
+    def test_without_env_the_child_inherits(self, sinks, monkeypatch):
+        monkeypatch.setenv("KERNCAP_INHERITED", "yes")
+        out, err = sinks
+        proc = run_streaming(sh('printf %s "$KERNCAP_INHERITED"'), stdout_sink=out, stderr_sink=err)
+
+        assert proc.stdout == "yes"
+
+    def test_child_runs_in_its_own_session(self, sinks):
+        """start_new_session is what makes process-group signalling reach workers."""
+        out, err = sinks
+        proc = run_streaming(sh("ps -o sid= -p $$"), stdout_sink=out, stderr_sink=err)
+
+        assert proc.stdout.strip()
+        assert int(proc.stdout.strip()) != os.getsid(0)
+
+
+# --------------------------------------------------------------------------
+# run_streaming — tail bounding
+# --------------------------------------------------------------------------
+
+
+class TestTailBounding:
+    def test_tail_bytes_truncates_to_the_last_n(self, sinks):
+        out, err = sinks
+        proc = run_streaming(
+            sh("printf 0123456789ABCDEFGHIJ"), tail_bytes=5, stdout_sink=out, stderr_sink=err
+        )
+
+        assert proc.stdout == "FGHIJ"
+        # The live stream is unbounded — only the retained tail is capped.
+        assert out.getvalue() == b"0123456789ABCDEFGHIJ"
+
+    def test_stdout_and_stderr_are_bounded_independently(self, sinks):
+        out, err = sinks
+        proc = run_streaming(
+            sh("printf aaaaaa; printf bbbbbb >&2"),
+            tail_bytes=2,
+            stdout_sink=out,
+            stderr_sink=err,
+        )
+
+        assert proc.stdout == "aa"
+        assert proc.stderr == "bb"
+
+    def test_env_var_overrides_the_argument(self, sinks, monkeypatch):
+        monkeypatch.setenv("KERNCAP_TAIL_BYTES", "3")
+        out, err = sinks
+        proc = run_streaming(
+            sh("printf 0123456789"), tail_bytes=1024, stdout_sink=out, stderr_sink=err
+        )
+
+        assert proc.stdout == "789"
+
+    def test_unparseable_env_var_is_ignored(self, sinks, monkeypatch):
+        """A typo in the env var must not crash a long profiling run."""
+        monkeypatch.setenv("KERNCAP_TAIL_BYTES", "not-a-number")
+        out, err = sinks
+        proc = run_streaming(
+            sh("printf 0123456789"), tail_bytes=4, stdout_sink=out, stderr_sink=err
+        )
+
+        assert proc.stdout == "6789"
+
+    def test_empty_env_var_is_ignored(self, sinks, monkeypatch):
+        monkeypatch.setenv("KERNCAP_TAIL_BYTES", "")
+        out, err = sinks
+        proc = run_streaming(
+            sh("printf 0123456789"), tail_bytes=4, stdout_sink=out, stderr_sink=err
+        )
+
+        assert proc.stdout == "6789"
+
+    def test_negative_env_var_clamps_to_zero(self, sinks, monkeypatch):
+        """max(0, ...) — a negative maxlen would be a ValueError from deque."""
+        monkeypatch.setenv("KERNCAP_TAIL_BYTES", "-5")
+        out, err = sinks
+        proc = run_streaming(sh("printf hello"), stdout_sink=out, stderr_sink=err)
+
+        assert proc.stdout == ""
+        assert out.getvalue() == b"hello"
+
+    def test_default_tail_is_64_kib(self):
+        assert _DEFAULT_TAIL_BYTES == 64 * 1024
+
+
+# --------------------------------------------------------------------------
+# run_streaming — timeout
+# --------------------------------------------------------------------------
+
+
+class TestTimeout:
+    def test_timeout_raises_with_partial_output_attached(self, sinks):
+        """The diagnostics gathered before the timeout must survive it."""
+        out, err = sinks
+        with pytest.raises(subprocess.TimeoutExpired) as exc:
+            run_streaming(
+                sh("printf partial; printf trouble >&2; sleep 30"),
+                timeout=1.5,
+                stdout_sink=out,
+                stderr_sink=err,
+            )
+
+        assert "partial" in (exc.value.output or "")
+        assert "trouble" in (exc.value.stderr or "")
+
+    def test_timeout_kills_the_child(self, sinks):
+        out, err = sinks
+        start = time.monotonic()
+        with pytest.raises(subprocess.TimeoutExpired):
+            run_streaming(sh("sleep 30"), timeout=1.0, stdout_sink=out, stderr_sink=err)
+
+        # Must not have waited for the 30s child.
+        assert time.monotonic() - start < 15
+
+    def test_no_timeout_waits_for_completion(self, sinks):
+        out, err = sinks
+        proc = run_streaming(sh("sleep 0.2; printf done"), stdout_sink=out, stderr_sink=err)
+        assert proc.stdout == "done"
+
+
+# --------------------------------------------------------------------------
+# _terminate_process_group
+# --------------------------------------------------------------------------
+
+
+class TestTerminateProcessGroup:
+    def test_kills_the_whole_group(self):
+        """A child that spawns a grandchild: signalling the leader is not enough."""
+        proc = subprocess.Popen(
+            sh("sleep 30 & sleep 30"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        pgid = os.getpgid(proc.pid)
+
+        _terminate_process_group(proc)
+
+        assert proc.poll() is not None
+        # The group is gone; signalling it again must fail.
+        with pytest.raises(ProcessLookupError):
+            os.killpg(pgid, 0)
+        proc.stdout.close()
+        proc.stderr.close()
+
+    def test_escalates_to_sigkill_when_sigterm_is_ignored(self):
+        """A child trapping SIGTERM must still be killed."""
+        proc = subprocess.Popen(
+            sh("trap '' TERM; sleep 30"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        time.sleep(0.3)  # let the trap install
+
+        _terminate_process_group(proc)
+
+        assert proc.poll() is not None
+        assert proc.returncode == -signal.SIGKILL
+        proc.stdout.close()
+        proc.stderr.close()
+
+    def test_falls_back_to_signalling_the_process_directly(self, monkeypatch):
+        """If the pgid cannot be read, the leader is still signalled."""
+        proc = subprocess.Popen(
+            sh("sleep 30"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        monkeypatch.setattr(os, "getpgid", lambda _pid: (_ for _ in ()).throw(ProcessLookupError()))
+
+        _terminate_process_group(proc)
+
+        assert proc.poll() is not None
+        proc.stdout.close()
+        proc.stderr.close()
+
+    def test_already_dead_process_is_a_noop(self):
+        proc = subprocess.Popen(
+            sh("true"), stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True
+        )
+        proc.wait()
+
+        _terminate_process_group(proc)  # must not raise
+
+        proc.stdout.close()
+        proc.stderr.close()
+
+
+# --------------------------------------------------------------------------
+# _watch_sentinel / completion_sentinel
+# --------------------------------------------------------------------------
+
+
+class TestWatchSentinel:
+    def test_returns_when_the_process_exits_on_its_own(self, tmp_path):
+        proc = subprocess.Popen(
+            sh("true"), stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True
+        )
+        proc.wait()
+        stop = threading.Event()
+
+        _watch_sentinel(proc, str(tmp_path / "never"), stop)  # must return, not hang
+
+        proc.stdout.close()
+        proc.stderr.close()
+
+    def test_stop_event_ends_the_watch(self, tmp_path):
+        proc = subprocess.Popen(
+            sh("sleep 30"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        stop = threading.Event()
+        stop.set()
+
+        _watch_sentinel(proc, str(tmp_path / "never"), stop)
+
+        assert proc.poll() is None  # untouched
+        _terminate_process_group(proc)
+        proc.stdout.close()
+        proc.stderr.close()
+
+
+class TestCompletionSentinel:
+    def test_preexisting_sentinel_terminates_immediately(self, tmp_path, sinks):
+        """The artifacts are already on disk, so the host need not finish."""
+        sentinel = tmp_path / "done.marker"
+        sentinel.write_text("")
+        out, err = sinks
+
+        start = time.monotonic()
+        proc = run_streaming(
+            sh("sleep 30"),
+            completion_sentinel=str(sentinel),
+            stdout_sink=out,
+            stderr_sink=err,
+        )
+
+        assert time.monotonic() - start < 15
+        assert proc.returncode < 0  # killed by signal, not a clean exit
+
+    def test_sentinel_written_by_the_child_terminates_the_run(self, tmp_path, sinks):
+        """The real shape: capture completes mid-run and drops the marker."""
+        sentinel = tmp_path / "done.marker"
+        out, err = sinks
+
+        start = time.monotonic()
+        proc = run_streaming(
+            sh(f"printf captured; touch {sentinel}; sleep 30"),
+            completion_sentinel=str(sentinel),
+            stdout_sink=out,
+            stderr_sink=err,
+        )
+
+        assert time.monotonic() - start < 20
+        assert proc.stdout == "captured"
+        assert proc.returncode < 0
+
+    def test_no_sentinel_leaves_a_short_child_alone(self, sinks):
+        out, err = sinks
+        proc = run_streaming(sh("printf ok"), stdout_sink=out, stderr_sink=err)
+        assert proc.returncode == 0
+        assert proc.stdout == "ok"
+
+    def test_sentinel_that_never_appears_lets_the_child_finish(self, tmp_path, sinks):
+        out, err = sinks
+        proc = run_streaming(
+            sh("printf finished"),
+            completion_sentinel=str(tmp_path / "never"),
+            stdout_sink=out,
+            stderr_sink=err,
+        )
+
+        assert proc.returncode == 0
+        assert proc.stdout == "finished"

--- a/kerncap/tests/unit/test_triton_capture.py
+++ b/kerncap/tests/unit/test_triton_capture.py
@@ -1,0 +1,389 @@
+"""Unit tests for the two Triton capture backends' injection contracts.
+
+Neither backend can be verified by its return value — both just hand back
+``output_dir``. What actually determines whether a capture works is the
+environment they build for the child: ``LD_PRELOAD``, ``PYTHONPATH``, and the
+``KERNCAP_*`` variables the compile shim and ``libkerncap.so`` read. If one of
+those silently stops being injected, capture produces nothing and the failure
+surfaces far away from the cause.
+
+So that environment is what these tests assert. ``run_streaming`` is stubbed at
+its call site and records the env it was handed; no GPU, no ROCm, no Triton.
+"""
+
+import os
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from kerncap.triton_capture import run_triton_capture
+from kerncap.triton_capture_hsa import _maybe_clear_triton_caches, run_triton_capture_hsa
+
+
+class Recorder:
+    """A ``run_streaming`` stub that records its call and fakes the artifacts."""
+
+    def __init__(self, artifacts=("metadata.json",), returncode=0, raises=None):
+        self.artifacts = artifacts
+        self.returncode = returncode
+        self.raises = raises
+        self.cmd = None
+        self.env = None
+        self.kwargs = None
+
+    def __call__(self, cmd, **kwargs):
+        self.cmd = list(cmd)
+        self.env = dict(kwargs.get("env") or {})
+        self.kwargs = kwargs
+        if self.raises is not None:
+            raise self.raises
+        out = self.env.get("KERNCAP_OUTPUT")
+        for name in self.artifacts:
+            with open(os.path.join(out, name), "w") as fh:
+                fh.write("{}")
+        return subprocess.CompletedProcess(
+            args=list(cmd), returncode=self.returncode, stdout="app out", stderr="app err"
+        )
+
+
+# --------------------------------------------------------------------------
+# run_triton_capture — the legacy python backend
+# --------------------------------------------------------------------------
+
+
+class TestRunTritonCapture:
+    def test_returns_the_output_dir_and_creates_it(self, tmp_path):
+        out = tmp_path / "cap"
+        rec = Recorder()
+        with patch("kerncap.triton_capture.run_streaming", rec):
+            assert run_triton_capture("k", ["python", "b.py"], str(out)) == str(out)
+        assert out.is_dir()
+
+    def test_command_is_passed_through_unwrapped(self, tmp_path):
+        """No runpy wrapper — anything that eventually runs Triton is hooked."""
+        rec = Recorder()
+        with patch("kerncap.triton_capture.run_streaming", rec):
+            run_triton_capture("k", ["vllm", "serve", "model"], str(tmp_path / "cap"))
+
+        assert rec.cmd == ["vllm", "serve", "model"]
+
+    def test_injects_the_kernel_and_output_variables(self, tmp_path):
+        out = tmp_path / "cap"
+        rec = Recorder()
+        with patch("kerncap.triton_capture.run_streaming", rec):
+            run_triton_capture("my_kernel", ["python", "b.py"], str(out))
+
+        assert rec.env["KERNCAP_KERNEL"] == "my_kernel"
+        assert rec.env["KERNCAP_OUTPUT"] == str(out)
+
+    def test_pythonpath_points_at_the_sitecustomize_dir(self, tmp_path):
+        """This is the mechanism: every interpreter imports sitecustomize."""
+        rec = Recorder()
+        with patch("kerncap.triton_capture.run_streaming", rec):
+            run_triton_capture("k", ["python", "b.py"], str(tmp_path / "cap"))
+
+        site_dir = rec.env["PYTHONPATH"].split(os.pathsep)[0]
+        assert "kerncap_site_" in site_dir
+        assert rec.env["_KERNCAP_TRITON_HOOK"].startswith(site_dir)
+
+    def test_existing_pythonpath_is_preserved(self, tmp_path, monkeypatch):
+        """Clobbering the user's PYTHONPATH would break their imports."""
+        monkeypatch.setenv("PYTHONPATH", "/user/libs")
+        rec = Recorder()
+        with patch("kerncap.triton_capture.run_streaming", rec):
+            run_triton_capture("k", ["python", "b.py"], str(tmp_path / "cap"))
+
+        parts = rec.env["PYTHONPATH"].split(os.pathsep)
+        assert len(parts) == 2
+        assert parts[1] == "/user/libs"
+
+    def test_sitecustomize_and_hook_are_written(self, tmp_path):
+        """Captured while the call is in flight — the dir is removed after."""
+        contents = {}
+        rec = Recorder()
+
+        def _capture_files(cmd, **kwargs):
+            site_dir = kwargs["env"]["PYTHONPATH"].split(os.pathsep)[0]
+            hook = kwargs["env"]["_KERNCAP_TRITON_HOOK"]
+            contents["site"] = open(os.path.join(site_dir, "sitecustomize.py")).read()
+            contents["hook"] = open(hook).read()
+            return rec(cmd, **kwargs)
+
+        with patch("kerncap.triton_capture.run_streaming", _capture_files):
+            run_triton_capture("k", ["python", "b.py"], str(tmp_path / "cap"))
+
+        assert contents["site"].strip()
+        assert contents["hook"].strip()
+
+    def test_dispatch_is_only_set_when_non_negative(self, tmp_path):
+        """-1 means 'first match' and must not pin a dispatch index."""
+        rec = Recorder()
+        with patch("kerncap.triton_capture.run_streaming", rec):
+            run_triton_capture("k", ["python", "b.py"], str(tmp_path / "a"), dispatch=-1)
+        assert "KERNCAP_DISPATCH" not in rec.env
+
+        rec2 = Recorder()
+        with patch("kerncap.triton_capture.run_streaming", rec2):
+            run_triton_capture("k", ["python", "b.py"], str(tmp_path / "b"), dispatch=0)
+        assert rec2.env["KERNCAP_DISPATCH"] == "0"
+
+    def test_timeout_is_forwarded_and_translated(self, tmp_path):
+        rec = Recorder()
+        with patch("kerncap.triton_capture.run_streaming", rec):
+            run_triton_capture("k", ["python", "b.py"], str(tmp_path / "cap"), timeout=45)
+        assert rec.kwargs["timeout"] == 45
+
+        boom = Recorder(raises=subprocess.TimeoutExpired("python", 45))
+        with patch("kerncap.triton_capture.run_streaming", boom):
+            with pytest.raises(TimeoutError, match="did not complete within 45s"):
+                run_triton_capture("k", ["python", "b.py"], str(tmp_path / "c2"), timeout=45)
+
+    def test_missing_metadata_raises_with_output_tails(self, tmp_path):
+        """The child's own output is the only clue why the hook never fired."""
+        rec = Recorder(artifacts=())
+        with patch("kerncap.triton_capture.run_streaming", rec):
+            with pytest.raises(RuntimeError) as exc:
+                run_triton_capture("k", ["python", "b.py"], str(tmp_path / "cap"))
+
+        assert "did not produce metadata.json" in str(exc.value)
+        assert "app out" in str(exc.value)
+        assert "app err" in str(exc.value)
+
+    def test_temp_site_dir_is_always_cleaned_up(self, tmp_path):
+        """Including on the failure path — the finally block."""
+        seen = {}
+
+        def _run(cmd, **kwargs):
+            seen["site"] = kwargs["env"]["PYTHONPATH"].split(os.pathsep)[0]
+            raise RuntimeError("boom")
+
+        with patch("kerncap.triton_capture.run_streaming", _run):
+            with pytest.raises(RuntimeError):
+                run_triton_capture("k", ["python", "b.py"], str(tmp_path / "cap"))
+
+        assert not os.path.exists(seen["site"])
+
+
+# --------------------------------------------------------------------------
+# _maybe_clear_triton_caches
+# --------------------------------------------------------------------------
+
+
+class TestMaybeClearTritonCaches:
+    def test_clears_the_cache_under_triton_home(self, tmp_path, monkeypatch):
+        """A cache hit means the compile shim never fires and name_map is empty."""
+        monkeypatch.setenv("TRITON_HOME", str(tmp_path))
+        monkeypatch.delenv("KERNCAP_NO_CLEAR_TRITON_CACHE", raising=False)
+        cache = tmp_path / ".triton" / "cache"
+        cache.mkdir(parents=True)
+        (cache / "entry").write_text("x")
+
+        _maybe_clear_triton_caches()
+
+        assert not cache.exists()
+
+    def test_opt_out_leaves_the_cache_alone(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TRITON_HOME", str(tmp_path))
+        monkeypatch.setenv("KERNCAP_NO_CLEAR_TRITON_CACHE", "1")
+        cache = tmp_path / ".triton" / "cache"
+        cache.mkdir(parents=True)
+
+        _maybe_clear_triton_caches()
+
+        assert cache.exists()
+
+    def test_only_the_exact_opt_out_value_counts(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TRITON_HOME", str(tmp_path))
+        monkeypatch.setenv("KERNCAP_NO_CLEAR_TRITON_CACHE", "yes")
+        cache = tmp_path / ".triton" / "cache"
+        cache.mkdir(parents=True)
+
+        _maybe_clear_triton_caches()
+
+        assert not cache.exists()
+
+    def test_falls_back_to_the_home_directory(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("TRITON_HOME", raising=False)
+        monkeypatch.delenv("KERNCAP_NO_CLEAR_TRITON_CACHE", raising=False)
+        monkeypatch.setattr(os.path, "expanduser", lambda _p: str(tmp_path))
+        cache = tmp_path / ".triton" / "cache"
+        cache.mkdir(parents=True)
+
+        _maybe_clear_triton_caches()
+
+        assert not cache.exists()
+
+    def test_absent_cache_is_a_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TRITON_HOME", str(tmp_path))
+        monkeypatch.delenv("KERNCAP_NO_CLEAR_TRITON_CACHE", raising=False)
+
+        _maybe_clear_triton_caches()  # must not raise
+
+    def test_removal_failure_is_swallowed(self, tmp_path, monkeypatch):
+        """A read-only cache must not abort the capture."""
+        monkeypatch.setenv("TRITON_HOME", str(tmp_path))
+        monkeypatch.delenv("KERNCAP_NO_CLEAR_TRITON_CACHE", raising=False)
+        (tmp_path / ".triton" / "cache").mkdir(parents=True)
+
+        with patch("shutil.rmtree", side_effect=OSError("read-only")):
+            _maybe_clear_triton_caches()  # must not raise
+
+
+# --------------------------------------------------------------------------
+# run_triton_capture_hsa — the default backend
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def lib(tmp_path):
+    """A stand-in libkerncap.so path, patched into _get_lib_path."""
+    path = tmp_path / "libkerncap.so"
+    path.write_bytes(b"\x7fELF")
+    return str(path)
+
+
+@pytest.fixture(autouse=True)
+def no_cache_clearing(monkeypatch):
+    """Never touch the developer's real ~/.triton/cache from these tests."""
+    monkeypatch.setenv("KERNCAP_NO_CLEAR_TRITON_CACHE", "1")
+
+
+def run_hsa(rec, lib, out, **kwargs):
+    with (
+        patch("kerncap._get_lib_path", return_value=lib),
+        patch("kerncap.triton_capture_hsa.run_streaming", rec),
+    ):
+        return run_triton_capture_hsa("k", ["python", "b.py"], str(out), **kwargs)
+
+
+class TestRunTritonCaptureHsa:
+    def test_returns_the_output_dir(self, tmp_path, lib):
+        out = tmp_path / "cap"
+        assert run_hsa(Recorder(), lib, out) == str(out)
+
+    def test_ld_preload_is_set_to_the_library(self, tmp_path, lib):
+        """Without LD_PRELOAD nothing is intercepted at all."""
+        rec = Recorder()
+        run_hsa(rec, lib, tmp_path / "cap")
+
+        assert rec.env["LD_PRELOAD"] == lib
+
+    def test_existing_ld_preload_is_prepended_not_replaced(self, tmp_path, lib, monkeypatch):
+        monkeypatch.setenv("LD_PRELOAD", "/other/lib.so")
+        rec = Recorder()
+        run_hsa(rec, lib, tmp_path / "cap")
+
+        assert rec.env["LD_PRELOAD"] == f"{lib}:/other/lib.so"
+
+    @pytest.mark.parametrize("var", ["HSA_TOOLS_LIB", "HSA_TOOLS_REPORT_LOAD_FAILURE"])
+    def test_inherited_hsa_tools_variables_are_stripped(self, tmp_path, lib, monkeypatch, var):
+        """A leftover HSA_TOOLS_LIB would load a second, conflicting tool."""
+        monkeypatch.setenv(var, "/some/other/tool.so")
+        rec = Recorder()
+        run_hsa(rec, lib, tmp_path / "cap")
+
+        assert var not in rec.env
+
+    def test_injects_the_full_kerncap_contract(self, tmp_path, lib):
+        out = tmp_path / "cap"
+        rec = Recorder()
+        run_hsa(rec, lib, out)
+
+        assert rec.env["KERNCAP_KERNEL"] == "k"
+        assert rec.env["KERNCAP_OUTPUT"] == str(out)
+        assert rec.env["KERNCAP_CAPTURE_CHILD"] == "1"
+        assert rec.env["KERNCAP_TRITON_NAME_MAP"] == str(out / "name_map.json")
+        assert rec.env["KERNCAP_TRITON_HSACO_DIR"] == str(out / "triton_hsacos")
+        assert rec.env["KERNCAP_TRITON_SOURCE_DIR"] == str(out / "triton_sources")
+
+    def test_artifact_directories_are_created_up_front(self, tmp_path, lib):
+        """The shim writes into these from inside the child; they must exist."""
+        out = tmp_path / "cap"
+        run_hsa(Recorder(), lib, out)
+
+        assert (out / "triton_hsacos").is_dir()
+        assert (out / "triton_sources").is_dir()
+
+    def test_pythonpath_carries_the_hsa_hook(self, tmp_path, lib):
+        rec = Recorder()
+        run_hsa(rec, lib, tmp_path / "cap")
+
+        site_dir = rec.env["PYTHONPATH"].split(os.pathsep)[0]
+        assert "kerncap_site_hsa_" in site_dir
+        assert rec.env["_KERNCAP_TRITON_HSA_HOOK"].startswith(site_dir)
+
+    def test_existing_pythonpath_is_preserved(self, tmp_path, lib, monkeypatch):
+        monkeypatch.setenv("PYTHONPATH", "/user/libs")
+        rec = Recorder()
+        run_hsa(rec, lib, tmp_path / "cap")
+
+        assert rec.env["PYTHONPATH"].split(os.pathsep)[1] == "/user/libs"
+
+    def test_completion_sentinel_is_passed(self, tmp_path, lib):
+        """This is what lets a long-lived host be killed once artifacts land."""
+        out = tmp_path / "cap"
+        rec = Recorder()
+        run_hsa(rec, lib, out)
+
+        assert rec.kwargs["completion_sentinel"] == str(out / "capture_complete")
+
+    def test_dispatch_is_only_set_when_non_negative(self, tmp_path, lib):
+        rec = Recorder()
+        run_hsa(rec, lib, tmp_path / "a", dispatch=-1)
+        assert "KERNCAP_DISPATCH" not in rec.env
+
+        rec2 = Recorder()
+        run_hsa(rec2, lib, tmp_path / "b", dispatch=3)
+        assert rec2.env["KERNCAP_DISPATCH"] == "3"
+
+    @pytest.mark.parametrize("artifact", ["dispatch.json", "metadata.json"])
+    def test_either_artifact_satisfies_the_check(self, tmp_path, lib, artifact):
+        """The HSA path may write either; requiring both would be wrong."""
+        out = tmp_path / "cap"
+        assert run_hsa(Recorder(artifacts=(artifact,)), lib, out) == str(out)
+
+    def test_neither_artifact_raises_with_output_tails(self, tmp_path, lib):
+        with pytest.raises(RuntimeError) as exc:
+            run_hsa(Recorder(artifacts=()), lib, tmp_path / "cap")
+
+        assert "did not produce metadata.json/dispatch.json" in str(exc.value)
+        assert "app out" in str(exc.value)
+        assert "app err" in str(exc.value)
+
+    def test_a_sentinel_killed_child_is_not_an_error(self, tmp_path, lib):
+        """The watchdog kills with a signal; artifacts on disk mean success."""
+        out = tmp_path / "cap"
+        rec = Recorder(returncode=-15)
+
+        assert run_hsa(rec, lib, out) == str(out)
+
+    def test_timeout_is_forwarded_and_translated(self, tmp_path, lib):
+        rec = Recorder()
+        run_hsa(rec, lib, tmp_path / "cap", timeout=60)
+        assert rec.kwargs["timeout"] == 60
+
+        boom = Recorder(raises=subprocess.TimeoutExpired("python", 60))
+        with pytest.raises(TimeoutError, match="did not complete within 60s"):
+            run_hsa(boom, lib, tmp_path / "c2", timeout=60)
+
+    def test_temp_site_dir_is_always_cleaned_up(self, tmp_path, lib):
+        seen = {}
+
+        def _run(cmd, **kwargs):
+            seen["site"] = kwargs["env"]["PYTHONPATH"].split(os.pathsep)[0]
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            run_hsa(_run, lib, tmp_path / "cap")
+
+        assert not os.path.exists(seen["site"])
+
+    def test_a_missing_library_propagates(self, tmp_path):
+        """No libkerncap.so means the HSA backend cannot work at all."""
+        with (
+            patch("kerncap._get_lib_path", side_effect=FileNotFoundError("libkerncap.so")),
+            patch("kerncap.triton_capture_hsa.run_streaming", Recorder()) as _,
+        ):
+            with pytest.raises(FileNotFoundError):
+                run_triton_capture_hsa("k", ["python", "b.py"], str(tmp_path / "cap"))


### PR DESCRIPTION
Part 2 of 2, following #162, #161 and #158. Part 1 is <PR1-number>; **base this
on that branch**, not `main`.

Raises kerncap source coverage from **67% to 84%**. 204 new tests, 511 pass in
~13s.

⚠️ **Unlike the rest of this series, this PR contains one source change** —
isolated in its own commit (`b14d495`), 4 lines plus a comment. Details below;
skip it if you would rather it landed separately.

| module | stmts | before | after |
|---|---:|---:|---:|
| `extract.py` | 238 | 26% | **100%** |
| `hsaco_extractor.py` | 57 | **0%** | **100%** |
| `profiler.py` | 90 | 64% | **100%** |
| `triton_capture.py` | 41 | 29% | **100%** |
| `triton_capture_hsa.py` | 72 | 19% | **100%** |
| `_subprocess.py` | 103 | 17% | **91%** |
| **TOTAL** | **2452** | **67%** | **84%** |

**430 statements newly covered.** Across both PRs kerncap goes 58% → 84%.

## The one source change

`_generate_reproducer` falls back to the HSACO-only HIP harness when the
editable Triton reproducer cannot be generated. The label it returned depended
on how the language had been determined rather than on what was generated:
`_generate_hsaco` returns `language or "hip"`, so an explicit
`--language triton` came back as `"triton"` while the same capture
auto-detected from metadata came back as `"hip"`.

The `"triton"` case is the harmful one. `ExtractResult.language` is what
`cli._print_next_steps` keys off, and for `"triton"` it tells the user to run
`python3 reproducer.py` — a file this path never writes. The fallback emits
`capture/` and a `Makefile`, nothing else.

The fallback now normalises to `"hip"`, so the label describes the artifact
produced rather than the language the kernel was written in. Source finding is
untouched — `_generate_hsaco` still receives the caller's `language`, only the
returned label is normalised.

[...Approach / Three things this surfaced / Deliberately not covered sections
unchanged, minus the now-fixed bullet...]

## Test plan

**AMD Instinct MI210, ROCm 7.2.3, Python 3.12.3**, via Slurm. `kerncap` installed as CI installs it
(`pip install -e kerncap`), so `libkerncap.so` is built from `src/` against ROCm.

```
before (ece8d91):  307 passed, 0 skipped   67%   (2450 stmts, 813 missed)
after  (b14d495):  511 passed, 0 skipped   84%   (2452 stmts, 385 missed)
```

Zero skips in either leg: with `libkerncap.so` really built, the
`test_kernarg_metadata.py` tests that drive the C kernarg parser through ctypes
execute rather than skipping.

Note `_subprocess.py` reads 90% or 91% run to run — one of the signal-race
handlers lands either way, which moves the total between 84% and 85%. The
figures above are the hardware run.

Pre-existing integration suite, same node, unaffected: `16 passed, 3 skipped,
2 deselected in 27.35s`.

`ruff check` and `ruff format --check` clean at **0.15.22** from the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)