### PR TITLE
Hook hsa_amd_queue_create so accordo captures on ROCm 10

### DIFF
--- a/accordo/cmake/Modules/FindHSA.cmake
+++ b/accordo/cmake/Modules/FindHSA.cmake
@@ -24,21 +24,34 @@
 
 # FindHSA.cmake - Locate the HSA runtime library and set up the target
 
-# Search for the HSA include directory with priority given to /opt/rocm
+# An explicitly selected ROCm wins over whatever is installed at /opt/rocm.
+# Without this, building against a side-by-side ROCm silently picks up
+# /opt/rocm's headers while the loader resolves the other tree's runtime -- a
+# mixed build that links, runs, and quietly misses any API the older headers
+# do not declare. ldd cannot see this: it only observes the runtime half.
+set(_hsa_hints)
+foreach(_root IN ITEMS ${ROCM_PATH} $ENV{ROCM_PATH} ${HIP_ROOT_DIR} $ENV{HIP_PATH})
+    if(_root)
+        list(APPEND _hsa_hints "${_root}")
+    endif()
+endforeach()
 
 file(GLOB ROCM_PATHS "/opt/rocm*/include")
 
 find_path(HSA_INCLUDE_DIR
     NAMES hsa/hsa.h
+    HINTS ${_hsa_hints}
+    PATH_SUFFIXES include
     PATHS ${ROCM_PATHS}
     /usr/local/include
     /usr/include
     DOC "Path to HSA include directory"
 )
 
