### PR TITLE
Add tests for the rocm_mcp and uprof_mcp tool layers

### DIFF
--- a/.github/workflows/intellikit-pytest.yml
+++ b/.github/workflows/intellikit-pytest.yml
@@ -42,6 +42,10 @@ jobs:
               - 'metrix/**'
             nexus:
               - 'nexus/**'
+            rocm_mcp:
+              - 'rocm_mcp/**'
+            uprof_mcp:
+              - 'uprof_mcp/**'
             infra:
               - '.github/**'
               - 'apptainer/**'
@@ -52,15 +56,14 @@ jobs:
       - name: Build package matrix
         id: build-matrix
         run: |
-          ALL='["accordo","kerncap","linex","metrix","nexus"]'
+          ALL='["accordo","kerncap","linex","metrix","nexus","rocm_mcp","uprof_mcp"]'
 
           # Infra changes or non-PR events → test everything
           if [[ "${{ steps.filter.outputs.infra }}" == "true" || "${{ github.event_name }}" != "pull_request" ]]; then
             echo "packages=${ALL}" >> "$GITHUB_OUTPUT"
           else
-            # Filter to only pytest-eligible packages (exclude rocm_mcp, uprof_mcp)
             CHANGED='${{ steps.filter.outputs.changes }}'
-            FILTERED=$(echo "$CHANGED" | jq -c '[.[] | select(. == "accordo" or . == "kerncap" or . == "linex" or . == "metrix" or . == "nexus")]')
+            FILTERED=$(echo "$CHANGED" | jq -c '[.[] | select(. == "accordo" or . == "kerncap" or . == "linex" or . == "metrix" or . == "nexus" or . == "rocm_mcp" or . == "uprof_mcp")]')
             echo "packages=${FILTERED}" >> "$GITHUB_OUTPUT"
           fi
 

--- a/rocm_mcp/src/rocm_mcp/compile/hip_compiler.py
+++ b/rocm_mcp/src/rocm_mcp/compile/hip_compiler.py
@@ -94,7 +94,10 @@ class HipCompiler:
                 or defaults to 'hipcc' in the system PATH.
         """
         self.logger = logger or logging.getLogger(self.__class__.__name__)
-        self.hipcc_exe = os.getenv("INTELLIKIT_HIPCC", str(hipcc) if hipcc is not None else "hipcc")
+        # An explicit argument wins over the environment; the env var is only a
+        # fallback when the caller did not choose. The reverse made it impossible
+        # to override the env var in-process.
+        self.hipcc_exe = str(hipcc) if hipcc is not None else os.getenv("INTELLIKIT_HIPCC", "hipcc")
         self.logger.info("Initialized compiler.")
 
     def compile(

--- a/rocm_mcp/src/rocm_mcp/sysinfo/amd_smi_mcp.py
+++ b/rocm_mcp/src/rocm_mcp/sysinfo/amd_smi_mcp.py
@@ -16,7 +16,21 @@ mcp = FastMCP(
     instructions=("MCP server for querying AMD GPU system management information."),
 )
 logger = get_logger(mcp.name)
-amd_smi = AmdSmi(logger=logger)
+amd_smi: AmdSmi | None = None
+
+
+def _get_amd_smi() -> AmdSmi:
+    """Return the shared AmdSmi, constructing it on first use.
+
+    Constructing it at import time called ``amdsmi_init()`` as a side effect of
+    importing this module, so the module could not be imported at all without a
+    working driver -- not even to print ``--help``. Tests may assign ``amd_smi``
+    directly to substitute a fake.
+    """
+    global amd_smi  # noqa: PLW0603
+    if amd_smi is None:
+        amd_smi = AmdSmi(logger=logger)
+    return amd_smi
 
 
 @mcp.tool()
@@ -27,7 +41,7 @@ async def get_driver_information(ctx: Annotated[Context, Field(description="MCP 
         str: The driver version, name, and date.
     """
     try:
-        result = amd_smi.get_driver_information()
+        result = _get_amd_smi().get_driver_information()
     except Exception as e:
         msg = f"Failed to get driver version: {e!s}"
         await ctx.error(msg)
@@ -48,7 +62,7 @@ async def list_gpus(ctx: Annotated[Context, Field(description="MCP context.")]) 
         str: GPU index, BDF address, and UUID for each GPU.
     """
     try:
-        gpus = amd_smi.list_gpus()
+        gpus = _get_amd_smi().list_gpus()
     except Exception as e:
         msg = f"Failed to list GPUs: {e!s}"
         await ctx.error(msg)
@@ -72,7 +86,7 @@ async def get_gpu_static_info(
         str: Market name, VRAM, compute units, power caps, and other hardware details.
     """
     try:
-        infos = amd_smi.get_gpu_static_info(gpu_index)
+        infos = _get_amd_smi().get_gpu_static_info(gpu_index)
     except IndexError as e:
         return f"Error: {e!s}"
     except Exception as e:
