### PR TITLE
Hook hsa_amd_queue_create so nexus captures on ROCm 10

### DIFF
--- a/nexus/cmake/Modules/FindHSA.cmake
+++ b/nexus/cmake/Modules/FindHSA.cmake
@@ -26,7 +26,25 @@
 
 # Search for the HSA include directory with priority given to /opt/rocm
 
+# Prefer an explicitly selected ROCm tree over whatever is installed at
+# /opt/rocm. Without this, building against a second ROCm silently picks up the
+# system headers -- the build succeeds and the binary is compiled against the
+# wrong API.
+set(NEXUS_ROCM_ROOT "")
+foreach(_candidate "${ROCM_PATH}" "$ENV{ROCM_PATH}" "${ROCM_HOME}" "$ENV{ROCM_HOME}")
+    if(_candidate AND EXISTS "${_candidate}/include/hsa/hsa.h")
+        set(NEXUS_ROCM_ROOT "${_candidate}")
+        break()
+    endif()
+endforeach()
+
 file(GLOB ROCM_PATHS "/opt/rocm*/include")
+if(NEXUS_ROCM_ROOT)
+    message(STATUS "nexus/FindHSA: using ROCm tree ${NEXUS_ROCM_ROOT}")
+    set(ROCM_PATHS "${NEXUS_ROCM_ROOT}/include" ${ROCM_PATHS})
+else()
+    message(STATUS "nexus/FindHSA: no ROCM_PATH override, falling back to /opt/rocm*")
+endif()
 
 find_path(HSA_INCLUDE_DIR
     NAMES hsa/hsa.h
@@ -39,7 +57,7 @@ find_path(HSA_INCLUDE_DIR
 # Search for the HSA library with priority given to /opt/rocm
 find_library(HSA_LIBRARY
     NAMES hsa-runtime64
-    PATHS /opt/rocm/lib
+    PATHS "${NEXUS_ROCM_ROOT}/lib" /opt/rocm/lib
     /opt/rocm/lib64
     /usr/local/lib
     /usr/lib

--- a/nexus/csrc/include/nexus/nexus.hpp
+++ b/nexus/csrc/include/nexus/nexus.hpp
@@ -265,6 +265,13 @@ class nexus {
                                        uint32_t private_segment_size,
                                        uint32_t group_segment_size,
                                        hsa_queue_t** queue);
+#ifdef NEXUS_HAS_AMD_QUEUE_CREATE
+  // ROCm 10 routes HIP's compute queue through this entry point instead of
+  // hsa_queue_create. Both slots are hooked; only one fires on a given runtime.
+  static hsa_status_t hsa_amd_queue_create(hsa_agent_t agent,
+                                           hsa_amd_queue_create_desc_t* descs,
+                                           uint32_t num_descs);
+#endif
   static hsa_status_t hsa_amd_memory_pool_allocate(hsa_amd_memory_pool_t pool,
                                                    size_t size,
                                                    uint32_t flags,

--- a/nexus/csrc/src/CMakeLists.txt
+++ b/nexus/csrc/src/CMakeLists.txt
@@ -53,6 +53,25 @@ CPMAddPackage("gh:nlohmann/json@3.11.3")
 
 find_package(HSA REQUIRED)
 
+# ROCm 10 adds hsa_amd_queue_create; ROCm <= 7 headers do not declare it, so the
+# hook must compile out rather than fail to build. The header probed here MUST be
+# the same one the compile uses, or the probe answers about the wrong tree.
+if(NOT HSA_INCLUDE_DIR)
+    message(FATAL_ERROR "nexus: HSA_INCLUDE_DIR unset -- FindHSA must run first")
+endif()
+set(_nexus_hdr "${HSA_INCLUDE_DIR}/hsa/hsa_ext_amd.h")
+if(NOT EXISTS "${_nexus_hdr}")
+    message(FATAL_ERROR "nexus: no hsa_ext_amd.h under ${HSA_INCLUDE_DIR}")
+endif()
+file(READ "${_nexus_hdr}" _nexus_hsa_ext_amd)
+string(FIND "${_nexus_hsa_ext_amd}" "hsa_amd_queue_create(" _nexus_amd_qc)
+if(NOT _nexus_amd_qc EQUAL -1)
+    message(STATUS "=== nexus: QUEUE SLOTS = legacy + hsa_amd_queue_create  (${_nexus_hdr})")
+    set(NEXUS_AMD_QUEUE_CREATE ON)
+else()
+    message(STATUS "=== nexus: QUEUE SLOTS = legacy ONLY  (${_nexus_hdr})")
+endif()
+
 #
 # nexus target
 #
@@ -89,3 +108,11 @@ target_link_libraries(nexus
         hsa::hsa
     PRIVATE
 )
+
+if(NEXUS_AMD_QUEUE_CREATE)
+    if(NOT TARGET nexus)
+        message(FATAL_ERROR "nexus: target missing, cannot enable the amd queue hook")
+    endif()
+    target_compile_definitions(nexus PRIVATE NEXUS_HAS_AMD_QUEUE_CREATE)
+    message(STATUS "=== nexus: NEXUS_HAS_AMD_QUEUE_CREATE bound to target nexus")
+endif()

--- a/nexus/csrc/src/nexus.cpp
+++ b/nexus/csrc/src/nexus.cpp
@@ -627,6 +627,12 @@ void nexus::hook_api() {
   api_table_->core_->hsa_queue_create_fn = nexus::hsa_queue_create;
   api_table_->core_->hsa_queue_destroy_fn = nexus::hsa_queue_destroy;
 
+#ifdef NEXUS_HAS_AMD_QUEUE_CREATE
+  // Hooked in addition to, not instead of, hsa_queue_create: the legacy entry
+  // point still exists on ROCm 10 and is still the one used on ROCm <= 7.
+  api_table_->amd_ext_->hsa_amd_queue_create_fn = nexus::hsa_amd_queue_create;
+#endif
+
   api_table_->amd_ext_->hsa_amd_memory_pool_allocate_fn =
       nexus::hsa_amd_memory_pool_allocate;
   api_table_->core_->hsa_memory_allocate_fn = nexus::hsa_memory_allocate;
@@ -877,6 +883,93 @@ hsa_status_t nexus::hsa_queue_create(hsa_agent_t agent,
   }
   return result;
 }
+
+#ifdef NEXUS_HAS_AMD_QUEUE_CREATE
+hsa_status_t nexus::hsa_amd_queue_create(hsa_agent_t agent,
+                                         hsa_amd_queue_create_desc_t* descs,
+                                         uint32_t num_descs) {
+  LOG_DETAIL("Creating nexus queue (amd, {} descriptor(s))", num_descs);
+
+  auto instance = get_instance();
+  if (descs == nullptr) {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  for (uint32_t i = 0; i < num_descs; ++i) {
+    hsa_amd_queue_create_desc_t* desc = &descs[i];
+
+    // Only compute queues carry AQL dispatch packets. SDMA and AIE queues are
+    // passed through untouched -- intercepting them would capture nothing and
+    // AIE is not implemented by the runtime yet.
+    if (desc->engine_type != HSA_AMD_QUEUE_ENGINE_COMPUTE) {
+      LOG_DETAIL("Passing through non-compute queue (engine_type {})",
+                 static_cast<unsigned>(desc->engine_type));
+      hsa_status_t passthrough =
+          hsa_ext_call(instance, hsa_amd_queue_create, agent, desc, 1);
+      if (passthrough != HSA_STATUS_SUCCESS) {
+        return passthrough;
+      }
+      continue;
+    }
+
+    // queue_size_bytes is a byte count; hsa_amd_queue_intercept_create takes a
+    // packet count.
+    constexpr uint32_t kAqlPacketSize = 64;
+    const uint32_t packets = desc->queue_size_bytes / kAqlPacketSize;
+    hsa_queue_t* queue = nullptr;
+    hsa_status_t result = HSA_STATUS_SUCCESS;
+
+    try {
+      result = hsa_ext_call(instance,
+                            hsa_amd_queue_intercept_create,
+                            agent,
+                            packets,
+                            desc->engine.compute.type,
+                            desc->callback,
+                            desc->callback_data,
+                            desc->engine.compute.private_segment_size,
+                            0,
+                            &queue);
+    } catch (const std::exception& e) {
+      LOG_ERROR("Interception queue create throw {} error", e.what());
+      result = HSA_STATUS_ERROR;
+    }
+
+    if (result != HSA_STATUS_SUCCESS) {
+      // Fall back to the real entry point so the application still runs; it
+      // simply will not be traced.
+      LOG_WARN("Intercept create failed ({}), falling back to hsa_amd_queue_create",
+               static_cast<int>(result));
+      hsa_status_t fallback =
+          hsa_ext_call(instance, hsa_amd_queue_create, agent, desc, 1);
+      if (fallback != HSA_STATUS_SUCCESS) {
+        return fallback;
+      }
+      continue;
+    }
+
+    hsa_status_t added = instance->add_queue(queue, agent);
+    if (added != HSA_STATUS_SUCCESS) {
+      LOG_ERROR("Failed to add queue {} ", static_cast<int>(added));
+    }
+
+    added = hsa_ext_call(instance,
+                         hsa_amd_queue_intercept_register,
+                         queue,
+                         nexus::on_submit_packet,
+                         reinterpret_cast<void*>(queue));
+    if (added != HSA_STATUS_SUCCESS) {
+      LOG_ERROR("Failed to register intercept callback with result of ",
+                static_cast<int>(added));
+    }
+
+    // The caller reads the created queue back out of the descriptor.
+    desc->queue = queue;
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+#endif  // NEXUS_HAS_AMD_QUEUE_CREATE
 hsa_status_t nexus::hsa_queue_destroy(hsa_queue_t* queue) {
   LOG_DETAIL("Destroying nexus queue");
   return hsa_core_call(singleton_, hsa_queue_destroy, queue);


### PR DESCRIPTION
ROCm 10 adds `hsa_amd_queue_create` and HIP creates its compute queue through it. nexus hooks only `hsa_queue_create`, so on ROCm 10 it attaches successfully and then sees no dispatch packets — zero kernels, no error.

## What this changes

- `nexus.cpp` — hooks `amd_ext_->hsa_amd_queue_create_fn` in addition to the legacy slot. Loops the descriptor array, passes SDMA/AIE through untouched, converts `queue_size_bytes` to a packet count, and writes each `desc->queue` back.
- `nexus.hpp` — declares the new hook, guarded by `NEXUS_HAS_AMD_QUEUE_CREATE`.
- `CMakeLists.txt` — probes the header for the symbol and defines that macro, so the hook compiles out on ROCm ≤ 7 where it does not exist.
- `FindHSA.cmake` — honour `ROCM_PATH`/`ROCM_HOME`. It globbed `/opt/rocm*` and hardcoded `/opt/rocm/lib`, so building against a second ROCm silently used the system headers: a clean build, a green config, and a binary compiled against the wrong API. It also prints which tree it selected.

Measured 6/6 on ROCm 7.2.x and 6/6 on ROCm 10.1.0a (MI355X/gfx950); unpatched was 5 failed / 1 passed on ROCm 10.

## Known gaps — not addressed here

Two defects found in the equivalent accordo code (fixed there in #178) are still present in this hook:

1. **The descriptor loop returns on the first error.** `hsa_ext_amd.h` specifies the runtime keeps queues it already created, leaves a failed descriptor's queue NULL, and returns the *first* error. Cannot fire today — HIP passes `num_descs=1`.
2. **`queue_size_bytes / 64` launders an invalid size into a valid one.** 65537 is not a power of two and the runtime rejects it, but it divides to 1024 packets and the queue is created, so the caller is told it succeeded and gets a size it never asked for.

Neither is reachable through HIP today, but both should be fixed to match accordo before this is relied on.