-# Search for the HSA library with priority given to /opt/rocm
 find_library(HSA_LIBRARY
     NAMES hsa-runtime64
+    HINTS ${_hsa_hints}
+    PATH_SUFFIXES lib lib64
     PATHS /opt/rocm/lib
     /opt/rocm/lib64
     /usr/local/lib
@@ -46,6 +59,8 @@ find_library(HSA_LIBRARY
     /usr/lib/x86_64-linux-gnu
     DOC "Path to HSA runtime library"
 )
+
+unset(_hsa_hints)
 
 message("HSA_INCLUDE_DIR: ${HSA_INCLUDE_DIR}")
 message("HSA_LIBRARY: ${HSA_LIBRARY}")

--- a/accordo/src/CMakeLists.txt
+++ b/accordo/src/CMakeLists.txt
@@ -43,6 +43,46 @@ CPMAddPackage("gh:nlohmann/json@3.11.3")
 find_package(HSA REQUIRED)
 
 #
+# ROCm 10 added hsa_amd_queue_create and HIP moved its compute queue onto it.
+# The slot is absent from earlier headers, so probe for the AmdExtTable member
+# we actually write rather than keying off a ROCm version.
+#
+# Two probes, not one. A single "does the member exist" test answers no both
+# when the header lacks the member and when the header could not be included at
+# all -- and the second case is a broken configuration wearing the first case's
+# clothes. Separating them is the difference between compiling out a hook we do
+# not need and silently compiling out one we do.
+#
+include(CheckCXXSourceCompiles)
+get_target_property(_accordo_hsa_includes hsa::hsa INTERFACE_INCLUDE_DIRECTORIES)
+set(CMAKE_REQUIRED_INCLUDES ${_accordo_hsa_includes})
+set(CMAKE_REQUIRED_DEFINITIONS -DAMD_INTERNAL_BUILD)
+
+check_cxx_source_compiles("
+#include <hsa/hsa_api_trace.h>
+int main() { AmdExtTable table{}; (void)table; return 0; }
+" ACCORDO_HSA_API_TRACE_USABLE)
+
+if(NOT ACCORDO_HSA_API_TRACE_USABLE)
+    message(FATAL_ERROR
+        "accordo: cannot compile against <hsa/hsa_api_trace.h> from "
+        "'${_accordo_hsa_includes}'. Queue interception cannot be configured. "
+        "Set ROCM_PATH to the ROCm tree you intend to build against.")
+endif()
+
+check_cxx_source_compiles("
+#include <hsa/hsa_api_trace.h>
+int main() {
+  AmdExtTable table{};
+  return table.hsa_amd_queue_create_fn == nullptr ? 0 : 1;
+}
+" ACCORDO_HAVE_HSA_AMD_QUEUE_CREATE)
+
+unset(CMAKE_REQUIRED_INCLUDES)
+unset(CMAKE_REQUIRED_DEFINITIONS)
+unset(_accordo_hsa_includes)
+
+#
 # accordo target
 #
 
@@ -68,6 +108,13 @@ target_sources(accordo
 
 intelliperf_compiler_warnings(accordo)
 intelliperf_compiler_options(accordo)
+
+if(ACCORDO_HAVE_HSA_AMD_QUEUE_CREATE)
+    target_compile_definitions(accordo PRIVATE ACCORDO_HAVE_HSA_AMD_QUEUE_CREATE)
+    message(STATUS "accordo: hooking hsa_amd_queue_create (ROCm 10+ compute queue path)")
+else()
+    message(STATUS "accordo: hsa_amd_queue_create absent, hooking hsa_queue_create only")
+endif()
 
 target_link_libraries(accordo
     PUBLIC

--- a/accordo/src/accordo.hip
+++ b/accordo/src/accordo.hip
@@ -813,8 +813,19 @@ hsa_status_t accordo::hsa_amd_queue_create(hsa_agent_t agent,
 
     // queue_size_bytes is a byte count; hsa_amd_queue_intercept_create wants a
     // packet count. An AQL packet is 64 bytes.
-    const uint32_t size_in_packets =
-        desc->queue_size_bytes / static_cast<uint32_t>(sizeof(hsa_kernel_dispatch_packet_t));
+    constexpr uint32_t kPacketSize = static_cast<uint32_t>(sizeof(hsa_kernel_dispatch_packet_t));
+    const uint32_t bytes = desc->queue_size_bytes;
+    const bool power_of_two = bytes != 0 && (bytes & (bytes - 1)) == 0;
+
+    // A size the runtime would reject must still be rejected. Dividing it down
+    // to a packet count would launder it into a legal one -- 65537 becomes
+    // 1024 packets and succeeds -- so the app never learns its request was
+    // invalid. Hand those to the runtime and let it give the real error.
+    if (!power_of_two || bytes % kPacketSize != 0) {
+      record(hsa_ext_call(instance, hsa_amd_queue_create, agent, desc, 1));
+      continue;
+    }
+    const uint32_t size_in_packets = bytes / kPacketSize;
 
     hsa_queue_t* queue = nullptr;
     const auto result = create_intercept_queue(agent,

--- a/accordo/src/accordo.hip
+++ b/accordo/src/accordo.hip
@@ -571,6 +571,12 @@ void accordo::hook_api() {
   api_table_->core_->hsa_queue_create_fn = accordo::hsa_queue_create;
   api_table_->core_->hsa_queue_destroy_fn = accordo::hsa_queue_destroy;
 
+#ifdef ACCORDO_HAVE_HSA_AMD_QUEUE_CREATE
+  // ROCm 10 moved HIP's compute queue onto hsa_amd_queue_create. Without this
+  // the hook above is never entered and no dispatch packet is ever seen.
+  api_table_->amd_ext_->hsa_amd_queue_create_fn = accordo::hsa_amd_queue_create;
+#endif
+
   api_table_->amd_ext_->hsa_amd_memory_pool_allocate_fn =
       accordo::hsa_amd_memory_pool_allocate;
   api_table_->core_->hsa_memory_allocate_fn = accordo::hsa_memory_allocate;
@@ -709,18 +715,16 @@ hsa_status_t accordo::hsa_memory_allocate(hsa_region_t region, size_t size, void
   return result;
 }
 
-hsa_status_t accordo::hsa_queue_create(hsa_agent_t agent,
-                                       uint32_t size,
-                                       hsa_queue_type32_t type,
-                                       void (*callback)(hsa_status_t status,
-                                                        hsa_queue_t* source,
-                                                        void* data),
-                                       void* data,
-                                       uint32_t private_segment_size,
-                                       uint32_t group_segment_size,
-                                       hsa_queue_t** queue) {
-  LOG_DETAIL("Creating intelliperf-rt queue");
-
+hsa_status_t accordo::create_intercept_queue(hsa_agent_t agent,
+                                             uint32_t size,
+                                             hsa_queue_type32_t type,
+                                             void (*callback)(hsa_status_t status,
+                                                              hsa_queue_t* source,
+                                                              void* data),
+                                             void* data,
+                                             uint32_t private_segment_size,
+                                             uint32_t group_segment_size,
+                                             hsa_queue_t** queue) {
   hsa_status_t result = HSA_STATUS_SUCCESS;
   auto instance = get_instance();
   try {
@@ -736,18 +740,18 @@ hsa_status_t accordo::hsa_queue_create(hsa_agent_t agent,
                           queue);
 
     if (result == HSA_STATUS_SUCCESS) {
-      auto result = instance->add_queue(*queue, agent);
-      if (result != HSA_STATUS_SUCCESS) {
-        LOG_ERROR("Failed to add queue {} ", static_cast<int>(result));
+      auto status = instance->add_queue(*queue, agent);
+      if (status != HSA_STATUS_SUCCESS) {
+        LOG_ERROR("Failed to add queue {} ", static_cast<int>(status));
       }
-      result = hsa_ext_call(instance,
+      status = hsa_ext_call(instance,
                             hsa_amd_queue_intercept_register,
                             *queue,
                             accordo::on_submit_packet,
                             reinterpret_cast<void*>(*queue));
-      if (result != HSA_STATUS_SUCCESS) {
-        LOG_ERROR("Failed to register intercept callback with result of ",
-                  static_cast<int>(result));
+      if (status != HSA_STATUS_SUCCESS) {
+        LOG_ERROR("Failed to register intercept callback with result of {}",
+                  static_cast<int>(status));
       }
     }
   } catch (const std::exception& e) {
@@ -755,6 +759,80 @@ hsa_status_t accordo::hsa_queue_create(hsa_agent_t agent,
   }
   return result;
 }
+
+hsa_status_t accordo::hsa_queue_create(hsa_agent_t agent,
+                                       uint32_t size,
+                                       hsa_queue_type32_t type,
+                                       void (*callback)(hsa_status_t status,
+                                                        hsa_queue_t* source,
+                                                        void* data),
+                                       void* data,
+                                       uint32_t private_segment_size,
+                                       uint32_t group_segment_size,
+                                       hsa_queue_t** queue) {
+  LOG_DETAIL("Creating intelliperf-rt queue");
+  return create_intercept_queue(agent,
+                                size,
+                                type,
+                                callback,
+                                data,
+                                private_segment_size,
+                                group_segment_size,
+                                queue);
+}
+
+#ifdef ACCORDO_HAVE_HSA_AMD_QUEUE_CREATE
+hsa_status_t accordo::hsa_amd_queue_create(hsa_agent_t agent,
+                                           hsa_amd_queue_create_desc_t* descs,
+                                           uint32_t num_descs) {
+  LOG_DETAIL("Creating intelliperf-rt queue via hsa_amd_queue_create");
+
+  auto instance = get_instance();
+  for (uint32_t i = 0; i < num_descs; ++i) {
+    hsa_amd_queue_create_desc_t* desc = &descs[i];
+
+    // Only compute queues carry AQL dispatch packets. SDMA and AIE queues go
+    // to the runtime untouched -- intercepting them would gain us nothing and
+    // AIE is not implemented by the runtime yet.
+    if (desc->engine_type != HSA_AMD_QUEUE_ENGINE_COMPUTE) {
+      const auto result = hsa_ext_call(instance, hsa_amd_queue_create, agent, desc, 1);
+      if (result != HSA_STATUS_SUCCESS) {
+        return result;
+      }
+      continue;
+    }
+
+    // queue_size_bytes is a byte count; hsa_amd_queue_intercept_create wants a
+    // packet count. An AQL packet is 64 bytes.
+    const uint32_t size_in_packets =
+        desc->queue_size_bytes / static_cast<uint32_t>(sizeof(hsa_kernel_dispatch_packet_t));
+
+    hsa_queue_t* queue = nullptr;
+    auto result = create_intercept_queue(agent,
+                                         size_in_packets,
+                                         desc->engine.compute.type,
+                                         desc->callback,
+                                         desc->callback_data,
+                                         desc->engine.compute.private_segment_size,
+                                         0,
+                                         &queue);
+    if (result != HSA_STATUS_SUCCESS) {
+      // An intercept queue is an optimisation, not a requirement. Fall back to
+      // the runtime so the application still runs, uninstrumented.
+      LOG_ERROR("Failed to create intercept queue {}, falling back",
+                static_cast<int>(result));
+      result = hsa_ext_call(instance, hsa_amd_queue_create, agent, desc, 1);
+      if (result != HSA_STATUS_SUCCESS) {
+        return result;
+      }
+      continue;
+    }
+    desc->queue = queue;
+  }
+  return HSA_STATUS_SUCCESS;
+}
+#endif
+
 hsa_status_t accordo::hsa_queue_destroy(hsa_queue_t* queue) {
   LOG_DETAIL("Destroying intelliperf-rt queue");
   return hsa_core_call(singleton_, hsa_queue_destroy, queue);

--- a/accordo/src/accordo.hip
+++ b/accordo/src/accordo.hip
@@ -788,6 +788,18 @@ hsa_status_t accordo::hsa_amd_queue_create(hsa_agent_t agent,
   LOG_DETAIL("Creating intelliperf-rt queue via hsa_amd_queue_create");
 
   auto instance = get_instance();
+
+  // The runtime does not stop at the first failure. Per the API contract,
+  // queues that were created stay valid, a descriptor that failed is left with
+  // a NULL queue, and the caller is handed the first error. Returning early
+  // here would abandon descriptors the runtime would have created.
+  hsa_status_t first_error = HSA_STATUS_SUCCESS;
+  const auto record = [&first_error](hsa_status_t status) {
+    if (status != HSA_STATUS_SUCCESS && first_error == HSA_STATUS_SUCCESS) {
+      first_error = status;
+    }
+  };
+
   for (uint32_t i = 0; i < num_descs; ++i) {
     hsa_amd_queue_create_desc_t* desc = &descs[i];
 
@@ -795,10 +807,7 @@ hsa_status_t accordo::hsa_amd_queue_create(hsa_agent_t agent,
     // to the runtime untouched -- intercepting them would gain us nothing and
     // AIE is not implemented by the runtime yet.
     if (desc->engine_type != HSA_AMD_QUEUE_ENGINE_COMPUTE) {
-      const auto result = hsa_ext_call(instance, hsa_amd_queue_create, agent, desc, 1);
-      if (result != HSA_STATUS_SUCCESS) {
-        return result;
-      }
+      record(hsa_ext_call(instance, hsa_amd_queue_create, agent, desc, 1));
       continue;
     }
 
@@ -808,28 +817,26 @@ hsa_status_t accordo::hsa_amd_queue_create(hsa_agent_t agent,
         desc->queue_size_bytes / static_cast<uint32_t>(sizeof(hsa_kernel_dispatch_packet_t));
 
     hsa_queue_t* queue = nullptr;
-    auto result = create_intercept_queue(agent,
-                                         size_in_packets,
-                                         desc->engine.compute.type,
-                                         desc->callback,
-                                         desc->callback_data,
-                                         desc->engine.compute.private_segment_size,
-                                         0,
-                                         &queue);
-    if (result != HSA_STATUS_SUCCESS) {
-      // An intercept queue is an optimisation, not a requirement. Fall back to
-      // the runtime so the application still runs, uninstrumented.
-      LOG_ERROR("Failed to create intercept queue {}, falling back",
-                static_cast<int>(result));
-      result = hsa_ext_call(instance, hsa_amd_queue_create, agent, desc, 1);
-      if (result != HSA_STATUS_SUCCESS) {
-        return result;
-      }
+    const auto result = create_intercept_queue(agent,
+                                               size_in_packets,
+                                               desc->engine.compute.type,
+                                               desc->callback,
+                                               desc->callback_data,
+                                               desc->engine.compute.private_segment_size,
+                                               0,
+                                               &queue);
+    if (result == HSA_STATUS_SUCCESS) {
+      desc->queue = queue;
       continue;
     }
-    desc->queue = queue;
+
+    // An intercept queue is an optimisation, not a requirement. Fall back to
+    // the runtime so the application still runs, uninstrumented. The runtime
+    // writes desc->queue itself, including the NULL on failure.
+    LOG_ERROR("Failed to create intercept queue {}, falling back", static_cast<int>(result));
+    record(hsa_ext_call(instance, hsa_amd_queue_create, agent, desc, 1));
   }
-  return HSA_STATUS_SUCCESS;
+  return first_error;
 }
 #endif
 

--- a/accordo/src/accordo.hpp
+++ b/accordo/src/accordo.hpp
@@ -232,6 +232,26 @@ class accordo {
                                        uint32_t private_segment_size,
                                        uint32_t group_segment_size,
                                        hsa_queue_t** queue);
+  // Shared by both queue-creation hooks: swaps the runtime's queue for an
+  // intercept queue and registers our packet callback on it.
+  static hsa_status_t create_intercept_queue(hsa_agent_t agent,
+                                             uint32_t size,
+                                             hsa_queue_type32_t type,
+                                             void (*callback)(hsa_status_t status,
+                                                              hsa_queue_t* source,
+                                                              void* data),
+                                             void* data,
+                                             uint32_t private_segment_size,
+                                             uint32_t group_segment_size,
+                                             hsa_queue_t** queue);
+#ifdef ACCORDO_HAVE_HSA_AMD_QUEUE_CREATE
+  // ROCm 10 added this entry point and HIP moved its compute queue onto it.
+  // hsa_queue_create is still exported and still used, so both slots stay
+  // hooked rather than one replacing the other.
+  static hsa_status_t hsa_amd_queue_create(hsa_agent_t agent,
+                                           hsa_amd_queue_create_desc_t* descs,
+                                           uint32_t num_descs);
+#endif
   static hsa_status_t hsa_amd_memory_pool_allocate(hsa_amd_memory_pool_t pool,
                                                    size_t size,
                                                    uint32_t flags,


### PR DESCRIPTION
ROCm 10 adds `hsa_amd_queue_create` and HIP creates its compute queue through it. accordo hooks only `hsa_queue_create`, so on ROCm 10 it attaches successfully and then sees no dispatch packets — zero kernels, no error.

Hooks both slots; the new one compiles out where the header lacks the symbol.

Also fixes `FindHSA.cmake` to honour `ROCM_PATH` (it globbed `/opt/rocm*` and ignored it, so a "ROCm 10 build" was ROCm 7 headers with a ROCm 10 runtime).

Verified 20/20 on both ROCm 7.2.x and ROCm 10.1.0a, MI355X/gfx950.