@@ -110,7 +124,7 @@ async def get_gpu_metrics(
         str: Activity, temperature, power, clock, and VRAM usage for each GPU.
     """
     try:
-        metrics_list = amd_smi.get_gpu_metrics(gpu_index)
+        metrics_list = _get_amd_smi().get_gpu_metrics(gpu_index)
     except IndexError as e:
         return f"Error: {e!s}"
     except Exception as e:
@@ -149,7 +163,7 @@ async def get_gpu_firmware_info(
         str: VBIOS info and firmware block versions for each GPU.
     """
     try:
-        fw_list = amd_smi.get_gpu_firmware_info(gpu_index)
+        fw_list = _get_amd_smi().get_gpu_firmware_info(gpu_index)
     except IndexError as e:
         return f"Error: {e!s}"
     except Exception as e:
@@ -184,7 +198,7 @@ async def get_gpu_process_info(
         str: PID, name, and VRAM usage for processes on each GPU.
     """
     try:
-        proc_list = amd_smi.get_gpu_process_info(gpu_index)
+        proc_list = _get_amd_smi().get_gpu_process_info(gpu_index)
     except IndexError as e:
         return f"Error: {e!s}"
     except Exception as e:
@@ -219,7 +233,7 @@ async def get_gpu_bad_pages(
         str: ECC error counts and retired page count for each GPU.
     """
     try:
-        bp_list = amd_smi.get_gpu_bad_page_info(gpu_index)
+        bp_list = _get_amd_smi().get_gpu_bad_page_info(gpu_index)
     except IndexError as e:
         return f"Error: {e!s}"
     except Exception as e:

--- a/rocm_mcp/src/rocm_mcp/sysinfo/rocminfo.py
+++ b/rocm_mcp/src/rocm_mcp/sysinfo/rocminfo.py
@@ -131,8 +131,11 @@ class Rocminfo:
                 or defaults to 'rocminfo' in the system PATH.
         """
         self.logger = logger or logging.getLogger(self.__class__.__name__)
-        self.rocminfo_exe = os.getenv(
-            "INTELLIKIT_ROCMINFO", str(rocminfo) if rocminfo is not None else "rocminfo"
+        # An explicit argument wins over the environment; the env var is only a
+        # fallback when the caller did not choose. The reverse made it impossible
+        # to override the env var in-process.
+        self.rocminfo_exe = (
+            str(rocminfo) if rocminfo is not None else os.getenv("INTELLIKIT_ROCMINFO", "rocminfo")
         )
         self.logger.info("Initialized rocminfo wrapper.")
 

--- a/rocm_mcp/tests/compile/test_hip_compiler.py
+++ b/rocm_mcp/tests/compile/test_hip_compiler.py
@@ -7,10 +7,14 @@ import pytest
 
 from rocm_mcp import HipCompiler
 
+# Anchored to this file, not the working directory: CI runs pytest from the
+# repository root, where a path relative to rocm_mcp/ does not resolve.
+_HERE = Path(__file__).parent
+
 
 def test_hip_compiler_minimal(tmp_path: Path) -> None:
     """Test HIP compilation only with source."""
-    source_file = "tests/compile/vectoradd_hip.cpp"
+    source_file = str(_HERE / "vectoradd_hip.cpp")
     output_file = tmp_path / "vectoradd_hip.out"
     compiler = HipCompiler()
     result = compiler.compile(source_file=source_file, output_file=output_file)
@@ -28,7 +32,7 @@ def test_hip_compiler_no_source(tmp_path: Path) -> None:
 
 def test_hip_compiler_unknown_source(tmp_path: Path) -> None:
     """Test HIP compilation with unknown source."""
-    source_file = "tests/compile/doesntexist.cpp"
+    source_file = str(_HERE / "doesntexist.cpp")
     output_file = tmp_path / "vectoradd_hip.out"
     compiler = HipCompiler()
     with pytest.raises(FileNotFoundError, match="not exist"):
@@ -37,7 +41,7 @@ def test_hip_compiler_unknown_source(tmp_path: Path) -> None:
 
 def test_hip_compiler_no_output() -> None:
     """Test HIP compilation with missing output file."""
-    source_file = "tests/compile/vectoradd_hip.cpp"
+    source_file = str(_HERE / "vectoradd_hip.cpp")
     compiler = HipCompiler()
     with pytest.raises(ValueError, match="provided"):
         compiler.compile(source_file=source_file, output_file=None)
@@ -45,7 +49,7 @@ def test_hip_compiler_no_output() -> None:
 
 def test_hip_compiler_flags(tmp_path: Path) -> None:
     """Test HIP compilation with flags."""
-    source_file = "tests/compile/vectoradd_hip.cpp"
+    source_file = str(_HERE / "vectoradd_hip.cpp")
     output_file = tmp_path / "vectoradd_hip.out"
     compiler = HipCompiler()
     result = compiler.compile(
@@ -59,7 +63,7 @@ def test_hip_compiler_flags(tmp_path: Path) -> None:
 
 def test_hip_compiler_include_dirs(tmp_path: Path) -> None:
     """Test HIP compilation with include dirs."""
-    source_file = "tests/compile/vectoradd_hip.cpp"
+    source_file = str(_HERE / "vectoradd_hip.cpp")
     output_file = tmp_path / "vectoradd_hip.out"
     compiler = HipCompiler()
     result = compiler.compile(
@@ -73,7 +77,7 @@ def test_hip_compiler_include_dirs(tmp_path: Path) -> None:
 
 def test_hip_compiler_libraries(tmp_path: Path) -> None:
     """Test HIP compilation with libraries."""
-    source_file = "tests/compile/vectoradd_hip.cpp"
+    source_file = str(_HERE / "vectoradd_hip.cpp")
     output_file = tmp_path / "vectoradd_hip.out"
     compiler = HipCompiler()
     result = compiler.compile(

--- a/rocm_mcp/tests/compile/test_hip_compiler_mcp.py
+++ b/rocm_mcp/tests/compile/test_hip_compiler_mcp.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the HIP compiler MCP server tools.
+
+These exercise the MCP tool layer without ROCm or hipcc by substituting a
+fake ``HipCompiler`` over the module-level singleton.  The fixtures build
+real ``HipCompilerResult`` objects rather than mocks, so a field rename in
+``rocm_mcp.compile.hip_compiler`` breaks these tests instead of silently
+passing.
+
+Both tools are covered on the success path, the "compiler ran but rejected
+the code" path (``result.success`` is False, the analogue of an empty
+result), and the failure paths -- the temporary directory could not be
+created, or the compiler itself raised.  Every failure has to both return
+the error string and report it through ``ctx.error``, and that is asserted.
+
+All file paths come from ``tmp_path`` so the tests do not depend on the
+working directory pytest happens to be invoked from.
+"""
+
+import asyncio
+import inspect
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from rocm_mcp import HipCompilerResult
+from rocm_mcp.compile import hip_compiler_mcp
+
+SOURCE = """
+#include <hip/hip_runtime.h>
+int main() { return 0; }
+"""
+
+
+def _tool(obj):  # noqa: ANN001, ANN202
+    """Return the underlying function whether or not FastMCP wrapped it."""
+    return getattr(obj, "fn", obj)
+
+
+compile_hip_source_file = _tool(hip_compiler_mcp.compile_hip_source_file)
+compile_hip_source_string = _tool(hip_compiler_mcp.compile_hip_source_string)
+
+
+class FakeContext:
+    """Minimal stand-in for the FastMCP Context that records log calls."""
+
+    def __init__(self) -> None:
+        """Start with empty info and error logs."""
+        self.infos: list[str] = []
+        self.errors: list[str] = []
+
+    async def info(self, message: str) -> None:
+        """Record an informational message."""
+        self.infos.append(message)
+
+    async def error(self, message: str) -> None:
+        """Record an error message."""
+        self.errors.append(message)
+
+
+class FakeHipCompiler:
+    """Stand-in for HipCompiler that records compile() calls."""
+
+    def __init__(
+        self, result: HipCompilerResult | None = None, error: Exception | None = None
+    ) -> None:
+        """Serve ``result`` from compile(), or raise ``error`` if given."""
+        self.result = result if result is not None else _ok()
+        self.error = error
+        self.calls: list[dict] = []
+
+    def compile(
+        self,
+        source_file: Path,
+        output_file: Path,
+        extra_flags: list[str] | None = None,
+    ) -> HipCompilerResult:
+        """Record the arguments and serve the canned result or error."""
+        self.calls.append(
+            {"source_file": source_file, "output_file": output_file, "extra_flags": extra_flags}
+        )
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def _ok() -> HipCompilerResult:
+    """Build a real successful HipCompilerResult."""
+    return HipCompilerResult(success=True, errors=None, raw_output="\n")
+
+
+def _failed(errors: str = "error: expected ';'") -> HipCompilerResult:
+    """Build a real failed HipCompilerResult."""
+    return HipCompilerResult(success=False, errors=errors, raw_output=f"\n{errors}")
+
+
+def _call(tool, fake: FakeHipCompiler, **kwargs) -> tuple[str, FakeContext]:  # noqa: ANN001
+    """Run an async tool against a patched compiler singleton."""
+    ctx = FakeContext()
+    with patch.object(hip_compiler_mcp, "compiler", fake):
+        return asyncio.run(tool(ctx, **kwargs)), ctx
+
+
+class TestCompileHipSourceFile:
+    """Cover the compile_hip_source_file tool."""
+
+    def test_success_message_names_source_and_output(self, tmp_path: Path) -> None:
+        """A successful compile reports both paths and logs via ctx.info."""
+        src = tmp_path / "vectoradd.hip"
+        src.write_text(SOURCE)
+        out_file = tmp_path / "vectoradd.out"
+        out, ctx = _call(
+            compile_hip_source_file,
+            FakeHipCompiler(),
+            source_file=src,
+            output_file=out_file,
+        )
+        assert out == f"Compilation of HIP code in {src} succeeded. Executable at {out_file}"
+        assert ctx.infos == [out]
+        assert ctx.errors == []
+
+    def test_source_file_is_coerced_to_path(self, tmp_path: Path) -> None:
+        """A string source path reaches the compiler as a Path."""
+        src = tmp_path / "vectoradd.hip"
+        src.write_text(SOURCE)
+        fake = FakeHipCompiler()
+        _call(
+            compile_hip_source_file,
+            fake,
+            source_file=str(src),
+            output_file=tmp_path / "a.out",
+        )
+        assert fake.calls[0]["source_file"] == Path(src)
+        assert isinstance(fake.calls[0]["source_file"], Path)
+
+    def test_temporary_output_named_after_source_stem(self, tmp_path: Path) -> None:
+        """With no output_file a temporary file named after the source is used."""
+        src = tmp_path / "vectoradd.hip"
+        src.write_text(SOURCE)
+        fake = FakeHipCompiler()
+        out, _ = _call(compile_hip_source_file, fake, source_file=src)
+        produced = fake.calls[0]["output_file"]
+        assert produced.name == "vectoradd"
+        # The temporary directory is somewhere other than the source directory.
+        assert produced.parent != src.parent
+        assert str(produced) in out
+
+    def test_extra_flags_are_forwarded(self, tmp_path: Path) -> None:
+        """Extra compiler flags reach the compiler unchanged."""
+        src = tmp_path / "vectoradd.hip"
+        src.write_text(SOURCE)
+        fake = FakeHipCompiler()
+        _call(
+            compile_hip_source_file,
+            fake,
+            source_file=src,
+            output_file=tmp_path / "a.out",
+            extra_flags=["-O3", "-DNDEBUG"],
+        )
+        assert fake.calls[0]["extra_flags"] == ["-O3", "-DNDEBUG"]
+
+    def test_extra_flags_default_to_none(self, tmp_path: Path) -> None:
+        """Omitting extra_flags forwards None rather than an empty list."""
+        src = tmp_path / "vectoradd.hip"
+        src.write_text(SOURCE)
+        fake = FakeHipCompiler()
+        _call(compile_hip_source_file, fake, source_file=src, output_file=tmp_path / "a.out")
+        assert fake.calls[0]["extra_flags"] is None
+
+    def test_temp_dir_failure_is_returned_and_reported(self, tmp_path: Path) -> None:
+        """A failure to allocate the temporary output is reported to the client."""
+        src = tmp_path / "vectoradd.hip"
+        src.write_text(SOURCE)
+        fake = FakeHipCompiler()
+        ctx = FakeContext()
+        with (
+            patch.object(hip_compiler_mcp, "compiler", fake),
+            patch("tempfile.mkdtemp", side_effect=OSError("no space left on device")),
+        ):
+            out = asyncio.run(compile_hip_source_file(ctx, source_file=src))
+        assert out == "Failed to create output file: no space left on device"
+        assert ctx.errors == [out]
+        # The compiler is never reached once the output path could not be made.
+        assert fake.calls == []
+
+    def test_compiler_exception_is_returned_and_reported(self, tmp_path: Path) -> None:
+        """A raising compiler yields the error string and calls ctx.error."""
+        src = tmp_path / "vectoradd.hip"
+        src.write_text(SOURCE)
+        out, ctx = _call(
+            compile_hip_source_file,
+            FakeHipCompiler(error=FileNotFoundError("hipcc executable not found at 'hipcc'")),
+            source_file=src,
+            output_file=tmp_path / "a.out",
+        )
+        assert out == f"Compilation of {src} failed: hipcc executable not found at 'hipcc'"
+        assert ctx.errors == [out]
+
+    def test_unsuccessful_compilation_reports_compiler_errors(self, tmp_path: Path) -> None:
+        """A clean run that rejected the code surfaces the compiler diagnostics."""
+        src = tmp_path / "broken.hip"
+        src.write_text(SOURCE)
+        out, ctx = _call(
+            compile_hip_source_file,
+            FakeHipCompiler(result=_failed("error: expected ';'")),
+            source_file=src,
+            output_file=tmp_path / "a.out",
+        )
+        assert out == f"Compilation of HIP code in {src} failed: error: expected ';'"
+        assert ctx.errors == [out]
+        assert ctx.infos == []
+
+
+class TestCompileHipSourceString:
+    """Cover the compile_hip_source_string tool."""
+
+    def test_source_string_is_written_to_a_temporary_file(self) -> None:
+        """The string lands in hip_source.cpp inside a temporary directory."""
+        fake = FakeHipCompiler()
+        out, ctx = _call(compile_hip_source_string, fake, source=SOURCE)
+        written = fake.calls[0]["source_file"]
+        assert written.name == "hip_source.cpp"
+        assert written.read_text() == SOURCE
+        assert out.startswith(f"Compilation of HIP code in {written} succeeded.")
+        assert ctx.infos == [out]
+        assert ctx.errors == []
+
+    def test_temporary_executable_is_named_hip_exe(self) -> None:
+        """With no output_file the executable defaults to hip_exe next to the source."""
+        fake = FakeHipCompiler()
+        _call(compile_hip_source_string, fake, source=SOURCE)
+        call = fake.calls[0]
+        assert call["output_file"].name == "hip_exe"
+        assert call["output_file"].parent == call["source_file"].parent
+
+    def test_explicit_output_file_is_honoured(self, tmp_path: Path) -> None:
+        """An explicit output path is used instead of the temporary one."""
+        fake = FakeHipCompiler()
+        out_file = tmp_path / "custom.out"
+        out, _ = _call(compile_hip_source_string, fake, source=SOURCE, output_file=out_file)
+        assert fake.calls[0]["output_file"] == out_file
+        assert out.endswith(f"Executable at {out_file}")
+
+    def test_extra_flags_are_forwarded(self) -> None:
+        """Extra compiler flags reach the compiler unchanged."""
+        fake = FakeHipCompiler()
+        _call(compile_hip_source_string, fake, source=SOURCE, extra_flags=["--offload-arch=gfx942"])
+        assert fake.calls[0]["extra_flags"] == ["--offload-arch=gfx942"]
+
+    def test_temp_dir_failure_is_returned_and_reported(self) -> None:
+        """A failure to write the temporary source is reported to the client."""
+        fake = FakeHipCompiler()
+        ctx = FakeContext()
+        with (
+            patch.object(hip_compiler_mcp, "compiler", fake),
+            patch("tempfile.mkdtemp", side_effect=OSError("read-only file system")),
+        ):
+            out = asyncio.run(compile_hip_source_string(ctx, source=SOURCE))
+        assert out == "Failed to create temporary source file: read-only file system"
+        assert ctx.errors == [out]
+        assert fake.calls == []
+
+    def test_compiler_exception_is_returned_and_reported(self) -> None:
+        """A raising compiler yields the error string and calls ctx.error."""
+        fake = FakeHipCompiler(error=RuntimeError("hipcc execution failed"))
+        out, ctx = _call(compile_hip_source_string, fake, source=SOURCE)
+        written = fake.calls[0]["source_file"]
+        assert out == f"Compilation of {written} failed: hipcc execution failed"
+        assert ctx.errors == [out]
+
+    def test_unsuccessful_compilation_reports_compiler_errors(self) -> None:
+        """A clean run that rejected the code surfaces the compiler diagnostics."""
+        fake = FakeHipCompiler(result=_failed("error: use of undeclared identifier"))
+        out, ctx = _call(compile_hip_source_string, fake, source="int main() { nope; }")
+        written = fake.calls[0]["source_file"]
+        assert out == (
+            f"Compilation of HIP code in {written} failed: error: use of undeclared identifier"
+        )
+        assert ctx.errors == [out]
+        assert ctx.infos == []
+
+
+class TestMain:
+    """Cover the transport dispatch in main()."""
+
+    def test_default_transport_is_stdio(self) -> None:
+        """With no arguments the server runs over stdio."""
+        with (
+            patch.object(hip_compiler_mcp.mcp, "run") as run,
+            patch("sys.argv", ["hip-compiler-mcp"]),
+        ):
+            hip_compiler_mcp.main()
+        run.assert_called_once_with(transport="stdio")
+
+    def test_explicit_stdio(self) -> None:
+        """An explicit --transport stdio behaves like the default."""
+        with (
+            patch.object(hip_compiler_mcp.mcp, "run") as run,
+            patch("sys.argv", ["hip-compiler-mcp", "--transport", "stdio"]),
+        ):
+            hip_compiler_mcp.main()
+        run.assert_called_once_with(transport="stdio")
+
+    def test_http_transport_uses_defaults(self) -> None:
+        """HTTP falls back to loopback, port 8000 and the hip_compiler path."""
+        with (
+            patch.object(hip_compiler_mcp.mcp, "run") as run,
+            patch("sys.argv", ["hip-compiler-mcp", "--transport", "http"]),
+        ):
+            hip_compiler_mcp.main()
+        run.assert_called_once_with(
+            transport="streamable-http",
+            host="127.0.0.1",
+            port=8000,
+            path="/rocm_mcp/hip_compiler",
+        )
+
+    def test_http_transport_honours_overrides(self) -> None:
+        """Host, port and path overrides reach mcp.run()."""
+        argv = [
+            "hip-compiler-mcp",
+            "--transport",
+            "http",
+            "--host",
+            "0.0.0.0",  # noqa: S104
+            "--port",
+            "9300",
+            "--path",
+            "/custom",
+        ]
+        with patch.object(hip_compiler_mcp.mcp, "run") as run, patch("sys.argv", argv):
+            hip_compiler_mcp.main()
+        run.assert_called_once_with(
+            transport="streamable-http",
+            host="0.0.0.0",  # noqa: S104
+            port=9300,
+            path="/custom",
+        )
+
+    def test_invalid_transport_rejected(self) -> None:
+        """A transport outside the declared choices is rejected by argparse."""
+        with (
+            patch("sys.argv", ["hip-compiler-mcp", "--transport", "carrier-pigeon"]),
+            pytest.raises(SystemExit),
+        ):
+            hip_compiler_mcp.main()
+
+
+class TestToolRegistration:
+    """Assert the tools are actually registered with the real FastMCP server."""
+
+    def test_both_tools_registered_with_mcp(self) -> None:
+        """Both tool names show up in the server's tool listing."""
+        assert {"compile_hip_source_file", "compile_hip_source_string"} <= _registered_tools()
+
+    def test_server_name(self) -> None:
+        """The server advertises itself as hip_compiler."""
+        assert hip_compiler_mcp.mcp.name == "hip_compiler"
+
+
+def _registered_tools() -> set[str]:
+    """Fetch registered tool names across FastMCP versions."""
+    for attr in ("list_tools", "get_tools"):
+        getter = getattr(hip_compiler_mcp.mcp, attr, None)
+        if getter is not None:
+            break
+    else:
+        pytest.fail("FastMCP exposes neither list_tools() nor get_tools()")
+    result = getter()
+    if inspect.isawaitable(result):
+        result = asyncio.run(result)
+    tools = result.values() if hasattr(result, "values") else result
+    names = set()
+    for t in tools:
+        name = getattr(t, "name", None)
+        names.add(name if name is not None else str(t))
+    return names

--- a/rocm_mcp/tests/docs/test_hip_docs_mcp.py
+++ b/rocm_mcp/tests/docs/test_hip_docs_mcp.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the HIP documentation MCP server tools.
+
+These exercise the MCP tool layer without any network access by substituting
+a fake ``HipDocs`` for the class the tools instantiate.  The fixtures build
+real ``HipApiResult`` objects rather than mocks, so a field rename in
+``rocm_mcp.doc.hip_docs`` breaks these tests instead of silently passing.
+
+Unlike the other rocm_mcp servers, these tools construct their collaborator
+per call rather than using a module-level singleton, so the fake records the
+``version`` it was constructed with -- that is the only way to prove the
+version argument is honoured rather than ignored.
+
+Both tools are covered on the success path, the no-results path, and the
+failure path, where the collaborator raises and the tool has to both return
+the error string and report it through ``ctx.error``.
+"""
+
+import asyncio
+import inspect
+from typing import ClassVar
+from unittest.mock import patch
+
+import pytest
+
+from rocm_mcp.doc import HipApiResult, hip_docs_mcp
+
+
+def _tool(obj):  # noqa: ANN001, ANN202
+    """Return the underlying function whether or not FastMCP wrapped it."""
+    return getattr(obj, "fn", obj)
+
+
+search_hip_api = _tool(hip_docs_mcp.search_hip_api)
+get_hip_api_reference = _tool(hip_docs_mcp.get_hip_api_reference)
+
+
+class FakeContext:
+    """Minimal stand-in for the FastMCP Context that records log calls."""
+
+    def __init__(self) -> None:
+        """Start with empty info and error logs."""
+        self.infos: list[str] = []
+        self.errors: list[str] = []
+
+    async def info(self, message: str) -> None:
+        """Record an informational message."""
+        self.infos.append(message)
+
+    async def error(self, message: str) -> None:
+        """Record an error message."""
+        self.errors.append(message)
+
+
+class FakeHipDocs:
+    """Stand-in for HipDocs that records construction and query arguments."""
+
+    search_results: ClassVar[list[HipApiResult]] = []
+    reference: ClassVar[HipApiResult | None] = None
+    error: ClassVar[Exception | None] = None
+    calls: ClassVar[list[dict]] = []
+
+    def __init__(self, version: str = "latest") -> None:
+        """Record the documentation version the tool asked for."""
+        FakeHipDocs.calls.append({"version": version})
+
+    def search_api(self, query: str, limit: int = 5) -> list[HipApiResult]:
+        """Record the query and serve the canned results, or raise."""
+        FakeHipDocs.calls[-1].update({"query": query, "limit": limit})
+        if FakeHipDocs.error is not None:
+            raise FakeHipDocs.error
+        return FakeHipDocs.search_results
+
+    def get_api_reference(self, api_name: str) -> HipApiResult | None:
+        """Record the API name and serve the canned reference, or raise."""
+        FakeHipDocs.calls[-1].update({"api_name": api_name})
+        if FakeHipDocs.error is not None:
+            raise FakeHipDocs.error
+        return FakeHipDocs.reference
+
+
+@pytest.fixture(autouse=True)
+def _fake_hip_docs():  # noqa: ANN202
+    """Patch HipDocs for every test and reset the recorded state."""
+    FakeHipDocs.search_results = []
+    FakeHipDocs.reference = None
+    FakeHipDocs.error = None
+    FakeHipDocs.calls = []
+    with patch.object(hip_docs_mcp, "HipDocs", FakeHipDocs):
+        yield
+
+
+def _result(title: str, content: str | None = None) -> HipApiResult:
+    """Build a real HipApiResult so a field rename fails the test."""
+    return HipApiResult(
+        title=title,
+        url=f"https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group__Memory.html#{title}",
+        description=f"{title} description",
+        content=content,
+    )
+
+
+def _call(tool, **kwargs) -> tuple[str, FakeContext]:  # noqa: ANN001
+    """Run an async tool with a recording context."""
+    ctx = FakeContext()
+    return asyncio.run(tool(ctx, **kwargs)), ctx
+
+
+class TestSearchHipApi:
+    """Cover the search_hip_api tool."""
+
+    def test_formats_every_result(self) -> None:
+        """The header, the numbering, and each URL and description are rendered."""
+        FakeHipDocs.search_results = [_result("hipMalloc"), _result("hipMallocAsync")]
+        out, ctx = _call(search_hip_api, query="hipMalloc")
+        assert out.startswith("Found 2 results for 'hipMalloc' in HIP latest documentation:")
+        assert "1. hipMalloc" in out
+        assert "2. hipMallocAsync" in out
+        assert f"   URL: {FakeHipDocs.search_results[0].url}" in out
+        assert "   Description: hipMalloc description" in out
+        assert ctx.errors == []
+
+    def test_query_and_limit_are_forwarded(self) -> None:
+        """The query string and result limit reach HipDocs.search_api()."""
+        FakeHipDocs.search_results = [_result("hipMemcpy")]
+        _call(search_hip_api, query="hipMemcpy", limit=3)
+        assert FakeHipDocs.calls[0]["query"] == "hipMemcpy"
+        assert FakeHipDocs.calls[0]["limit"] == 3  # noqa: PLR2004
+
+    def test_limit_defaults_to_five(self) -> None:
+        """Omitting the limit uses the documented default of five."""
+        FakeHipDocs.search_results = [_result("hipMemcpy")]
+        _call(search_hip_api, query="hipMemcpy")
+        assert FakeHipDocs.calls[0]["limit"] == 5  # noqa: PLR2004
+
+    def test_version_is_forwarded_and_reported(self) -> None:
+        """A pinned version reaches the constructor and shows up in the header."""
+        FakeHipDocs.search_results = [_result("hipMemcpy")]
+        out, _ = _call(search_hip_api, query="hipMemcpy", version="6.2.0")
+        assert FakeHipDocs.calls[0]["version"] == "6.2.0"
+        assert "in HIP 6.2.0 documentation:" in out
+
+    def test_version_defaults_to_latest(self) -> None:
+        """Omitting the version asks for the latest documentation."""
+        FakeHipDocs.search_results = [_result("hipMemcpy")]
+        _call(search_hip_api, query="hipMemcpy")
+        assert FakeHipDocs.calls[0]["version"] == "latest"
+
+    def test_no_results(self) -> None:
+        """An empty result set reports the query, and is not treated as an error."""
+        out, ctx = _call(search_hip_api, query="hipNotAThing")
+        assert out == "No HIP API documentation found for query: hipNotAThing"
+        assert ctx.errors == []
+
+    def test_failure_is_returned_and_reported(self) -> None:
+        """A raising collaborator yields the error string and calls ctx.error."""
+        FakeHipDocs.error = RuntimeError("connection reset")
+        out, ctx = _call(search_hip_api, query="hipMalloc")
+        assert out == "Error searching HIP API documentation: connection reset"
+        assert ctx.errors == [out]
+
+
+class TestGetHipApiReference:
+    """Cover the get_hip_api_reference tool."""
+
+    def test_renders_title_url_and_description(self) -> None:
+        """The reference block leads with the title, URL and description."""
+        FakeHipDocs.reference = _result("hipMalloc")
+        out, ctx = _call(get_hip_api_reference, api_name="hipMalloc")
+        assert out.startswith("HIP API Reference: hipMalloc")
+        assert f"URL: {FakeHipDocs.reference.url}" in out
+        assert "Description:\nhipMalloc description" in out
+        assert ctx.errors == []
+
+    def test_full_documentation_included_when_content_present(self) -> None:
+        """A reference carrying content gets a Full Documentation section."""
+        FakeHipDocs.reference = _result("hipMalloc", content="hipError_t hipMalloc(void** ptr)")
+        out, _ = _call(get_hip_api_reference, api_name="hipMalloc")
+        assert "Full Documentation:\nhipError_t hipMalloc(void** ptr)" in out
+
+    def test_full_documentation_omitted_when_content_absent(self) -> None:
+        """A reference without content omits the Full Documentation section."""
+        FakeHipDocs.reference = _result("hipMalloc")
+        out, _ = _call(get_hip_api_reference, api_name="hipMalloc")
+        assert "Full Documentation:" not in out
+
+    def test_api_name_and_version_are_forwarded(self) -> None:
+        """The API name and version reach the collaborator."""
+        FakeHipDocs.reference = _result("hipFree")
+        _call(get_hip_api_reference, api_name="hipFree", version="6.2.0")
+        assert FakeHipDocs.calls[0] == {"version": "6.2.0", "api_name": "hipFree"}
+
+    def test_no_reference_found(self) -> None:
+        """A missing reference reports the name, and is not treated as an error."""
+        out, ctx = _call(get_hip_api_reference, api_name="hipNotAThing")
+        assert out == "No HIP API reference found for: hipNotAThing"
+        assert ctx.errors == []
+
+    def test_failure_is_returned_and_reported(self) -> None:
+        """A raising collaborator yields the error string and calls ctx.error."""
+        FakeHipDocs.error = RuntimeError("read timeout")
+        out, ctx = _call(get_hip_api_reference, api_name="hipMalloc")
+        assert out == "Failed to get HIP API reference: read timeout"
+        assert ctx.errors == [out]
+
+
+class TestMain:
+    """Cover the transport dispatch in main()."""
+
+    def test_default_transport_is_stdio(self) -> None:
+        """With no arguments the server runs over stdio."""
+        with patch.object(hip_docs_mcp.mcp, "run") as run, patch("sys.argv", ["hip-docs-mcp"]):
+            hip_docs_mcp.main()
+        run.assert_called_once_with(transport="stdio")
+
+    def test_explicit_stdio(self) -> None:
+        """An explicit --transport stdio behaves like the default."""
+        with (
+            patch.object(hip_docs_mcp.mcp, "run") as run,
+            patch("sys.argv", ["hip-docs-mcp", "--transport", "stdio"]),
+        ):
+            hip_docs_mcp.main()
+        run.assert_called_once_with(transport="stdio")
+
+    def test_http_transport_uses_defaults(self) -> None:
+        """HTTP falls back to loopback, port 8000 and the hip_docs path."""
+        with (
+            patch.object(hip_docs_mcp.mcp, "run") as run,
+            patch("sys.argv", ["hip-docs-mcp", "--transport", "http"]),
+        ):
+            hip_docs_mcp.main()
+        run.assert_called_once_with(
+            transport="streamable-http", host="127.0.0.1", port=8000, path="/rocm_mcp/hip_docs"
+        )
+
+    def test_http_transport_honours_overrides(self) -> None:
+        """Host, port and path overrides reach mcp.run()."""
+        argv = [
+            "hip-docs-mcp",
+            "--transport",
+            "http",
+            "--host",
+            "0.0.0.0",  # noqa: S104
+            "--port",
+            "9400",
+            "--path",
+            "/custom",
+        ]
+        with patch.object(hip_docs_mcp.mcp, "run") as run, patch("sys.argv", argv):
+            hip_docs_mcp.main()
+        run.assert_called_once_with(
+            transport="streamable-http",
+            host="0.0.0.0",  # noqa: S104
+            port=9400,
+            path="/custom",
+        )
+
+    def test_invalid_transport_rejected(self) -> None:
+        """A transport outside the declared choices is rejected by argparse."""
+        with (
+            patch("sys.argv", ["hip-docs-mcp", "--transport", "carrier-pigeon"]),
+            pytest.raises(SystemExit),
+        ):
+            hip_docs_mcp.main()
+
+
+class TestToolRegistration:
+    """Assert the tools are actually registered with the real FastMCP server."""
+
+    def test_both_tools_registered_with_mcp(self) -> None:
+        """Both tool names show up in the server's tool listing."""
+        assert {"search_hip_api", "get_hip_api_reference"} <= _registered_tools()
+
+    def test_server_name(self) -> None:
+        """The server advertises itself as hip_docs."""
+        assert hip_docs_mcp.mcp.name == "hip_docs"
+
+
+def _registered_tools() -> set[str]:
+    """Fetch registered tool names across FastMCP versions."""
+    for attr in ("list_tools", "get_tools"):
+        getter = getattr(hip_docs_mcp.mcp, attr, None)
+        if getter is not None:
+            break
+    else:
+        pytest.fail("FastMCP exposes neither list_tools() nor get_tools()")
+    result = getter()
+    if inspect.isawaitable(result):
+        result = asyncio.run(result)
+    tools = result.values() if hasattr(result, "values") else result
+    names = set()
+    for t in tools:
+        name = getattr(t, "name", None)
+        names.add(name if name is not None else str(t))
+    return names

--- a/rocm_mcp/tests/sysinfo/test_amd_smi.py
+++ b/rocm_mcp/tests/sysinfo/test_amd_smi.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 
+import gc
+from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,6 +21,22 @@ from rocm_mcp.sysinfo.amd_smi import (
     GpuStaticInfo,
     ProcessEntry,
 )
+
+
+@pytest.fixture(autouse=True)
+def _flush_finalizers() -> Iterator[None]:
+    """Finalize stray AmdSmi instances before and after each test.
+
+    ``AmdSmi.__del__`` calls ``amdsmi_shut_down()``. An instance created by an
+    earlier test can be collected *during* a later one, where it reaches that
+    test's patched mock and inflates the call count -- so ``assert_called_once()``
+    fails depending on collection order rather than on anything the test did.
+    Collecting at both ends makes the count deterministic.
+    """
+    gc.collect()
+    yield
+    gc.collect()
+
 
 SAMPLE_DRIVER_INFO = {
     "driver_name": "amdgpu",

--- a/rocm_mcp/tests/sysinfo/test_amd_smi_mcp.py
+++ b/rocm_mcp/tests/sysinfo/test_amd_smi_mcp.py
@@ -567,3 +567,42 @@ def _registered_tools() -> set[str]:
         name = getattr(t, "name", None)
         names.add(name if name is not None else str(t))
     return names
+
+
+class TestLazyConstruction:
+    """The AmdSmi handle is built on first use, not at import time."""
+
+    def test_constructs_once_and_caches(self) -> None:
+        """_get_amd_smi builds the handle once and reuses it."""
+        built = []
+
+        class _Fake:
+            def __init__(self, **kwargs: object) -> None:
+                built.append(kwargs)
+
+        with (
+            patch.object(amd_smi_mcp, "amd_smi", None),
+            patch.object(amd_smi_mcp, "AmdSmi", _Fake),
+        ):
+            first = amd_smi_mcp._get_amd_smi()  # noqa: SLF001
+            second = amd_smi_mcp._get_amd_smi()  # noqa: SLF001
+
+        assert first is second
+        # Constructed exactly once despite two calls -- importing the module must
+        # not call amdsmi_init(), and neither should a second tool invocation.
+        assert len(built) == 1
+
+    def test_returns_a_substituted_fake_without_constructing(self) -> None:
+        """Assigning amd_smi directly is honoured, so tests need no driver."""
+        sentinel = object()
+
+        class _Boom:
+            def __init__(self, **_: object) -> None:
+                msg = "must not construct when one was supplied"
+                raise AssertionError(msg)
+
+        with (
+            patch.object(amd_smi_mcp, "amd_smi", sentinel),
+            patch.object(amd_smi_mcp, "AmdSmi", _Boom),
+        ):
+            assert amd_smi_mcp._get_amd_smi() is sentinel  # noqa: SLF001

--- a/rocm_mcp/tests/sysinfo/test_amd_smi_mcp.py
+++ b/rocm_mcp/tests/sysinfo/test_amd_smi_mcp.py
@@ -1,0 +1,569 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the amd-smi MCP server tools.
+
+These exercise the MCP tool layer without a GPU by substituting a fake
+``AmdSmi`` over the module-level singleton.  The fixtures build the real
+``GpuStaticInfo``/``GpuMetrics``/``GpuFirmwareInfo``/... dataclasses rather
+than mocks, so a field rename in ``rocm_mcp.sysinfo.amd_smi`` breaks these
+tests instead of silently passing.
+
+Every tool is covered on the success path, the empty path (no GPUs came
+back), and the failure path, where the collaborator raises and the tool has
+to both return the error string and report it through ``ctx.error``.  The
+tools that take a ``gpu_index`` additionally have an ``IndexError`` path that
+is deliberately *not* reported through ``ctx.error`` -- an out-of-range index
+is a caller mistake, not a server fault -- and that distinction is asserted.
+"""
+
+import asyncio
+import inspect
+from unittest.mock import patch
+
+import pytest
+
+from rocm_mcp.sysinfo import (
+    DriverInformationResult,
+    FirmwareEntry,
+    GpuBadPageInfo,
+    GpuFirmwareInfo,
+    GpuInfo,
+    GpuMetrics,
+    GpuProcessInfo,
+    GpuStaticInfo,
+    ProcessEntry,
+    amd_smi_mcp,
+)
+
+
+def _tool(obj):  # noqa: ANN001, ANN202
+    """Return the underlying function whether or not FastMCP wrapped it."""
+    return getattr(obj, "fn", obj)
+
+
+get_driver_information = _tool(amd_smi_mcp.get_driver_information)
+list_gpus = _tool(amd_smi_mcp.list_gpus)
+get_gpu_static_info = _tool(amd_smi_mcp.get_gpu_static_info)
+get_gpu_metrics = _tool(amd_smi_mcp.get_gpu_metrics)
+get_gpu_firmware_info = _tool(amd_smi_mcp.get_gpu_firmware_info)
+get_gpu_process_info = _tool(amd_smi_mcp.get_gpu_process_info)
+get_gpu_bad_pages = _tool(amd_smi_mcp.get_gpu_bad_pages)
+
+
+class FakeContext:
+    """Minimal stand-in for the FastMCP Context that records log calls."""
+
+    def __init__(self) -> None:
+        """Start with empty info and error logs."""
+        self.infos: list[str] = []
+        self.errors: list[str] = []
+
+    async def info(self, message: str) -> None:
+        """Record an informational message."""
+        self.infos.append(message)
+
+    async def error(self, message: str) -> None:
+        """Record an error message."""
+        self.errors.append(message)
+
+
+class FakeAmdSmi:
+    """Stand-in for AmdSmi that serves one canned result or raises."""
+
+    def __init__(self, result: object = None, error: Exception | None = None) -> None:
+        """Serve ``result`` from every query, or raise ``error`` if given."""
+        self.result = result
+        self.error = error
+        self.calls: list[int | None] = []
+
+    def _serve(self, gpu_index: int | None = None) -> object:
+        """Record the requested index and serve the canned result or error."""
+        self.calls.append(gpu_index)
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+    def get_driver_information(self) -> object:
+        """Serve the canned driver information."""
+        return self._serve()
+
+    def list_gpus(self) -> object:
+        """Serve the canned GPU list."""
+        return self._serve()
+
+    def get_gpu_static_info(self, gpu_index: int | None = None) -> object:
+        """Serve the canned static info."""
+        return self._serve(gpu_index)
+
+    def get_gpu_metrics(self, gpu_index: int | None = None) -> object:
+        """Serve the canned metrics."""
+        return self._serve(gpu_index)
+
+    def get_gpu_firmware_info(self, gpu_index: int | None = None) -> object:
+        """Serve the canned firmware info."""
+        return self._serve(gpu_index)
+
+    def get_gpu_process_info(self, gpu_index: int | None = None) -> object:
+        """Serve the canned process info."""
+        return self._serve(gpu_index)
+
+    def get_gpu_bad_page_info(self, gpu_index: int | None = None) -> object:
+        """Serve the canned bad page info."""
+        return self._serve(gpu_index)
+
+
+def _call(tool, fake: FakeAmdSmi, **kwargs) -> tuple[str, FakeContext]:  # noqa: ANN001
+    """Run an async tool against a patched amd_smi singleton."""
+    ctx = FakeContext()
+    with patch.object(amd_smi_mcp, "amd_smi", fake):
+        return asyncio.run(tool(ctx, **kwargs)), ctx
+
+
+def _static(index: int = 0) -> GpuStaticInfo:
+    """Build a real GpuStaticInfo so a field rename fails the test."""
+    return GpuStaticInfo(
+        gpu_index=index,
+        bdf="0000:03:00.0",
+        market_name="Instinct MI300X",
+        vendor_id="0x1002",
+        device_id="0x74a0",
+        rev_id="0x00",
+        asic_serial="0x1234567890ABCDEF",
+        num_compute_units=304,
+        vram_type="HBM3",
+        vram_vendor="SK Hynix",
+        vram_size_mb=196608,
+        model_name="MI300X OAM",
+        power_cap_w=750,
+        default_power_cap_w=750,
+        min_power_cap_w=0,
+        max_power_cap_w=760,
+    )
+
+
+def _metrics(index: int = 0) -> GpuMetrics:
+    """Build a real GpuMetrics so a field rename fails the test."""
+    return GpuMetrics(
+        gpu_index=index,
+        bdf="0000:03:00.0",
+        gfx_activity_pct=85,
+        umc_activity_pct=42,
+        mm_activity_pct=10,
+        temp_edge_c=55,
+        temp_hotspot_c=72,
+        temp_vram_c=48,
+        current_power_w=320,
+        gfx_voltage_mv=900,
+        soc_voltage_mv=850,
+        mem_voltage_mv=1200,
+        gfx_clock_mhz=2100,
+        gfx_max_clock_mhz=2400,
+        mem_clock_mhz=1600,
+        mem_max_clock_mhz=2000,
+        vram_used_mb=65536,
+        vram_total_mb=196608,
+    )
+
+
+def _firmware(index: int = 0, entries: list[FirmwareEntry] | None = None) -> GpuFirmwareInfo:
+    """Build a real GpuFirmwareInfo so a field rename fails the test."""
+    return GpuFirmwareInfo(
+        gpu_index=index,
+        bdf="0000:03:00.0",
+        vbios_name="MI300X VBIOS",
+        vbios_version="022.040.000.001",
+        vbios_build_date="2024/01/01",
+        vbios_part_number="113-MI300X",
+        firmware_list=[FirmwareEntry(name="SMU", version="85.101.0")]
+        if entries is None
+        else entries,
+    )
+
+
+def _processes(index: int = 0, procs: list[ProcessEntry] | None = None) -> GpuProcessInfo:
+    """Build a real GpuProcessInfo so a field rename fails the test."""
+    return GpuProcessInfo(
+        gpu_index=index,
+        bdf="0000:03:00.0",
+        processes=[ProcessEntry(pid=4242, name="python3", vram_usage_mb=512)]
+        if procs is None
+        else procs,
+    )
+
+
+def _bad_pages(index: int = 0) -> GpuBadPageInfo:
+    """Build a real GpuBadPageInfo so a field rename fails the test."""
+    return GpuBadPageInfo(
+        gpu_index=index,
+        bdf="0000:03:00.0",
+        correctable_ecc_count=3,
+        uncorrectable_ecc_count=1,
+        deferred_ecc_count=0,
+        bad_page_count=2,
+    )
+
+
+_OUT_OF_RANGE = IndexError("GPU index 9 out of range (0-0)")
+
+
+class TestGetDriverInformation:
+    """Cover the get_driver_information tool."""
+
+    def test_renders_all_driver_fields(self) -> None:
+        """Name, version and date come from the real DriverInformationResult."""
+        driver = DriverInformationResult(version="6.16.13", name="amdgpu", date="2025/01/01 00:00")
+        out, ctx = _call(get_driver_information, FakeAmdSmi(driver))
+        assert out == (
+            "Driver Name: amdgpu\nDriver Version: 6.16.13\nDriver Date: 2025/01/01 00:00"
+        )
+        assert ctx.errors == []
+
+    def test_failure_is_returned_and_reported(self) -> None:
+        """A raising collaborator yields the error string and calls ctx.error."""
+        out, ctx = _call(get_driver_information, FakeAmdSmi(error=RuntimeError("no driver")))
+        assert out == "Failed to get driver version: no driver"
+        assert ctx.errors == [out]
+
+
+class TestListGpus:
+    """Cover the list_gpus tool."""
+
+    def test_lists_every_gpu(self) -> None:
+        """Index, BDF and UUID are rendered for each GPU."""
+        gpus = [
+            GpuInfo(gpu_index=0, bdf="0000:03:00.0", uuid="GPU-aaaa"),
+            GpuInfo(gpu_index=1, bdf="0000:04:00.0", uuid="GPU-bbbb"),
+        ]
+        out, ctx = _call(list_gpus, FakeAmdSmi(gpus))
+        assert "GPU 0:\n  BDF: 0000:03:00.0\n  UUID: GPU-aaaa" in out
+        assert "GPU 1:\n  BDF: 0000:04:00.0\n  UUID: GPU-bbbb" in out
+        assert ctx.errors == []
+
+    def test_no_gpus(self) -> None:
+        """An empty GPU list renders as an empty string, not an error."""
+        out, ctx = _call(list_gpus, FakeAmdSmi([]))
+        assert out == ""
+        assert ctx.errors == []
+
+    def test_failure_is_returned_and_reported(self) -> None:
+        """A raising collaborator yields the error string and calls ctx.error."""
+        out, ctx = _call(list_gpus, FakeAmdSmi(error=RuntimeError("no processors")))
+        assert out == "Failed to list GPUs: no processors"
+        assert ctx.errors == [out]
+
+
+class TestGetGpuStaticInfo:
+    """Cover the get_gpu_static_info tool."""
+
+    def test_renders_static_fields(self) -> None:
+        """Market name, IDs, CUs, VRAM, model and power caps all render."""
+        out, ctx = _call(get_gpu_static_info, FakeAmdSmi([_static()]))
+        assert out.startswith("GPU 0 (0000:03:00.0):")
+        assert "  Market Name: Instinct MI300X" in out
+        assert "  Vendor/Device/Rev ID: 0x1002/0x74a0/0x00" in out
+        assert "  ASIC Serial: 0x1234567890ABCDEF" in out
+        assert "  Compute Units: 304" in out
+        assert "  VRAM: 196608 MB HBM3 (SK Hynix)" in out
+        assert "  Model: MI300X OAM" in out
+        assert "  Power Cap: 750W (default 750W, range 0-760W)" in out
+        assert ctx.errors == []
+
+    def test_all_gpus_by_default(self) -> None:
+        """With no index the tool asks for every GPU and renders them all."""
+        fake = FakeAmdSmi([_static(0), _static(1)])
+        out, _ = _call(get_gpu_static_info, fake)
+        assert fake.calls == [None]
+        assert "GPU 0 (" in out
+        assert "GPU 1 (" in out
+
+    def test_gpu_index_is_forwarded(self) -> None:
+        """An explicit index reaches the wrapper unchanged."""
+        fake = FakeAmdSmi([_static(1)])
+        _call(get_gpu_static_info, fake, gpu_index=1)
+        assert fake.calls == [1]
+
+    def test_no_gpus(self) -> None:
+        """An empty result renders as an empty string, not an error."""
+        out, ctx = _call(get_gpu_static_info, FakeAmdSmi([]))
+        assert out == ""
+        assert ctx.errors == []
+
+    def test_index_error_is_returned_without_ctx_error(self) -> None:
+        """An out-of-range index is a caller mistake, so it is not reported."""
+        out, ctx = _call(get_gpu_static_info, FakeAmdSmi(error=_OUT_OF_RANGE), gpu_index=9)
+        assert out == "Error: GPU index 9 out of range (0-0)"
+        assert ctx.errors == []
+
+    def test_failure_is_returned_and_reported(self) -> None:
+        """A raising collaborator yields the error string and calls ctx.error."""
+        out, ctx = _call(get_gpu_static_info, FakeAmdSmi(error=RuntimeError("boom")))
+        assert out == "Failed to get GPU static info: boom"
+        assert ctx.errors == [out]
+
+
+class TestGetGpuMetrics:
+    """Cover the get_gpu_metrics tool."""
+
+    def test_renders_metric_fields(self) -> None:
+        """Activity, temperature, power, voltage, clocks and VRAM all render."""
+        out, ctx = _call(get_gpu_metrics, FakeAmdSmi([_metrics()]))
+        assert out.startswith("GPU 0 (0000:03:00.0):")
+        assert "  Activity: GFX 85%, UMC 42%, MM 10%" in out
+        assert "  Temperature: Edge 55C, Hotspot 72C, VRAM 48C" in out
+        assert "  Power: 320W" in out
+        assert "  Voltage: GFX 900mV, SoC 850mV, Mem 1200mV" in out
+        assert "  Clocks: GFX 2100/2400 MHz, MEM 1600/2000 MHz" in out
+        assert "  VRAM: 65536/196608 MB" in out
+        assert ctx.errors == []
+
+    def test_gpu_index_is_forwarded(self) -> None:
+        """An explicit index reaches the wrapper unchanged."""
+        fake = FakeAmdSmi([_metrics(2)])
+        _call(get_gpu_metrics, fake, gpu_index=2)
+        assert fake.calls == [2]
+
+    def test_no_gpus(self) -> None:
+        """An empty result renders as an empty string, not an error."""
+        out, ctx = _call(get_gpu_metrics, FakeAmdSmi([]))
+        assert out == ""
+        assert ctx.errors == []
+
+    def test_index_error_is_returned_without_ctx_error(self) -> None:
+        """An out-of-range index is a caller mistake, so it is not reported."""
+        out, ctx = _call(get_gpu_metrics, FakeAmdSmi(error=_OUT_OF_RANGE), gpu_index=9)
+        assert out == "Error: GPU index 9 out of range (0-0)"
+        assert ctx.errors == []
+
+    def test_failure_is_returned_and_reported(self) -> None:
+        """A raising collaborator yields the error string and calls ctx.error."""
+        out, ctx = _call(get_gpu_metrics, FakeAmdSmi(error=RuntimeError("boom")))
+        assert out == "Failed to get GPU metrics: boom"
+        assert ctx.errors == [out]
+
+
+class TestGetGpuFirmwareInfo:
+    """Cover the get_gpu_firmware_info tool."""
+
+    def test_renders_vbios_and_firmware_entries(self) -> None:
+        """The VBIOS line and every firmware entry are rendered."""
+        entries = [
+            FirmwareEntry(name="SMU", version="85.101.0"),
+            FirmwareEntry(name="VCN", version="0.0.6"),
+        ]
+        out, ctx = _call(get_gpu_firmware_info, FakeAmdSmi([_firmware(entries=entries)]))
+        assert out.startswith("GPU 0 (0000:03:00.0):")
+        assert "  VBIOS: MI300X VBIOS v022.040.000.001 (2024/01/01, 113-MI300X)" in out
+        assert "    SMU: 85.101.0" in out
+        assert "    VCN: 0.0.6" in out
+        assert ctx.errors == []
+
+    def test_empty_firmware_list_renders_placeholder(self) -> None:
+        """A GPU with no firmware entries shows the (none) placeholder."""
+        out, _ = _call(get_gpu_firmware_info, FakeAmdSmi([_firmware(entries=[])]))
+        assert "  Firmware:\n    (none)" in out
+
+    def test_gpu_index_is_forwarded(self) -> None:
+        """An explicit index reaches the wrapper unchanged."""
+        fake = FakeAmdSmi([_firmware(3)])
+        _call(get_gpu_firmware_info, fake, gpu_index=3)
+        assert fake.calls == [3]
+
+    def test_no_gpus(self) -> None:
+        """An empty result renders as an empty string, not an error."""
+        out, ctx = _call(get_gpu_firmware_info, FakeAmdSmi([]))
+        assert out == ""
+        assert ctx.errors == []
+
+    def test_index_error_is_returned_without_ctx_error(self) -> None:
+        """An out-of-range index is a caller mistake, so it is not reported."""
+        out, ctx = _call(get_gpu_firmware_info, FakeAmdSmi(error=_OUT_OF_RANGE), gpu_index=9)
+        assert out == "Error: GPU index 9 out of range (0-0)"
+        assert ctx.errors == []
+
+    def test_failure_is_returned_and_reported(self) -> None:
+        """A raising collaborator yields the error string and calls ctx.error."""
+        out, ctx = _call(get_gpu_firmware_info, FakeAmdSmi(error=RuntimeError("boom")))
+        assert out == "Failed to get GPU firmware info: boom"
+        assert ctx.errors == [out]
+
+
+class TestGetGpuProcessInfo:
+    """Cover the get_gpu_process_info tool."""
+
+    def test_renders_every_process(self) -> None:
+        """PID, name and VRAM usage are rendered for each process."""
+        procs = [
+            ProcessEntry(pid=4242, name="python3", vram_usage_mb=512),
+            ProcessEntry(pid=99, name="rocprof", vram_usage_mb=8),
+        ]
+        out, ctx = _call(get_gpu_process_info, FakeAmdSmi([_processes(procs=procs)]))
+        assert out.startswith("GPU 0 (0000:03:00.0):")
+        assert "    PID 4242 (python3): 512 MB VRAM" in out
+        assert "    PID 99 (rocprof): 8 MB VRAM" in out
+        assert ctx.errors == []
+
+    def test_idle_gpu_renders_placeholder(self) -> None:
+        """A GPU with no processes shows the (no processes) placeholder."""
+        out, _ = _call(get_gpu_process_info, FakeAmdSmi([_processes(procs=[])]))
+        assert out == "GPU 0 (0000:03:00.0):\n    (no processes)"
+
+    def test_gpu_index_is_forwarded(self) -> None:
+        """An explicit index reaches the wrapper unchanged."""
+        fake = FakeAmdSmi([_processes(1)])
+        _call(get_gpu_process_info, fake, gpu_index=1)
+        assert fake.calls == [1]
+
+    def test_no_gpus(self) -> None:
+        """An empty result renders as an empty string, not an error."""
+        out, ctx = _call(get_gpu_process_info, FakeAmdSmi([]))
+        assert out == ""
+        assert ctx.errors == []
+
+    def test_index_error_is_returned_without_ctx_error(self) -> None:
+        """An out-of-range index is a caller mistake, so it is not reported."""
+        out, ctx = _call(get_gpu_process_info, FakeAmdSmi(error=_OUT_OF_RANGE), gpu_index=9)
+        assert out == "Error: GPU index 9 out of range (0-0)"
+        assert ctx.errors == []
+
+    def test_failure_is_returned_and_reported(self) -> None:
+        """A raising collaborator yields the error string and calls ctx.error."""
+        out, ctx = _call(get_gpu_process_info, FakeAmdSmi(error=RuntimeError("boom")))
+        assert out == "Failed to get GPU process info: boom"
+        assert ctx.errors == [out]
+
+
+class TestGetGpuBadPages:
+    """Cover the get_gpu_bad_pages tool."""
+
+    def test_renders_ecc_counts_and_bad_pages(self) -> None:
+        """Correctable, uncorrectable, deferred and retired page counts render."""
+        out, ctx = _call(get_gpu_bad_pages, FakeAmdSmi([_bad_pages()]))
+        assert out.startswith("GPU 0 (0000:03:00.0):")
+        assert "  ECC Errors: 3 correctable, 1 uncorrectable, 0 deferred" in out
+        assert "  Bad Pages: 2" in out
+        assert ctx.errors == []
+
+    def test_gpu_index_is_forwarded(self) -> None:
+        """An explicit index reaches the wrapper unchanged."""
+        fake = FakeAmdSmi([_bad_pages(0)])
+        _call(get_gpu_bad_pages, fake, gpu_index=0)
+        assert fake.calls == [0]
+
+    def test_no_gpus(self) -> None:
+        """An empty result renders as an empty string, not an error."""
+        out, ctx = _call(get_gpu_bad_pages, FakeAmdSmi([]))
+        assert out == ""
+        assert ctx.errors == []
+
+    def test_index_error_is_returned_without_ctx_error(self) -> None:
+        """An out-of-range index is a caller mistake, so it is not reported."""
+        out, ctx = _call(get_gpu_bad_pages, FakeAmdSmi(error=_OUT_OF_RANGE), gpu_index=9)
+        assert out == "Error: GPU index 9 out of range (0-0)"
+        assert ctx.errors == []
+
+    def test_failure_is_returned_and_reported(self) -> None:
+        """A raising collaborator yields the error string and calls ctx.error."""
+        out, ctx = _call(get_gpu_bad_pages, FakeAmdSmi(error=RuntimeError("boom")))
+        assert out == "Failed to get GPU bad page info: boom"
+        assert ctx.errors == [out]
+
+
+class TestMain:
+    """Cover the transport dispatch in main()."""
+
+    def test_default_transport_is_stdio(self) -> None:
+        """With no arguments the server runs over stdio."""
+        with patch.object(amd_smi_mcp.mcp, "run") as run, patch("sys.argv", ["amd-smi-mcp"]):
+            amd_smi_mcp.main()
+        run.assert_called_once_with(transport="stdio")
+
+    def test_explicit_stdio(self) -> None:
+        """An explicit --transport stdio behaves like the default."""
+        with (
+            patch.object(amd_smi_mcp.mcp, "run") as run,
+            patch("sys.argv", ["amd-smi-mcp", "--transport", "stdio"]),
+        ):
+            amd_smi_mcp.main()
+        run.assert_called_once_with(transport="stdio")
+
+    def test_http_transport_uses_defaults(self) -> None:
+        """HTTP falls back to loopback, port 8001 and the amd_smi path."""
+        with (
+            patch.object(amd_smi_mcp.mcp, "run") as run,
+            patch("sys.argv", ["amd-smi-mcp", "--transport", "http"]),
+        ):
+            amd_smi_mcp.main()
+        run.assert_called_once_with(
+            transport="streamable-http", host="127.0.0.1", port=8001, path="/rocm_mcp/amd_smi"
+        )
+
+    def test_http_transport_honours_overrides(self) -> None:
+        """Host, port and path overrides reach mcp.run()."""
+        argv = [
+            "amd-smi-mcp",
+            "--transport",
+            "http",
+            "--host",
+            "0.0.0.0",  # noqa: S104
+            "--port",
+            "9200",
+            "--path",
+            "/custom",
+        ]
+        with patch.object(amd_smi_mcp.mcp, "run") as run, patch("sys.argv", argv):
+            amd_smi_mcp.main()
+        run.assert_called_once_with(
+            transport="streamable-http",
+            host="0.0.0.0",  # noqa: S104
+            port=9200,
+            path="/custom",
+        )
+
+    def test_invalid_transport_rejected(self) -> None:
+        """A transport outside the declared choices is rejected by argparse."""
+        with (
+            patch("sys.argv", ["amd-smi-mcp", "--transport", "carrier-pigeon"]),
+            pytest.raises(SystemExit),
+        ):
+            amd_smi_mcp.main()
+
+
+class TestToolRegistration:
+    """Assert the tools are actually registered with the real FastMCP server."""
+
+    def test_all_tools_registered_with_mcp(self) -> None:
+        """Every tool name shows up in the server's tool listing."""
+        expected = {
+            "get_driver_information",
+            "list_gpus",
+            "get_gpu_static_info",
+            "get_gpu_metrics",
+            "get_gpu_firmware_info",
+            "get_gpu_process_info",
+            "get_gpu_bad_pages",
+        }
+        assert expected <= _registered_tools()
+
+    def test_server_name(self) -> None:
+        """The server advertises itself as amd-smi."""
+        assert amd_smi_mcp.mcp.name == "amd-smi"
+
+
+def _registered_tools() -> set[str]:
+    """Fetch registered tool names across FastMCP versions."""
+    for attr in ("list_tools", "get_tools"):
+        getter = getattr(amd_smi_mcp.mcp, attr, None)
+        if getter is not None:
+            break
+    else:
+        pytest.fail("FastMCP exposes neither list_tools() nor get_tools()")
+    result = getter()
+    if inspect.isawaitable(result):
+        result = asyncio.run(result)
+    tools = result.values() if hasattr(result, "values") else result
+    names = set()
+    for t in tools:
+        name = getattr(t, "name", None)
+        names.add(name if name is not None else str(t))
+    return names

--- a/rocm_mcp/tests/sysinfo/test_rocminfo_mcp.py
+++ b/rocm_mcp/tests/sysinfo/test_rocminfo_mcp.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the rocminfo MCP server tools.
+
+These exercise the MCP tool layer without ROCm or a GPU by substituting a
+fake ``Rocminfo`` over the module-level singleton.  The fixtures build real
+``AgentInfo``/``RocminfoResult`` objects rather than mocks, so a field rename
+in ``rocm_mcp.sysinfo.rocminfo`` breaks these tests instead of silently
+passing.
+
+Every tool is covered on three paths: the success path, the empty path (no
+GPUs / no agents at all), and the failure path, where the collaborator raises
+and the tool has to both return the error string and report it through
+``ctx.error``.
+"""
+
+import asyncio
+import inspect
+from unittest.mock import patch
+
+import pytest
+
+from rocm_mcp.sysinfo import AgentInfo, DeviceType, RocminfoResult, rocminfo_mcp
+
+
+def _tool(obj):  # noqa: ANN001, ANN202
+    """Return the underlying function whether or not FastMCP wrapped it."""
+    return getattr(obj, "fn", obj)
+
+
+get_gpu_architecture = _tool(rocminfo_mcp.get_gpu_architecture)
+get_all_agents = _tool(rocminfo_mcp.get_all_agents)
+
+
+class FakeContext:
+    """Minimal stand-in for the FastMCP Context that records log calls."""
+
+    def __init__(self) -> None:
+        """Start with empty info and error logs."""
+        self.infos: list[str] = []
+        self.errors: list[str] = []
+
+    async def info(self, message: str) -> None:
+        """Record an informational message."""
+        self.infos.append(message)
+
+    async def error(self, message: str) -> None:
+        """Record an error message."""
+        self.errors.append(message)
+
+
+class FakeRocminfo:
+    """Stand-in for Rocminfo that serves canned agents or raises."""
+
+    def __init__(
+        self, result: RocminfoResult | None = None, error: Exception | None = None
+    ) -> None:
+        """Serve ``result`` from get_agents(), or raise ``error`` if given."""
+        self.result = result
+        self.error = error
+        self.calls = 0
+
+    def get_agents(self) -> RocminfoResult:
+        """Return the canned result, or raise the canned error."""
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def _agent(
+    number: int,
+    name: str,
+    device_type: DeviceType,
+    *,
+    marketing_name: str = "AMD Device",
+    vendor_name: str = "AMD",
+    uuid: str = "GPU-XX",
+    compute_units: int | None = 304,
+    max_clock_freq: int | None = 2100,
+    profile: str | None = "BASE_PROFILE",
+) -> AgentInfo:
+    """Build a real AgentInfo so a field rename fails the test."""
+    return AgentInfo(
+        agent_number=number,
+        name=name,
+        uuid=uuid,
+        marketing_name=marketing_name,
+        vendor_name=vendor_name,
+        device_type=device_type,
+        compute_units=compute_units,
+        max_clock_freq=max_clock_freq,
+        profile=profile,
+    )
+
+
+_CPU = _agent(1, "AMD EPYC 9654", DeviceType.CPU, marketing_name="AMD EPYC 9654", uuid="CPU-XX")
+_GPU0 = _agent(2, "gfx942", DeviceType.GPU, marketing_name="AMD Instinct MI300X")
+_GPU1 = _agent(3, "gfx942", DeviceType.GPU, marketing_name="AMD Instinct MI300X")
+
+
+def _result(*agents: AgentInfo) -> RocminfoResult:
+    """Wrap agents in a real RocminfoResult."""
+    return RocminfoResult(agents=list(agents), raw_output="")
+
+
+def _call(tool, fake: FakeRocminfo) -> tuple[str, FakeContext]:  # noqa: ANN001
+    """Run an async tool against a patched rocminfo singleton."""
+    ctx = FakeContext()
+    with patch.object(rocminfo_mcp, "rocminfo", fake):
+        return asyncio.run(tool(ctx)), ctx
+
+
+class TestGetGpuArchitecture:
+    """Cover the get_gpu_architecture tool."""
+
+    def test_lists_only_gpu_agents(self) -> None:
+        """CPU agents are filtered out and GPUs are renumbered from zero."""
+        out, ctx = _call(get_gpu_architecture, FakeRocminfo(_result(_CPU, _GPU0, _GPU1)))
+        assert "GPU 0:" in out
+        assert "GPU 1:" in out
+        assert "AMD EPYC 9654" not in out
+        assert ctx.errors == []
+
+    def test_reports_architecture_fields(self) -> None:
+        """Architecture, marketing name, vendor, CUs and clock are all rendered."""
+        out, _ = _call(get_gpu_architecture, FakeRocminfo(_result(_GPU0)))
+        assert "  Architecture: gfx942" in out
+        assert "  Marketing Name: AMD Instinct MI300X" in out
+        assert "  Vendor: AMD" in out
+        assert "  Compute Units: 304" in out
+        assert "  Max Clock Frequency: 2100 MHz" in out
+
+    def test_optional_fields_omitted_when_unset(self) -> None:
+        """Compute units and clock lines disappear when the parser found nothing."""
+        gpu = _agent(2, "gfx90a", DeviceType.GPU, compute_units=None, max_clock_freq=None)
+        out, _ = _call(get_gpu_architecture, FakeRocminfo(_result(gpu)))
+        assert "Compute Units" not in out
+        assert "Max Clock Frequency" not in out
+
+    def test_no_gpus_among_agents(self) -> None:
+        """A CPU-only system reports no GPUs rather than an empty string."""
+        out, ctx = _call(get_gpu_architecture, FakeRocminfo(_result(_CPU)))
+        assert out == "No GPUs found in the system."
+        # The empty result is not an error, so nothing is reported to the client.
+        assert ctx.errors == []
+
+    def test_no_agents_at_all(self) -> None:
+        """An entirely empty agent list takes the same no-GPU path."""
+        out, _ = _call(get_gpu_architecture, FakeRocminfo(_result()))
+        assert out == "No GPUs found in the system."
+
+    def test_failure_is_returned_and_reported(self) -> None:
+        """A raising collaborator yields the error string and calls ctx.error."""
+        boom = RuntimeError("rocminfo execution failed")
+        out, ctx = _call(get_gpu_architecture, FakeRocminfo(error=boom))
+        assert out == "Failed to get GPU architecture: rocminfo execution failed"
+        assert ctx.errors == [out]
+
+    def test_missing_executable_is_reported(self) -> None:
+        """FileNotFoundError from the wrapper is surfaced the same way."""
+        out, ctx = _call(get_gpu_architecture, FakeRocminfo(error=FileNotFoundError("no rocminfo")))
+        assert out.startswith("Failed to get GPU architecture:")
+        assert ctx.errors == [out]
+
+
+class TestGetAllAgents:
+    """Cover the get_all_agents tool."""
+
+    def test_renders_every_agent(self) -> None:
+        """Both CPU and GPU agents appear, keyed by their own agent number."""
+        out, ctx = _call(get_all_agents, FakeRocminfo(_result(_CPU, _GPU0)))
+        assert "Agent 1:" in out
+        assert "Agent 2:" in out
+        assert ctx.errors == []
+
+    def test_reports_agent_fields(self) -> None:
+        """Name, device type value, marketing name, vendor, UUID and profile render."""
+        out, _ = _call(get_all_agents, FakeRocminfo(_result(_GPU0)))
+        assert "  Name: gfx942" in out
+        assert "  Type: GPU" in out
+        assert "  Marketing Name: AMD Instinct MI300X" in out
+        assert "  Vendor: AMD" in out
+        assert "  UUID: GPU-XX" in out
+        assert "  Profile: BASE_PROFILE" in out
+        assert "  Compute Units: 304" in out
+        assert "  Max Clock Frequency: 2100 MHz" in out
+
+    def test_device_type_uses_enum_value(self) -> None:
+        """The rendered type comes from DeviceType.value, not the member name."""
+        unknown = _agent(9, "mystery", DeviceType.Unknown)
+        out, _ = _call(get_all_agents, FakeRocminfo(_result(unknown)))
+        assert f"  Type: {DeviceType.Unknown.value}" in out
+
+    def test_optional_fields_omitted_when_unset(self) -> None:
+        """Profile, compute units and clock lines are skipped when falsy."""
+        bare = _agent(
+            4,
+            "gfx1100",
+            DeviceType.GPU,
+            compute_units=None,
+            max_clock_freq=None,
+            profile=None,
+        )
+        out, _ = _call(get_all_agents, FakeRocminfo(_result(bare)))
+        assert "Profile" not in out
+        assert "Compute Units" not in out
+        assert "Max Clock Frequency" not in out
+
+    def test_no_agents(self) -> None:
+        """An empty agent list reports that, and is not treated as an error."""
+        out, ctx = _call(get_all_agents, FakeRocminfo(_result()))
+        assert out == "No HSA agents found in the system."
+        assert ctx.errors == []
+
+    def test_failure_is_returned_and_reported(self) -> None:
+        """A raising collaborator yields the error string and calls ctx.error."""
+        out, ctx = _call(get_all_agents, FakeRocminfo(error=RuntimeError("boom")))
+        assert out == "Failed to get agent information: boom"
+        assert ctx.errors == [out]
+
+
+class TestMain:
+    """Cover the transport dispatch in main()."""
+
+    def test_default_transport_is_stdio(self) -> None:
+        """With no arguments the server runs over stdio."""
+        with patch.object(rocminfo_mcp.mcp, "run") as run, patch("sys.argv", ["rocminfo-mcp"]):
+            rocminfo_mcp.main()
+        run.assert_called_once_with(transport="stdio")
+
+    def test_explicit_stdio(self) -> None:
+        """An explicit --transport stdio behaves like the default."""
+        with (
+            patch.object(rocminfo_mcp.mcp, "run") as run,
+            patch("sys.argv", ["rocminfo-mcp", "--transport", "stdio"]),
+        ):
+            rocminfo_mcp.main()
+        run.assert_called_once_with(transport="stdio")
+
+    def test_http_transport_uses_defaults(self) -> None:
+        """HTTP falls back to loopback, port 8000 and the rocminfo path."""
+        with (
+            patch.object(rocminfo_mcp.mcp, "run") as run,
+            patch("sys.argv", ["rocminfo-mcp", "--transport", "http"]),
+        ):
+            rocminfo_mcp.main()
+        run.assert_called_once_with(
+            transport="streamable-http", host="127.0.0.1", port=8000, path="/rocm_mcp/rocminfo"
+        )
+
+    def test_http_transport_honours_overrides(self) -> None:
+        """Host, port and path overrides reach mcp.run()."""
+        argv = [
+            "rocminfo-mcp",
+            "--transport",
+            "http",
+            "--host",
+            "0.0.0.0",  # noqa: S104
+            "--port",
+            "9100",
+            "--path",
+            "/custom",
+        ]
+        with patch.object(rocminfo_mcp.mcp, "run") as run, patch("sys.argv", argv):
+            rocminfo_mcp.main()
+        run.assert_called_once_with(
+            transport="streamable-http",
+            host="0.0.0.0",  # noqa: S104
+            port=9100,
+            path="/custom",
+        )
+
+    def test_invalid_transport_rejected(self) -> None:
+        """A transport outside the declared choices is rejected by argparse."""
+        with (
+            patch("sys.argv", ["rocminfo-mcp", "--transport", "carrier-pigeon"]),
+            pytest.raises(SystemExit),
+        ):
+            rocminfo_mcp.main()
+
+
+class TestToolRegistration:
+    """Assert the tools are actually registered with the real FastMCP server."""
+
+    def test_both_tools_registered_with_mcp(self) -> None:
+        """Both tool names show up in the server's tool listing."""
+        assert {"get_gpu_architecture", "get_all_agents"} <= _registered_tools()
+
+    def test_server_name(self) -> None:
+        """The server advertises itself as rocminfo."""
+        assert rocminfo_mcp.mcp.name == "rocminfo"
+
+
+def _registered_tools() -> set[str]:
+    """Fetch registered tool names across FastMCP versions."""
+    for attr in ("list_tools", "get_tools"):
+        getter = getattr(rocminfo_mcp.mcp, attr, None)
+        if getter is not None:
+            break
+    else:
+        pytest.fail("FastMCP exposes neither list_tools() nor get_tools()")
+    result = getter()
+    if inspect.isawaitable(result):
+        result = asyncio.run(result)
+    tools = result.values() if hasattr(result, "values") else result
+    names = set()
+    for t in tools:
+        name = getattr(t, "name", None)
+        names.add(name if name is not None else str(t))
+    return names

--- a/uprof_mcp/src/uprof_mcp/uprof_profiler.py
+++ b/uprof_mcp/src/uprof_mcp/uprof_profiler.py
@@ -109,9 +109,13 @@ class UProfProfiler:
                 environment variable 'INTELLIKIT_UPROF_CLI' or the default path DEFAULT_EXE_PATH.
         """
         self.logger = logger if logger is not None else logging.getLogger(self.__class__.__name__)
-        self.profiler_exe = os.getenv(
-            "INTELLIKIT_UPROF_CLI",
-            str(uprof) if uprof is not None else UProfProfiler.DEFAULT_EXE_PATH,
+        # An explicit argument wins over the environment; the env var is only a
+        # fallback when the caller did not choose. The reverse made it impossible
+        # to override the env var in-process.
+        self.profiler_exe = (
+            str(uprof)
+            if uprof is not None
+            else os.getenv("INTELLIKIT_UPROF_CLI", UProfProfiler.DEFAULT_EXE_PATH)
         )
         self.logger.info("Initialized profiler.")
 

--- a/uprof_mcp/src/uprof_mcp/uprof_profiler_mcp.py
+++ b/uprof_mcp/src/uprof_mcp/uprof_profiler_mcp.py
@@ -47,12 +47,15 @@ async def profile_for_hotspots(
                 executable_args=executable_arguments,
             )
         else:
-            with tempfile.TemporaryDirectory(delete=False) as tmpdir:
-                result = profiler.find_hotspots(
-                    output_dir=tmpdir,
-                    executable=executable,
-                    executable_args=executable_arguments,
-                )
+            # mkdtemp rather than TemporaryDirectory(delete=False): the latter is
+            # Python 3.12+, and this package supports >=3.10. The directory is kept
+            # deliberately -- the caller reads the report out of it after we return.
+            tmpdir = tempfile.mkdtemp()
+            result = profiler.find_hotspots(
+                output_dir=tmpdir,
+                executable=executable,
+                executable_args=executable_arguments,
+            )
 
         await ctx.info(f"Profiling of {executable} completed with results in {result.report_path}.")
         with result.report_path.open() as file:

--- a/uprof_mcp/tests/test_uprof_profiler.py
+++ b/uprof_mcp/tests/test_uprof_profiler.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the UProfProfiler wrapper around the AMD uProf CLI.
+
+AMD uProf is never invoked: ``subprocess.run`` is patched and fed the real
+``subprocess.CompletedProcess``/``CalledProcessError``/``TimeoutExpired``
+objects the wrapper claims to handle, so a change in how those are consumed
+breaks these tests instead of silently passing.  Every path out of
+``find_hotspots`` is covered -- success, a missing executable, a missing
+uProf CLI, a timeout, a non-zero exit, and both of the "uProf printed
+something we could not parse" ``RuntimeError`` paths.
+
+All paths come from ``tmp_path`` so the tests do not depend on the working
+directory pytest happens to be invoked from, and an autouse fixture clears
+``INTELLIKIT_UPROF_CLI`` so a developer machine that happens to have uProf
+configured cannot change the outcome.
+"""
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from uprof_mcp.uprof_profiler import UProfProfiler, UProfProfilerResult
+
+SAMPLE_STDOUT = """AMDuProfCLI: collection started
+Generated data files path: /scratch/AMDuProf-app-datafiles
+Generated report file: /scratch/AMDuProf-app.csv
+"""
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():  # noqa: ANN202
+    """Run each test with INTELLIKIT_UPROF_CLI unset unless it sets it."""
+    with patch.dict("os.environ"):
+        os.environ.pop("INTELLIKIT_UPROF_CLI", None)
+        yield
+
+
+def _executable(tmp_path: Path) -> Path:
+    """Create a real file to stand in for the profiled executable."""
+    exe = tmp_path / "app"
+    exe.write_text("#!/bin/sh\nexit 0\n")
+    return exe
+
+
+def _completed(stdout: str = SAMPLE_STDOUT) -> subprocess.CompletedProcess:
+    """Build a real CompletedProcess as subprocess.run would return."""
+    return subprocess.CompletedProcess(args=["AMDuProfCLI"], returncode=0, stdout=stdout, stderr="")
+
+
+class TestInit:
+    """Cover how the profiler decides which uProf CLI to run."""
+
+    def test_default_executable_path(self) -> None:
+        """With no argument and no environment override the default is used."""
+        assert UProfProfiler().profiler_exe == UProfProfiler.DEFAULT_EXE_PATH
+
+    def test_explicit_uprof_argument(self) -> None:
+        """An explicit uprof path wins over the default."""
+        profiler = UProfProfiler(uprof="/opt/AMDuProf_6.0/bin/AMDuProfCLI")
+        assert profiler.profiler_exe == "/opt/AMDuProf_6.0/bin/AMDuProfCLI"
+
+    def test_explicit_uprof_pathlike_is_stringified(self, tmp_path: Path) -> None:
+        """A PathLike uprof argument is stored as a string."""
+        profiler = UProfProfiler(uprof=tmp_path / "AMDuProfCLI")
+        assert profiler.profiler_exe == str(tmp_path / "AMDuProfCLI")
+
+    def test_environment_variable_override(self) -> None:
+        """INTELLIKIT_UPROF_CLI overrides the default path."""
+        env_path = "/custom/path/to/AMDuProfCLI"
+        with patch.dict("os.environ", {"INTELLIKIT_UPROF_CLI": env_path}):
+            assert UProfProfiler().profiler_exe == env_path
+
+    def test_default_logger_is_created(self) -> None:
+        """Omitting the logger yields one named after the class."""
+        assert UProfProfiler().logger.name == "UProfProfiler"
+
+    def test_supplied_logger_is_kept(self) -> None:
+        """A supplied logger is used as-is."""
+        logger = logging.getLogger("test-uprof")
+        assert UProfProfiler(logger=logger).logger is logger
+
+
+class TestFindHotspots:
+    """Cover every path out of find_hotspots."""
+
+    def test_success_returns_parsed_paths(self, tmp_path: Path) -> None:
+        """Both paths are lifted out of the uProf stdout into a real result."""
+        profiler = UProfProfiler()
+        with patch("subprocess.run", return_value=_completed()) as run:
+            result = profiler.find_hotspots(tmp_path / "out", _executable(tmp_path), ["--fast"])
+        assert isinstance(result, UProfProfilerResult)
+        assert result.results_path == Path("/scratch/AMDuProf-app-datafiles")
+        assert result.report_path == Path("/scratch/AMDuProf-app.csv")
+        assert run.call_count == 1
+
+    def test_command_line_is_assembled(self, tmp_path: Path) -> None:
+        """The uProf command names the config, both output paths and the args."""
+        out_dir = tmp_path / "out"
+        exe = _executable(tmp_path)
+        profiler = UProfProfiler(uprof="/opt/uprof/AMDuProfCLI")
+        with patch("subprocess.run", return_value=_completed()) as run:
+            profiler.find_hotspots(out_dir, exe, ["--size", "1024"])
+        assert run.call_args.args[0] == [
+            "/opt/uprof/AMDuProfCLI",
+            "profile",
+            "--config",
+            "hotspots",
+            "--output-dir",
+            str(out_dir),
+            "--log-path",
+            str(out_dir),
+            str(exe),
+            "--size",
+            "1024",
+        ]
+
+    def test_subprocess_options(self, tmp_path: Path) -> None:
+        """Output is captured, decoded, checked, and bounded by the timeout."""
+        profiler = UProfProfiler()
+        with patch("subprocess.run", return_value=_completed()) as run:
+            profiler.find_hotspots(tmp_path / "out", _executable(tmp_path), None)
+        assert run.call_args.kwargs == {
+            "timeout": UProfProfiler.DEFAULT_TIMEOUT,
+            "capture_output": True,
+            "check": True,
+            "text": True,
+        }
+
+    def test_none_arguments_append_nothing(self, tmp_path: Path) -> None:
+        """executable_args=None runs the executable with no trailing arguments."""
+        exe = _executable(tmp_path)
+        profiler = UProfProfiler()
+        with patch("subprocess.run", return_value=_completed()) as run:
+            profiler.find_hotspots(tmp_path / "out", exe, None)
+        assert run.call_args.args[0][-1] == str(exe)
+
+    def test_output_directory_is_created(self, tmp_path: Path) -> None:
+        """A missing output directory, including parents, is created."""
+        out_dir = tmp_path / "nested" / "results"
+        profiler = UProfProfiler()
+        with patch("subprocess.run", return_value=_completed()):
+            profiler.find_hotspots(out_dir, _executable(tmp_path), None)
+        assert out_dir.is_dir()
+
+    def test_existing_output_directory_is_reused(self, tmp_path: Path) -> None:
+        """An output directory that already exists is not an error."""
+        out_dir = tmp_path / "results"
+        out_dir.mkdir()
+        profiler = UProfProfiler()
+        with patch("subprocess.run", return_value=_completed()):
+            profiler.find_hotspots(out_dir, _executable(tmp_path), None)
+        assert out_dir.is_dir()
+
+    def test_parsed_paths_are_stripped(self, tmp_path: Path) -> None:
+        """Trailing whitespace on the uProf output lines is removed."""
+        stdout = (
+            "Generated data files path: /scratch/data   \r\n"
+            "Generated report file: /scratch/r.csv \n"
+        )
+        profiler = UProfProfiler()
+        with patch("subprocess.run", return_value=_completed(stdout)):
+            result = profiler.find_hotspots(tmp_path / "out", _executable(tmp_path), None)
+        assert result.results_path == Path("/scratch/data")
+        assert result.report_path == Path("/scratch/r.csv")
+
+    def test_missing_executable(self, tmp_path: Path) -> None:
+        """A non-existent executable fails before uProf is ever launched."""
+        profiler = UProfProfiler()
+        with patch("subprocess.run") as run:
+            with pytest.raises(FileNotFoundError, match=r"not found\."):
+                profiler.find_hotspots(tmp_path / "out", tmp_path / "missing", None)
+            assert run.call_count == 0
+
+    def test_directory_is_not_an_executable(self, tmp_path: Path) -> None:
+        """A directory passed as the executable is rejected the same way."""
+        a_dir = tmp_path / "a_dir"
+        a_dir.mkdir()
+        profiler = UProfProfiler()
+        with pytest.raises(FileNotFoundError, match=r"not found\."):
+            profiler.find_hotspots(tmp_path / "out", a_dir, None)
+
+    def test_missing_uprof_cli(self, tmp_path: Path) -> None:
+        """A missing uProf CLI is re-raised naming the path that was tried."""
+        profiler = UProfProfiler(uprof="/nowhere/AMDuProfCLI")
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError(2, "No such file")),
+            pytest.raises(FileNotFoundError, match="uprof executable not found at"),
+        ):
+            profiler.find_hotspots(tmp_path / "out", _executable(tmp_path), None)
+
+    def test_timeout_propagates(self, tmp_path: Path) -> None:
+        """A profiling run that overruns the timeout propagates TimeoutExpired."""
+        timeout = subprocess.TimeoutExpired(cmd=["AMDuProfCLI"], timeout=180)
+        profiler = UProfProfiler()
+        with (
+            patch("subprocess.run", side_effect=timeout),
+            pytest.raises(subprocess.TimeoutExpired),
+        ):
+            profiler.find_hotspots(tmp_path / "out", _executable(tmp_path), None)
+
+    def test_non_zero_exit_propagates(self, tmp_path: Path) -> None:
+        """A non-zero uProf exit propagates CalledProcessError."""
+        failure = subprocess.CalledProcessError(1, ["AMDuProfCLI"], stderr="profiling failed")
+        profiler = UProfProfiler()
+        with (
+            patch("subprocess.run", side_effect=failure),
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            profiler.find_hotspots(tmp_path / "out", _executable(tmp_path), None)
+
+    def test_missing_results_path_in_output(self, tmp_path: Path) -> None:
+        """Output without the data files line is a RuntimeError, not a crash."""
+        stdout = "Generated report file: /scratch/AMDuProf-app.csv\n"
+        profiler = UProfProfiler()
+        with (
+            patch("subprocess.run", return_value=_completed(stdout)),
+            pytest.raises(RuntimeError, match="Profiling results path not found"),
+        ):
+            profiler.find_hotspots(tmp_path / "out", _executable(tmp_path), None)
+
+    def test_missing_report_path_in_output(self, tmp_path: Path) -> None:
+        """Output without the report line is a RuntimeError, not a crash."""
+        stdout = "Generated data files path: /scratch/AMDuProf-app-datafiles\n"
+        profiler = UProfProfiler()
+        with (
+            patch("subprocess.run", return_value=_completed(stdout)),
+            pytest.raises(RuntimeError, match="Profiling report not found"),
+        ):
+            profiler.find_hotspots(tmp_path / "out", _executable(tmp_path), None)
+
+    def test_empty_output(self, tmp_path: Path) -> None:
+        """Completely empty uProf output trips the results path check first."""
+        profiler = UProfProfiler()
+        with (
+            patch("subprocess.run", return_value=_completed("")),
+            pytest.raises(RuntimeError, match="Profiling results path not found"),
+        ):
+            profiler.find_hotspots(tmp_path / "out", _executable(tmp_path), None)

--- a/uprof_mcp/tests/test_uprof_profiler_mcp.py
+++ b/uprof_mcp/tests/test_uprof_profiler_mcp.py
@@ -1,0 +1,337 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the uProf profiler MCP server tool.
+
+These exercise the MCP tool layer without AMD uProf by substituting a fake
+profiler over the module-level singleton.  The fake returns a real
+``UProfProfilerResult`` pointing at a report file created under ``tmp_path``,
+so a field rename in ``uprof_mcp.uprof_profiler`` breaks these tests instead
+of silently passing, and the tool genuinely has to open and read the report.
+
+The tool is covered on the success path with an explicit output directory,
+the success path that falls back to a temporary directory, the empty path
+(the report exists but has nothing in it), and the failure paths -- the
+profiler raised, or the report it named cannot be read.  Every failure has to
+both return the error string and report it through ``ctx.error``, and that is
+asserted.
+"""
+
+import asyncio
+import inspect
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from uprof_mcp import uprof_profiler_mcp
+from uprof_mcp.uprof_profiler import UProfProfilerResult
+
+REPORT = "Function,Samples\nmain,1024\nkernel,512\n"
+
+
+def _tool(obj):  # noqa: ANN001, ANN202
+    """Return the underlying function whether or not FastMCP wrapped it."""
+    return getattr(obj, "fn", obj)
+
+
+profile_for_hotspots = _tool(uprof_profiler_mcp.profile_for_hotspots)
+
+
+class FakeContext:
+    """Minimal stand-in for the FastMCP Context that records log calls."""
+
+    def __init__(self) -> None:
+        """Start with empty info and error logs."""
+        self.infos: list[str] = []
+        self.errors: list[str] = []
+
+    async def info(self, message: str) -> None:
+        """Record an informational message."""
+        self.infos.append(message)
+
+    async def error(self, message: str) -> None:
+        """Record an error message."""
+        self.errors.append(message)
+
+
+class FakeUProfProfiler:
+    """Stand-in for UProfProfiler that records find_hotspots() calls."""
+
+    def __init__(
+        self, result: UProfProfilerResult | None = None, error: Exception | None = None
+    ) -> None:
+        """Serve ``result`` from find_hotspots(), or raise ``error`` if given."""
+        self.result = result
+        self.error = error
+        self.calls: list[dict] = []
+
+    def find_hotspots(
+        self,
+        output_dir: str | Path,
+        executable: str | Path,
+        executable_args: list[str] | None,
+    ) -> UProfProfilerResult:
+        """Record the arguments and serve the canned result or error."""
+        self.calls.append(
+            {
+                "output_dir": output_dir,
+                "executable": executable,
+                "executable_args": executable_args,
+            }
+        )
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def _report(tmp_path: Path, text: str = REPORT) -> UProfProfilerResult:
+    """Write a report file and wrap it in a real UProfProfilerResult."""
+    report_path = tmp_path / "AMDuProf-app.csv"
+    report_path.write_text(text)
+    return UProfProfilerResult(results_path=tmp_path / "datafiles", report_path=report_path)
+
+
+def _call(fake: FakeUProfProfiler, **kwargs) -> tuple[str, FakeContext]:
+    """Run the tool against a patched profiler singleton."""
+    ctx = FakeContext()
+    with patch.object(uprof_profiler_mcp, "profiler", fake):
+        return asyncio.run(profile_for_hotspots(ctx, **kwargs)), ctx
+
+
+def _fake_temporary_directory(path: Path, calls: list[dict]):  # noqa: ANN202
+    """Build a TemporaryDirectory replacement that yields ``path``.
+
+    The real ``tempfile.TemporaryDirectory(delete=False)`` keyword only exists
+    on Python 3.12+, so patching it here both keeps the test off the host's
+    temporary directory and pins the keyword the server relies on.
+    """
+
+    @contextmanager
+    def _factory(**kwargs) -> Iterator[str]:
+        calls.append(kwargs)
+        yield str(path)
+
+    return _factory
+
+
+class TestProfileForHotspots:
+    """Cover the profile_for_hotspots tool."""
+
+    def test_returns_the_report_contents(self, tmp_path: Path) -> None:
+        """The tool reads the report uProf produced and returns it verbatim."""
+        out_dir = tmp_path / "results"
+        out, ctx = _call(
+            FakeUProfProfiler(_report(tmp_path)),
+            executable="./app",
+            executable_arguments=[],
+            output_dir=out_dir,
+        )
+        assert out == REPORT
+        assert ctx.errors == []
+
+    def test_reports_completion_through_ctx_info(self, tmp_path: Path) -> None:
+        """A successful run is announced with the report path."""
+        result = _report(tmp_path)
+        _, ctx = _call(
+            FakeUProfProfiler(result),
+            executable="./app",
+            executable_arguments=[],
+            output_dir=tmp_path / "results",
+        )
+        assert ctx.infos == [f"Profiling of ./app completed with results in {result.report_path}."]
+
+    def test_executable_and_arguments_are_forwarded(self, tmp_path: Path) -> None:
+        """The executable and its arguments reach the profiler unchanged."""
+        fake = FakeUProfProfiler(_report(tmp_path))
+        _call(
+            fake,
+            executable="./app",
+            executable_arguments=["--size", "1024"],
+            output_dir=tmp_path / "results",
+        )
+        assert fake.calls[0]["executable"] == "./app"
+        assert fake.calls[0]["executable_args"] == ["--size", "1024"]
+
+    def test_output_directory_is_created(self, tmp_path: Path) -> None:
+        """A missing output directory, including parents, is created first."""
+        out_dir = tmp_path / "nested" / "results"
+        fake = FakeUProfProfiler(_report(tmp_path))
+        _call(fake, executable="./app", executable_arguments=[], output_dir=out_dir)
+        assert out_dir.is_dir()
+        assert fake.calls[0]["output_dir"] == out_dir
+
+    def test_string_output_directory_is_coerced_to_path(self, tmp_path: Path) -> None:
+        """A string output directory reaches the profiler as a Path."""
+        out_dir = tmp_path / "results"
+        fake = FakeUProfProfiler(_report(tmp_path))
+        _call(fake, executable="./app", executable_arguments=[], output_dir=str(out_dir))
+        assert fake.calls[0]["output_dir"] == out_dir
+        assert isinstance(fake.calls[0]["output_dir"], Path)
+
+    def test_falls_back_to_a_kept_temporary_directory(self, tmp_path: Path) -> None:
+        """With no output directory a temporary one that survives the run is used."""
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        tempdir_calls: list[dict] = []
+        fake = FakeUProfProfiler(_report(tmp_path))
+        ctx = FakeContext()
+        with (
+            patch.object(uprof_profiler_mcp, "profiler", fake),
+            patch(
+                "tempfile.TemporaryDirectory",
+                _fake_temporary_directory(scratch, tempdir_calls),
+            ),
+        ):
+            out = asyncio.run(
+                profile_for_hotspots(ctx, executable="./app", executable_arguments=[])
+            )
+        assert out == REPORT
+        assert fake.calls[0]["output_dir"] == str(scratch)
+        # The results have to outlive the context manager or the report is gone.
+        assert tempdir_calls == [{"delete": False}]
+
+    def test_empty_report(self, tmp_path: Path) -> None:
+        """An empty report is returned as an empty string, not an error."""
+        out, ctx = _call(
+            FakeUProfProfiler(_report(tmp_path, text="")),
+            executable="./app",
+            executable_arguments=[],
+            output_dir=tmp_path / "results",
+        )
+        assert out == ""
+        assert ctx.errors == []
+
+    def test_profiler_failure_is_returned_and_reported(self, tmp_path: Path) -> None:
+        """A raising profiler yields the error string and calls ctx.error."""
+        out, ctx = _call(
+            FakeUProfProfiler(error=RuntimeError("Profiling report not found")),
+            executable="./app",
+            executable_arguments=[],
+            output_dir=tmp_path / "results",
+        )
+        assert out == "Profiling of ./app failed: Profiling report not found"
+        assert ctx.errors == [out]
+
+    def test_missing_uprof_is_returned_and_reported(self, tmp_path: Path) -> None:
+        """A missing uProf CLI surfaces the same way as any other failure."""
+        error = FileNotFoundError("uprof executable not found at '/opt/uprof/AMDuProfCLI'")
+        out, ctx = _call(
+            FakeUProfProfiler(error=error),
+            executable="./app",
+            executable_arguments=[],
+            output_dir=tmp_path / "results",
+        )
+        assert out.startswith("Profiling of ./app failed:")
+        assert ctx.errors == [out]
+
+    def test_unreadable_report_is_returned_and_reported(self, tmp_path: Path) -> None:
+        """A report path that does not exist is reported rather than raised."""
+        result = UProfProfilerResult(
+            results_path=tmp_path / "datafiles",
+            report_path=tmp_path / "does-not-exist.csv",
+        )
+        out, ctx = _call(
+            FakeUProfProfiler(result),
+            executable="./app",
+            executable_arguments=[],
+            output_dir=tmp_path / "results",
+        )
+        assert out.startswith("Profiling of ./app failed:")
+        assert ctx.errors == [out]
+
+
+class TestMain:
+    """Cover the transport dispatch in main()."""
+
+    def test_default_transport_is_stdio(self) -> None:
+        """With no arguments the server runs over stdio."""
+        with (
+            patch.object(uprof_profiler_mcp.mcp, "run") as run,
+            patch("sys.argv", ["uprof-profiler-mcp"]),
+        ):
+            uprof_profiler_mcp.main()
+        run.assert_called_once_with(transport="stdio")
+
+    def test_explicit_stdio(self) -> None:
+        """An explicit --transport stdio behaves like the default."""
+        with (
+            patch.object(uprof_profiler_mcp.mcp, "run") as run,
+            patch("sys.argv", ["uprof-profiler-mcp", "--transport", "stdio"]),
+        ):
+            uprof_profiler_mcp.main()
+        run.assert_called_once_with(transport="stdio")
+
+    def test_http_transport_uses_defaults(self) -> None:
+        """HTTP falls back to loopback, port 8000 and the uprof_mcp path."""
+        with (
+            patch.object(uprof_profiler_mcp.mcp, "run") as run,
+            patch("sys.argv", ["uprof-profiler-mcp", "--transport", "http"]),
+        ):
+            uprof_profiler_mcp.main()
+        run.assert_called_once_with(
+            transport="streamable-http", host="127.0.0.1", port=8000, path="/uprof_mcp"
+        )
+
+    def test_http_transport_honours_overrides(self) -> None:
+        """Host, port and path overrides reach mcp.run()."""
+        argv = [
+            "uprof-profiler-mcp",
+            "--transport",
+            "http",
+            "--host",
+            "0.0.0.0",  # noqa: S104
+            "--port",
+            "9500",
+            "--path",
+            "/custom",
+        ]
+        with patch.object(uprof_profiler_mcp.mcp, "run") as run, patch("sys.argv", argv):
+            uprof_profiler_mcp.main()
+        run.assert_called_once_with(
+            transport="streamable-http",
+            host="0.0.0.0",  # noqa: S104
+            port=9500,
+            path="/custom",
+        )
+
+    def test_invalid_transport_rejected(self) -> None:
+        """A transport outside the declared choices is rejected by argparse."""
+        with (
+            patch("sys.argv", ["uprof-profiler-mcp", "--transport", "carrier-pigeon"]),
+            pytest.raises(SystemExit),
+        ):
+            uprof_profiler_mcp.main()
+
+
+class TestToolRegistration:
+    """Assert the tool is actually registered with the real FastMCP server."""
+
+    def test_tool_registered_with_mcp(self) -> None:
+        """The tool name shows up in the server's tool listing."""
+        assert "profile_for_hotspots" in _registered_tools()
+
+    def test_server_name(self) -> None:
+        """The server advertises itself as uprof_profiler."""
+        assert uprof_profiler_mcp.mcp.name == "uprof_profiler"
+
+
+def _registered_tools() -> set[str]:
+    """Fetch registered tool names across FastMCP versions."""
+    for attr in ("list_tools", "get_tools"):
+        getter = getattr(uprof_profiler_mcp.mcp, attr, None)
+        if getter is not None:
+            break
+    else:
+        pytest.fail("FastMCP exposes neither list_tools() nor get_tools()")
+    result = getter()
+    if inspect.isawaitable(result):
+        result = asyncio.run(result)
+    tools = result.values() if hasattr(result, "values") else result
+    names = set()
+    for t in tools:
+        name = getattr(t, "name", None)
+        names.add(name if name is not None else str(t))
+    return names

--- a/uprof_mcp/tests/test_uprof_profiler_mcp.py
+++ b/uprof_mcp/tests/test_uprof_profiler_mcp.py
@@ -19,8 +19,6 @@ asserted.
 
 import asyncio
 import inspect
-from collections.abc import Iterator
-from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -101,22 +99,6 @@ def _call(fake: FakeUProfProfiler, **kwargs) -> tuple[str, FakeContext]:
         return asyncio.run(profile_for_hotspots(ctx, **kwargs)), ctx
 
 
-def _fake_temporary_directory(path: Path, calls: list[dict]):  # noqa: ANN202
-    """Build a TemporaryDirectory replacement that yields ``path``.
-
-    The real ``tempfile.TemporaryDirectory(delete=False)`` keyword only exists
-    on Python 3.12+, so patching it here both keeps the test off the host's
-    temporary directory and pins the keyword the server relies on.
-    """
-
-    @contextmanager
-    def _factory(**kwargs) -> Iterator[str]:
-        calls.append(kwargs)
-        yield str(path)
-
-    return _factory
-
-
 class TestProfileForHotspots:
     """Cover the profile_for_hotspots tool."""
 
@@ -175,23 +157,27 @@ class TestProfileForHotspots:
         """With no output directory a temporary one that survives the run is used."""
         scratch = tmp_path / "scratch"
         scratch.mkdir()
-        tempdir_calls: list[dict] = []
+        mkdtemp_calls: list[int] = []
         fake = FakeUProfProfiler(_report(tmp_path))
         ctx = FakeContext()
+
+        def _fake_mkdtemp() -> str:
+            mkdtemp_calls.append(1)
+            return str(scratch)
+
         with (
             patch.object(uprof_profiler_mcp, "profiler", fake),
-            patch(
-                "tempfile.TemporaryDirectory",
-                _fake_temporary_directory(scratch, tempdir_calls),
-            ),
+            patch("tempfile.mkdtemp", _fake_mkdtemp),
         ):
             out = asyncio.run(
                 profile_for_hotspots(ctx, executable="./app", executable_arguments=[])
             )
         assert out == REPORT
         assert fake.calls[0]["output_dir"] == str(scratch)
-        # The results have to outlive the context manager or the report is gone.
-        assert tempdir_calls == [{"delete": False}]
+        # mkdtemp, not TemporaryDirectory(delete=False): the latter is 3.12+ and this
+        # package supports >=3.10. The directory must outlive the call either way --
+        # the report is read out of it after we return.
+        assert mkdtemp_calls == [1]
 
     def test_empty_report(self, tmp_path: Path) -> None:
         """An empty report is returned as an empty string, not an error."""


### PR DESCRIPTION
Measured on an MI300X node: rocm_mcp **53% → 96%**, uprof_mcp **0% → 99%** (it had no tests at all). Both were excluded from the CI pytest matrix; this adds them.

The gap was entirely the MCP tool wrappers — the surface agents call. Same shape #157 found in linex.

Follows the `linex/tests/test_mcp_server.py` pattern: real dataclasses rather than MagicMock, fake collaborators over the module singletons, `asyncio.run` (no new pytest-asyncio dep).

Also fixes three defects the tests exposed:
- `TemporaryDirectory(delete=False)` is 3.12+, package declares >=3.10 → `mkdtemp()`
- explicit `hipcc=`/`rocminfo=`/`uprof=` argument was overridden by the env var
- `AmdSmi` was constructed at import time, so importing the module required a driver

And anchors `test_hip_compiler.py` paths to the test file — CI runs pytest from the repo root, where the old cwd-relative paths didn't resolve.