### PR TITLE
Reset workspace ownership at the start of self-hosted jobs

### DIFF
--- a/.github/workflows/intellikit-ci-test.yml
+++ b/.github/workflows/intellikit-ci-test.yml
@@ -70,6 +70,18 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Reset workspace ownership
+        # Containers run as root, so a job that is cancelled, superseded or
+        # killed leaves root-owned build artifacts behind. actions/checkout
+        # wipes the workspace before every run and cannot delete them, so the
+        # NEXT job fails at checkout with EACCES -- on a PR that did nothing
+        # wrong. Reset at the start, where it runs no matter how the previous
+        # job ended; a chown after the command only runs on the happy path.
+        run: |
+          if [ -d "${{ github.workspace }}" ] && command -v docker >/dev/null; then
+            docker run --rm -v "${{ github.workspace }}:/w" alpine:latest \
+              chown -R "$(id -u):$(id -g)" /w 2>/dev/null || true
+          fi
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -89,6 +101,18 @@ jobs:
         install_method: [editable, non-editable, github]
 
     steps:
+      - name: Reset workspace ownership
+        # Containers run as root, so a job that is cancelled, superseded or
+        # killed leaves root-owned build artifacts behind. actions/checkout
+        # wipes the workspace before every run and cannot delete them, so the
+        # NEXT job fails at checkout with EACCES -- on a PR that did nothing
+        # wrong. Reset at the start, where it runs no matter how the previous
+        # job ended; a chown after the command only runs on the happy path.
+        run: |
+          if [ -d "${{ github.workspace }}" ] && command -v docker >/dev/null; then
+            docker run --rm -v "${{ github.workspace }}:/w" alpine:latest \
+              chown -R "$(id -u):$(id -g)" /w 2>/dev/null || true
+          fi
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/intellikit-pytest.yml
+++ b/.github/workflows/intellikit-pytest.yml
@@ -70,6 +70,18 @@ jobs:
     runs-on: [self-hosted, mi3xx]
     timeout-minutes: 30
     steps:
+      - name: Reset workspace ownership
+        # Containers run as root, so a job that is cancelled, superseded or
+        # killed leaves root-owned build artifacts behind. actions/checkout
+        # wipes the workspace before every run and cannot delete them, so the
+        # NEXT job fails at checkout with EACCES -- on a PR that did nothing
+        # wrong. Reset at the start, where it runs no matter how the previous
+        # job ended; a chown after the command only runs on the happy path.
+        run: |
+          if [ -d "${{ github.workspace }}" ] && command -v docker >/dev/null; then
+            docker run --rm -v "${{ github.workspace }}:/w" alpine:latest \
+              chown -R "$(id -u):$(id -g)" /w 2>/dev/null || true
+          fi
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -89,6 +101,18 @@ jobs:
         install_method: [editable, non-editable]
 
     steps:
+      - name: Reset workspace ownership
+        # Containers run as root, so a job that is cancelled, superseded or
+        # killed leaves root-owned build artifacts behind. actions/checkout
+        # wipes the workspace before every run and cannot delete them, so the
+        # NEXT job fails at checkout with EACCES -- on a PR that did nothing
+        # wrong. Reset at the start, where it runs no matter how the previous
+        # job ended; a chown after the command only runs on the happy path.
+        run: |
+          if [ -d "${{ github.workspace }}" ] && command -v docker >/dev/null; then
+            docker run --rm -v "${{ github.workspace }}:/w" alpine:latest \
+              chown -R "$(id -u):$(id -g)" /w 2>/dev/null || true
+          fi
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Containers run as root, so anything written into the bind-mounted workspace is root-owned. #166 chowns it back *after* the command, which works when a job exits normally and does nothing when it doesn't — a cancelled, superseded or killed job never reaches that line.

`actions/checkout` wipes the workspace before every run, can't delete those files, and fails:

```
Error: File was unable to be removed
Error: EACCES: permission denied, unlink '.../.pytest_cache/.gitignore'
```

The job that fails is the **next** one, on a PR that did nothing wrong, and it fails at *Checkout repository* — so it reads as a checkout or branch problem. It has cost #157 and #158 a full cycle each.

Clearing by hand doesn't fix it: the artifacts are recreated inside the same run, because sibling matrix jobs start before the one holding the workspace returns.

Resetting at the **start** runs regardless of how the previous job ended, which is the property a post-command chown can't have. The chown is kept — it still helps the normal case and costs nothing.