### PR TITLE
Add tests for the validation pipelines, path resolution and compile_commands

### DIFF
--- a/kerncap/tests/unit/test_paths_and_capturer.py
+++ b/kerncap/tests/unit/test_paths_and_capturer.py
@@ -1,0 +1,245 @@
+"""Unit tests for kerncap's artifact-path resolution and the capture wrapper.
+
+``_get_lib_path`` and ``_get_replay_path`` decide whether kerncap can find the
+things it was built with. They are the first thing to fail on a broken install,
+and their error messages are what a user has to debug from, so the search order
+and the "searched:" report are pinned here.
+
+Both search real filesystem locations, so ``pathlib.Path.is_file`` is stubbed
+to place a hit at a chosen candidate rather than writing into site-packages.
+"""
+
+import os
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+import kerncap
+from kerncap import _get_lib_path, _get_replay_path
+from kerncap.capturer import run_capture
+
+
+def only_this_file_exists(target: str):
+    """A ``Path.is_file`` replacement that reports a hit only for *target*."""
+
+    def _is_file(self):
+        return str(self) == target
+
+    return _is_file
+
+
+def nothing_exists(self):
+    return False
+
+
+# --------------------------------------------------------------------------
+# _get_replay_path
+# --------------------------------------------------------------------------
+
+
+class TestGetReplayPath:
+    def test_finds_the_binary_in_the_package_bin_dir(self):
+        import pathlib
+
+        pkg_dir = pathlib.Path(kerncap.__file__).resolve().parent
+        target = str(pkg_dir / "bin" / "kerncap-replay")
+
+        with patch.object(pathlib.Path, "is_file", only_this_file_exists(target)):
+            assert _get_replay_path() == target
+
+    def test_falls_back_to_path(self):
+        """A system install with no packaged binary still works."""
+        import pathlib
+
+        with (
+            patch.object(pathlib.Path, "is_file", nothing_exists),
+            patch("shutil.which", return_value="/usr/local/bin/kerncap-replay"),
+        ):
+            assert _get_replay_path() == "/usr/local/bin/kerncap-replay"
+
+    def test_package_copy_wins_over_path(self):
+        import pathlib
+
+        pkg_dir = pathlib.Path(kerncap.__file__).resolve().parent
+        target = str(pkg_dir / "bin" / "kerncap-replay")
+
+        with (
+            patch.object(pathlib.Path, "is_file", only_this_file_exists(target)),
+            patch("shutil.which", return_value="/usr/local/bin/kerncap-replay"),
+        ):
+            assert _get_replay_path() == target
+
+    def test_reports_everywhere_it_looked(self):
+        """The message is the user's only debugging handle on a bad install."""
+        import pathlib
+
+        with (
+            patch.object(pathlib.Path, "is_file", nothing_exists),
+            patch("shutil.which", return_value=None),
+        ):
+            with pytest.raises(FileNotFoundError) as exc:
+                _get_replay_path()
+
+        message = str(exc.value)
+        assert "Could not locate kerncap-replay" in message
+        assert "Searched:" in message
+        assert "bin/kerncap-replay" in message
+
+
+# --------------------------------------------------------------------------
+# _get_lib_path
+# --------------------------------------------------------------------------
+
+
+class TestGetLibPath:
+    def test_env_override_wins(self, tmp_path, monkeypatch):
+        lib = tmp_path / "custom_libkerncap.so"
+        lib.write_bytes(b"\x7fELF")
+        monkeypatch.setenv("KERNCAP_LIB_PATH", str(lib))
+
+        assert _get_lib_path() == str(lib)
+
+    def test_env_override_pointing_at_nothing_is_ignored(self, tmp_path, monkeypatch):
+        """A stale env var must not shadow a working packaged library."""
+        import pathlib
+
+        monkeypatch.setenv("KERNCAP_LIB_PATH", str(tmp_path / "gone.so"))
+        pkg_dir = pathlib.Path(kerncap.__file__).resolve().parent
+        target = str(pkg_dir / "lib" / "libkerncap.so")
+
+        with patch.object(pathlib.Path, "is_file", only_this_file_exists(target)):
+            assert _get_lib_path() == target
+
+    def test_finds_the_library_beside_the_package(self, monkeypatch):
+        import pathlib
+
+        monkeypatch.delenv("KERNCAP_LIB_PATH", raising=False)
+        pkg_dir = pathlib.Path(kerncap.__file__).resolve().parent
+        target = str(pkg_dir / "libkerncap.so")
+
+        with patch.object(pathlib.Path, "is_file", only_this_file_exists(target)):
+            assert _get_lib_path() == target
+
+    def test_reports_everywhere_it_looked(self, monkeypatch):
+        import pathlib
+
+        monkeypatch.delenv("KERNCAP_LIB_PATH", raising=False)
+
+        with patch.object(pathlib.Path, "is_file", nothing_exists):
+            with pytest.raises(FileNotFoundError) as exc:
+                _get_lib_path()
+
+        message = str(exc.value)
+        assert "Could not locate libkerncap.so" in message
+        assert "KERNCAP_LIB_PATH" in message
+        assert "Searched:" in message
+
+
+# --------------------------------------------------------------------------
+# Kerncap.replay — capture directory resolution
+# --------------------------------------------------------------------------
+
+
+class TestReplayCaptureDir:
+    def test_prefers_the_capture_subdirectory(self, tmp_path):
+        (tmp_path / "capture").mkdir()
+        kc = kerncap.Kerncap()
+
+        with (
+            patch("kerncap._get_replay_path", return_value="/bin/replay"),
+            patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0, "", "")) as run,
+        ):
+            kc.replay(str(tmp_path))
+
+        assert run.call_args.args[0][1] == str(tmp_path / "capture")
+
+    def test_falls_back_to_the_directory_itself(self, tmp_path):
+        """Lets a user point straight at a capture/ dir."""
+        kc = kerncap.Kerncap()
+
+        with (
+            patch("kerncap._get_replay_path", return_value="/bin/replay"),
+            patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0, "", "")) as run,
+        ):
+            kc.replay(str(tmp_path))
+
+        assert run.call_args.args[0][1] == str(tmp_path)
+
+
+# --------------------------------------------------------------------------
+# capturer.run_capture — failure paths
+# --------------------------------------------------------------------------
+
+
+def fake_streaming(artifacts=(), returncode=0, raises=None):
+    """Stand in for ``run_streaming``, materialising capture artifacts."""
+
+    def _run(cmd, **kwargs):
+        if raises is not None:
+            raise raises
+        out = kwargs["env"]["KERNCAP_OUTPUT"]
+        for name in artifacts:
+            with open(os.path.join(out, name), "w") as fh:
+                fh.write("{}")
+        return subprocess.CompletedProcess(
+            list(cmd), returncode, stdout="app stdout", stderr="app stderr"
+        )
+
+    return _run
+
+
+@pytest.fixture
+def lib(tmp_path):
+    path = tmp_path / "libkerncap.so"
+    path.write_bytes(b"\x7fELF")
+    return str(path)
+
+
+class TestRunCaptureFailures:
+    def test_timeout_is_translated(self, tmp_path, lib):
+        with (
+            patch("kerncap._get_lib_path", return_value=lib),
+            patch(
+                "kerncap.capturer.run_streaming",
+                fake_streaming(raises=subprocess.TimeoutExpired("app", 30)),
+            ),
+        ):
+            with pytest.raises(TimeoutError, match="did not complete within 30s"):
+                run_capture("k", ["./app"], str(tmp_path / "cap"), timeout=30)
+
+    def test_no_artifacts_raises_with_both_streams(self, tmp_path, lib):
+        """The child's output is the only clue why interception did not fire."""
+        with (
+            patch("kerncap._get_lib_path", return_value=lib),
+            patch("kerncap.capturer.run_streaming", fake_streaming(artifacts=())),
+        ):
+            with pytest.raises(RuntimeError) as exc:
+                run_capture("k", ["./app"], str(tmp_path / "cap"))
+
+        message = str(exc.value)
+        assert "Capture did not produce output" in message
+        assert "app stdout" in message
+        assert "app stderr" in message
+
+    @pytest.mark.parametrize("artifact", ["dispatch.json", "metadata.json"])
+    def test_either_artifact_satisfies_the_check(self, tmp_path, lib, artifact):
+        out = tmp_path / "cap"
+        with (
+            patch("kerncap._get_lib_path", return_value=lib),
+            patch("kerncap.capturer.run_streaming", fake_streaming(artifacts=(artifact,))),
+        ):
+            assert run_capture("k", ["./app"], str(out)) == str(out)
+
+    def test_empty_streams_are_reported_as_na(self, tmp_path, lib):
+        """A silent child still produces a readable message."""
+
+        def _run(cmd, **kwargs):
+            return subprocess.CompletedProcess(list(cmd), 0, stdout="", stderr="")
+
+        with (
+            patch("kerncap._get_lib_path", return_value=lib),
+            patch("kerncap.capturer.run_streaming", _run),
+        ):
+            with pytest.raises(RuntimeError, match="N/A"):
+                run_capture("k", ["./app"], str(tmp_path / "cap"))

--- a/kerncap/tests/unit/test_source_finder_compile_commands.py
+++ b/kerncap/tests/unit/test_source_finder_compile_commands.py
@@ -1,0 +1,617 @@
+"""Unit tests for source_finder's compile_commands.json handling.
+
+These are the functions that decide which preprocessor defines and include
+paths a reproducer is rebuilt with. Getting them wrong does not fail loudly —
+it produces a reproducer that compiles into something subtly different from
+the kernel that was captured, which is the worst failure mode kerncap has.
+
+All pure JSON and string parsing plus a filesystem walk, so nothing here needs
+ROCm, a compiler, or a GPU.
+"""
+
+import json
+import os
+
+import pytest
+
+from kerncap.source_finder import (
+    _defines_from_compile_commands,
+    _extract_defines_from_command,
+    _extract_includes_from_command,
+    _extract_output_path,
+    _find_compile_commands,
+    _includes_from_compile_commands,
+    _match_tu_via_object_symbols,
+    _nm_has_symbol,
+)
+
+
+def write_cc(directory, entries):
+    """Write a compile_commands.json and return its path."""
+    path = directory / "compile_commands.json"
+    path.write_text(json.dumps(entries))
+    return str(path)
+
+
+def entry(file, command="", arguments=None, directory="/build"):
+    e = {"file": file, "directory": directory}
+    if command:
+        e["command"] = command
+    if arguments:
+        e["arguments"] = arguments
+    return e
+
+
+# --------------------------------------------------------------------------
+# _find_compile_commands
+# --------------------------------------------------------------------------
+
+
+class TestFindCompileCommands:
+    def test_finds_it_beside_the_binary(self, tmp_path):
+        cc = write_cc(tmp_path, [])
+        binary = tmp_path / "my_app"
+        binary.write_bytes(b"\x7fELF")
+
+        assert _find_compile_commands(str(binary)) == cc
+
+    def test_walks_up_the_tree(self, tmp_path):
+        cc = write_cc(tmp_path, [])
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        binary = nested / "my_app"
+        binary.write_bytes(b"\x7fELF")
+
+        assert _find_compile_commands(str(binary)) == cc
+
+    def test_stops_at_a_build_directory(self, tmp_path):
+        """A build/ dir is the project boundary; do not escape into the parent.
+
+        Walking past it could pick up an unrelated project's database and
+        rebuild the kernel with the wrong flags.
+        """
+        write_cc(tmp_path, [])
+        build = tmp_path / "build"
+        build.mkdir()
+        binary = build / "my_app"
+        binary.write_bytes(b"\x7fELF")
+
+        assert _find_compile_commands(str(binary)) is None
+
+    def test_a_database_inside_the_build_dir_is_still_found(self, tmp_path):
+        """The boundary check happens after the file check, not before."""
+        build = tmp_path / "build"
+        build.mkdir()
+        cc = write_cc(build, [])
+        binary = build / "my_app"
+        binary.write_bytes(b"\x7fELF")
+
+        assert _find_compile_commands(str(binary)) == cc
+
+    def test_returns_none_when_absent(self, tmp_path):
+        binary = tmp_path / "my_app"
+        binary.write_bytes(b"\x7fELF")
+
+        assert _find_compile_commands(str(binary)) is None
+
+
+# --------------------------------------------------------------------------
+# _extract_defines_from_command
+# --------------------------------------------------------------------------
+
+
+class TestExtractDefines:
+    def test_attached_form(self):
+        assert _extract_defines_from_command("hipcc -DFOO -DBAR=1 x.cu", []) == ["FOO", "BAR=1"]
+
+    def test_separated_form(self):
+        """``-D FOO`` consumes the next token."""
+        assert _extract_defines_from_command("hipcc -D FOO -D BAR=2 x.cu", []) == ["FOO", "BAR=2"]
+
+    def test_mixed_forms(self):
+        assert _extract_defines_from_command("hipcc -DA -D B -DC x.cu", []) == ["A", "B", "C"]
+
+    def test_arguments_win_over_command(self):
+        """A database may carry either; ``arguments`` is the reliable one."""
+        result = _extract_defines_from_command(
+            "hipcc -DFROM_COMMAND x.cu", ["hipcc", "-DFROM_ARGS"]
+        )
+        assert result == ["FROM_ARGS"]
+
+    def test_the_consumed_token_is_not_re_examined(self):
+        """``-D -DFOO`` takes ``-DFOO`` as the value, not as another define."""
+        assert _extract_defines_from_command("hipcc -D -DFOO x.cu", []) == ["-DFOO"]
+
+    def test_trailing_bare_d_is_ignored(self):
+        assert _extract_defines_from_command("hipcc x.cu -D", []) == []
+
+    def test_no_defines(self):
+        assert _extract_defines_from_command("hipcc -O3 x.cu", []) == []
+
+    def test_empty_input(self):
+        assert _extract_defines_from_command("", []) == []
+
+
+# --------------------------------------------------------------------------
+# _defines_from_compile_commands
+# --------------------------------------------------------------------------
+
+
+class TestDefinesFromCompileCommands:
+    def test_no_database_returns_empty(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _defines_from_compile_commands(str(binary), ["/src/k.cu"]) == []
+
+    def test_matches_by_absolute_path(self, tmp_path):
+        src = tmp_path / "kernels.cu"
+        src.write_text("")
+        write_cc(tmp_path, [entry(str(src), command="hipcc -DGGML_USE_HIP -c kernels.cu")])
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _defines_from_compile_commands(str(binary), [str(src)]) == ["GGML_USE_HIP"]
+
+    def test_matches_by_basename(self, tmp_path):
+        """The database may record a path that no longer resolves."""
+        write_cc(tmp_path, [entry("/elsewhere/kernels.cu", command="hipcc -DFOO -c kernels.cu")])
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _defines_from_compile_commands(str(binary), ["/my/tree/kernels.cu"]) == ["FOO"]
+
+    def test_relative_entry_files_resolve_against_directory(self, tmp_path):
+        src = tmp_path / "sub" / "kernels.cu"
+        src.parent.mkdir()
+        src.write_text("")
+        write_cc(
+            tmp_path,
+            [entry("kernels.cu", command="hipcc -DREL", directory=str(tmp_path / "sub"))],
+        )
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _defines_from_compile_commands(str(binary), [str(src)]) == ["REL"]
+
+    def test_the_first_matching_entry_wins(self, tmp_path):
+        src = tmp_path / "k.cu"
+        src.write_text("")
+        write_cc(
+            tmp_path,
+            [
+                entry(str(src), command="hipcc -DFIRST"),
+                entry(str(src), command="hipcc -DSECOND"),
+            ],
+        )
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _defines_from_compile_commands(str(binary), [str(src)]) == ["FIRST"]
+
+    def test_no_matching_entry_returns_empty(self, tmp_path):
+        write_cc(tmp_path, [entry("/other/thing.cu", command="hipcc -DNOPE")])
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _defines_from_compile_commands(str(binary), ["/my/k.cu"]) == []
+
+    @pytest.mark.parametrize("content", ["{not json", ""])
+    def test_a_malformed_database_is_tolerated(self, tmp_path, content):
+        """A broken database must degrade to 'no defines', not crash extraction."""
+        (tmp_path / "compile_commands.json").write_text(content)
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _defines_from_compile_commands(str(binary), ["/my/k.cu"]) == []
+
+
+# --------------------------------------------------------------------------
+# _extract_includes_from_command
+# --------------------------------------------------------------------------
+
+
+class TestExtractIncludes:
+    def test_attached_form_resolved_to_absolute(self, tmp_path):
+        inc = tmp_path / "include"
+        inc.mkdir()
+
+        result = _extract_includes_from_command(f"hipcc -I{inc} x.cu", [], str(tmp_path))
+
+        assert result == [str(inc)]
+
+    def test_separated_form(self, tmp_path):
+        inc = tmp_path / "include"
+        inc.mkdir()
+
+        result = _extract_includes_from_command(f"hipcc -I {inc} x.cu", [], str(tmp_path))
+
+        assert result == [str(inc)]
+
+    def test_relative_paths_resolve_against_the_working_dir(self, tmp_path):
+        inc = tmp_path / "include"
+        inc.mkdir()
+
+        result = _extract_includes_from_command("hipcc -Iinclude x.cu", [], str(tmp_path))
+
+        assert result == [str(inc)]
+
+    def test_parent_relative_paths_are_normalised(self, tmp_path):
+        inc = tmp_path / "include"
+        inc.mkdir()
+        sub = tmp_path / "build"
+        sub.mkdir()
+
+        result = _extract_includes_from_command("hipcc -I../include x.cu", [], str(sub))
+
+        assert result == [str(inc)]
+
+    def test_nonexistent_directories_are_dropped(self, tmp_path):
+        """A stale -I would silently widen the include path on rebuild."""
+        real = tmp_path / "real"
+        real.mkdir()
+
+        result = _extract_includes_from_command(
+            f"hipcc -I{real} -I{tmp_path / 'gone'} x.cu", [], str(tmp_path)
+        )
+
+        assert result == [str(real)]
+
+    def test_a_file_is_not_a_valid_include_dir(self, tmp_path):
+        f = tmp_path / "notadir.h"
+        f.write_text("")
+
+        assert _extract_includes_from_command(f"hipcc -I{f} x.cu", [], str(tmp_path)) == []
+
+    def test_arguments_win_over_command(self, tmp_path):
+        inc = tmp_path / "from_args"
+        inc.mkdir()
+
+        result = _extract_includes_from_command(
+            "hipcc -I/from/command x.cu", ["hipcc", f"-I{inc}"], str(tmp_path)
+        )
+
+        assert result == [str(inc)]
+
+    def test_trailing_bare_i_is_ignored(self, tmp_path):
+        assert _extract_includes_from_command("hipcc x.cu -I", [], str(tmp_path)) == []
+
+    def test_the_consumed_token_is_not_re_examined(self, tmp_path):
+        inc = tmp_path / "inc"
+        inc.mkdir()
+
+        result = _extract_includes_from_command(f"hipcc -I {inc} -O3", [], str(tmp_path))
+
+        assert result == [str(inc)]
+
+    def test_no_working_dir_leaves_relative_paths_alone(self):
+        """Without a working dir a relative path cannot be resolved, so it
+        will not match a real directory and is dropped."""
+        assert _extract_includes_from_command("hipcc -Iinclude x.cu", [], "") == []
+
+
+# --------------------------------------------------------------------------
+# _includes_from_compile_commands
+# --------------------------------------------------------------------------
+
+
+class TestIncludesFromCompileCommands:
+    def test_no_database_returns_empty(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _includes_from_compile_commands(str(binary), ["/src/k.cu"]) == []
+
+    def test_extracts_includes_for_a_matching_entry(self, tmp_path):
+        src = tmp_path / "k.cu"
+        src.write_text("")
+        inc = tmp_path / "include"
+        inc.mkdir()
+        write_cc(
+            tmp_path,
+            [entry(str(src), command=f"hipcc -I{inc} -c k.cu", directory=str(tmp_path))],
+        )
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _includes_from_compile_commands(str(binary), [str(src)]) == [str(inc)]
+
+    def test_matches_by_basename(self, tmp_path):
+        inc = tmp_path / "include"
+        inc.mkdir()
+        write_cc(
+            tmp_path,
+            [entry("/elsewhere/k.cu", command=f"hipcc -I{inc}", directory=str(tmp_path))],
+        )
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _includes_from_compile_commands(str(binary), ["/my/k.cu"]) == [str(inc)]
+
+    def test_falls_back_to_the_database_dir_when_no_directory_field(self, tmp_path):
+        """Relative -I paths still resolve when the entry omits 'directory'."""
+        inc = tmp_path / "include"
+        inc.mkdir()
+        (tmp_path / "compile_commands.json").write_text(
+            json.dumps([{"file": "/elsewhere/k.cu", "command": "hipcc -Iinclude"}])
+        )
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _includes_from_compile_commands(str(binary), ["/my/k.cu"]) == [str(inc)]
+
+    def test_no_matching_entry_returns_empty(self, tmp_path):
+        write_cc(tmp_path, [entry("/other/thing.cu", command="hipcc -I/x")])
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _includes_from_compile_commands(str(binary), ["/my/k.cu"]) == []
+
+    def test_a_malformed_database_is_tolerated(self, tmp_path):
+        (tmp_path / "compile_commands.json").write_text("[[[")
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7f")
+
+        assert _includes_from_compile_commands(str(binary), ["/my/k.cu"]) == []
+
+
+# --------------------------------------------------------------------------
+# _extract_output_path
+# --------------------------------------------------------------------------
+
+
+class TestExtractOutputPath:
+    def test_separated_form(self):
+        result = _extract_output_path(["hipcc", "-o", "obj/k.o", "k.cu"], "/build")
+        assert result == os.path.normpath("/build/obj/k.o")
+
+    def test_attached_form(self):
+        result = _extract_output_path(["hipcc", "-oobj/k.o", "k.cu"], "/build")
+        assert result == os.path.normpath("/build/obj/k.o")
+
+    def test_absolute_paths_are_left_alone(self):
+        assert _extract_output_path(["hipcc", "-o", "/abs/k.o"], "/build") == "/abs/k.o"
+
+    def test_no_working_dir(self):
+        assert _extract_output_path(["hipcc", "-o", "k.o"], "") == "k.o"
+
+    def test_no_output_flag(self):
+        assert _extract_output_path(["hipcc", "-c", "k.cu"], "/build") is None
+
+    def test_trailing_bare_o_is_ignored(self):
+        assert _extract_output_path(["hipcc", "k.cu", "-o"], "/build") is None
+
+    def test_optimisation_flags_are_not_mistaken_for_output(self):
+        """``-O3`` starts with ``-O``, not ``-o`` — case matters."""
+        assert _extract_output_path(["hipcc", "-O3", "k.cu"], "/build") is None
+
+
+# --------------------------------------------------------------------------
+# _nm_has_symbol
+# --------------------------------------------------------------------------
+
+
+class TestNmHasSymbol:
+    def test_three_column_form(self):
+        out = "0000000000001234 T _Z6kernelPf\n"
+        assert _nm_has_symbol(out, "_Z6kernelPf") is True
+
+    def test_two_column_form(self):
+        """Undefined symbols have no address column."""
+        assert _nm_has_symbol("         U _Z6kernelPf\n", "_Z6kernelPf") is True
+
+    def test_requires_an_exact_match(self):
+        """A prefix match would pick the wrong translation unit."""
+        out = "0000000000001234 T _Z6kernelPfSuffix\n"
+        assert _nm_has_symbol(out, "_Z6kernelPf") is False
+
+    def test_a_substring_elsewhere_on_the_line_does_not_count(self):
+        assert _nm_has_symbol("0000 T other _Z6kernelPf\n", "_Z6kernelPf") is False
+
+    def test_empty_output(self):
+        assert _nm_has_symbol("", "_Z6kernelPf") is False
+
+    def test_finds_the_symbol_among_many(self):
+        out = "0000 T _Z1aPf\n0010 T _Z6kernelPf\n0020 T _Z1bPf\n"
+        assert _nm_has_symbol(out, "_Z6kernelPf") is True
+
+
+# --------------------------------------------------------------------------
+# _match_tu_via_object_symbols
+# --------------------------------------------------------------------------
+
+
+class TestMatchTuViaObjectSymbols:
+    """Picking the right translation unit for a templated kernel.
+
+    Templated HIP kernels are instantiated across many .cu files (llama.cpp's
+    ``mmq-instance-*.cu`` is the motivating case). Only one object file
+    actually defines the captured mangled symbol, and choosing the wrong one
+    produces a reproducer that rebuilds a different instantiation.
+    """
+
+    @staticmethod
+    def setup_tu(tmp_path, name="k.cu", obj="k.o"):
+        """Create a source file plus its object file; return both paths."""
+        src = tmp_path / name
+        src.write_text("")
+        obj_path = tmp_path / obj
+        obj_path.write_bytes(b"\x7fELF")
+        return str(src), str(obj_path)
+
+    def test_matches_the_object_containing_the_symbol(self, tmp_path, monkeypatch):
+        src_a, obj_a = self.setup_tu(tmp_path, "a.cu", "a.o")
+        src_b, obj_b = self.setup_tu(tmp_path, "b.cu", "b.o")
+        cc = write_cc(
+            tmp_path,
+            [
+                entry(src_a, command=f"hipcc -o {obj_a} -c a.cu", directory=str(tmp_path)),
+                entry(src_b, command=f"hipcc -o {obj_b} -c b.cu", directory=str(tmp_path)),
+            ],
+        )
+
+        def _nm(argv, **_kwargs):
+            import subprocess as sp
+
+            found = argv[1] == obj_b
+            out = "0000 T _Z6kernelIiEvPT_\n" if found else "0000 T _Z5otherv\n"
+            return sp.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+        monkeypatch.setattr("subprocess.run", _nm)
+        candidates = [(src_a, "cmd_a", "dir_a"), (src_b, "cmd_b", "dir_b")]
+
+        result = _match_tu_via_object_symbols("_Z6kernelIiEvPT_", candidates, cc)
+
+        assert result == (src_b, "cmd_b", "dir_b")
+
+    def test_returns_none_when_no_object_defines_the_symbol(self, tmp_path, monkeypatch):
+        src, obj = self.setup_tu(tmp_path)
+        cc = write_cc(
+            tmp_path, [entry(src, command=f"hipcc -o {obj} -c k.cu", directory=str(tmp_path))]
+        )
+
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda argv, **kw: __import__("subprocess").CompletedProcess(
+                argv, 0, stdout="0000 T _Z5otherv\n", stderr=""
+            ),
+        )
+
+        assert _match_tu_via_object_symbols("_Z6missing", [(src, "c", "d")], cc) is None
+
+    def test_a_malformed_database_returns_none(self, tmp_path):
+        cc = tmp_path / "compile_commands.json"
+        cc.write_text("{not json")
+
+        assert _match_tu_via_object_symbols("_Z6kernel", [("/x.cu", "c", "d")], str(cc)) is None
+
+    def test_a_missing_database_returns_none(self, tmp_path):
+        missing = str(tmp_path / "compile_commands.json")
+
+        assert _match_tu_via_object_symbols("_Z6kernel", [("/x.cu", "c", "d")], missing) is None
+
+    def test_candidates_without_a_database_entry_are_skipped(self, tmp_path, monkeypatch):
+        src, obj = self.setup_tu(tmp_path)
+        cc = write_cc(tmp_path, [entry("/unrelated.cu", command="hipcc -o /u.o -c u.cu")])
+        called = []
+        monkeypatch.setattr("subprocess.run", lambda argv, **kw: called.append(argv))
+
+        assert _match_tu_via_object_symbols("_Z6kernel", [(src, "c", "d")], cc) is None
+        assert called == []
+
+    def test_entries_without_an_output_flag_are_skipped(self, tmp_path, monkeypatch):
+        """A link step or a syntax-only invocation has no object to inspect."""
+        src, _obj = self.setup_tu(tmp_path)
+        cc = write_cc(
+            tmp_path, [entry(src, command="hipcc -fsyntax-only k.cu", directory=str(tmp_path))]
+        )
+        called = []
+        monkeypatch.setattr("subprocess.run", lambda argv, **kw: called.append(argv))
+
+        assert _match_tu_via_object_symbols("_Z6kernel", [(src, "c", "d")], cc) is None
+        assert called == []
+
+    def test_an_unbuilt_object_file_is_skipped(self, tmp_path, monkeypatch):
+        """The database may reference objects a clean tree has not built."""
+        src = tmp_path / "k.cu"
+        src.write_text("")
+        cc = write_cc(
+            tmp_path,
+            [
+                entry(
+                    str(src),
+                    command=f"hipcc -o {tmp_path / 'never_built.o'} -c k.cu",
+                    directory=str(tmp_path),
+                )
+            ],
+        )
+        called = []
+        monkeypatch.setattr("subprocess.run", lambda argv, **kw: called.append(argv))
+
+        assert _match_tu_via_object_symbols("_Z6kernel", [(str(src), "c", "d")], cc) is None
+        assert called == []
+
+    def test_a_failing_nm_skips_that_candidate(self, tmp_path, monkeypatch):
+        src_a, obj_a = self.setup_tu(tmp_path, "a.cu", "a.o")
+        src_b, obj_b = self.setup_tu(tmp_path, "b.cu", "b.o")
+        cc = write_cc(
+            tmp_path,
+            [
+                entry(src_a, command=f"hipcc -o {obj_a} -c a.cu", directory=str(tmp_path)),
+                entry(src_b, command=f"hipcc -o {obj_b} -c b.cu", directory=str(tmp_path)),
+            ],
+        )
+
+        def _nm(argv, **_kwargs):
+            import subprocess as sp
+
+            if argv[1] == obj_a:
+                return sp.CompletedProcess(argv, 1, stdout="", stderr="not an object")
+            return sp.CompletedProcess(argv, 0, stdout="0000 T _Z6kernel\n", stderr="")
+
+        monkeypatch.setattr("subprocess.run", _nm)
+        candidates = [(src_a, "ca", "da"), (src_b, "cb", "db")]
+
+        assert _match_tu_via_object_symbols("_Z6kernel", candidates, cc) == (src_b, "cb", "db")
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            FileNotFoundError("nm"),
+            __import__("subprocess").TimeoutExpired("nm", 10),
+            OSError("exec format error"),
+        ],
+    )
+    def test_nm_exceptions_skip_that_candidate(self, tmp_path, monkeypatch, exc):
+        """No nm on PATH must not crash source finding."""
+        src, obj = self.setup_tu(tmp_path)
+        cc = write_cc(
+            tmp_path, [entry(src, command=f"hipcc -o {obj} -c k.cu", directory=str(tmp_path))]
+        )
+
+        def _raise(argv, **_kwargs):
+            raise exc
+
+        monkeypatch.setattr("subprocess.run", _raise)
+
+        assert _match_tu_via_object_symbols("_Z6kernel", [(src, "c", "d")], cc) is None
+
+    def test_relative_entry_files_resolve_against_directory(self, tmp_path, monkeypatch):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        src = sub / "k.cu"
+        src.write_text("")
+        obj = sub / "k.o"
+        obj.write_bytes(b"\x7fELF")
+        cc = write_cc(
+            tmp_path, [entry("k.cu", command=f"hipcc -o {obj} -c k.cu", directory=str(sub))]
+        )
+
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda argv, **kw: __import__("subprocess").CompletedProcess(
+                argv, 0, stdout="0000 T _Z6kernel\n", stderr=""
+            ),
+        )
+
+        assert _match_tu_via_object_symbols("_Z6kernel", [(str(src), "c", "d")], cc) == (
+            str(src),
+            "c",
+            "d",
+        )
+
+    def test_the_arguments_field_is_used_when_present(self, tmp_path, monkeypatch):
+        src, obj = self.setup_tu(tmp_path)
+        cc = write_cc(
+            tmp_path,
+            [entry(src, arguments=["hipcc", "-o", obj, "-c", "k.cu"], directory=str(tmp_path))],
+        )
+
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda argv, **kw: __import__("subprocess").CompletedProcess(
+                argv, 0, stdout="0000 T _Z6kernel\n", stderr=""
+            ),
+        )
+
+        assert _match_tu_via_object_symbols("_Z6kernel", [(src, "c", "d")], cc) is not None

--- a/kerncap/tests/unit/test_source_finder_compile_commands.py
+++ b/kerncap/tests/unit/test_source_finder_compile_commands.py
@@ -284,9 +284,30 @@ class TestExtractIncludes:
 
         assert result == [str(inc)]
 
-    def test_no_working_dir_leaves_relative_paths_alone(self):
-        """Without a working dir a relative path cannot be resolved, so it
-        will not match a real directory and is dropped."""
+    def test_without_a_working_dir_a_relative_path_resolves_against_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        """With ``working_dir=""`` the path stays relative, so ``os.path.isdir``
+        resolves it against the *process* working directory.
+
+        Real callers pass the compile_commands entry's ``directory``, so this
+        fallback does not bite in practice — but it means the function's result
+        depends on where the process happens to be. Pinned in both directions
+        below rather than left implicit.
+
+        ``chdir`` is what makes this deterministic: without it the assertion
+        silently depends on whether an ``include/`` directory happens to exist
+        wherever pytest was invoked from.
+        """
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "include").mkdir()
+
+        assert _extract_includes_from_command("hipcc -Iinclude x.cu", [], "") == ["include"]
+
+    def test_without_a_working_dir_an_unresolvable_path_is_dropped(self, tmp_path, monkeypatch):
+        """Same call, a CWD with no matching directory: the path is dropped."""
+        monkeypatch.chdir(tmp_path)
+
         assert _extract_includes_from_command("hipcc -Iinclude x.cu", [], "") == []
 
 

--- a/kerncap/tests/unit/test_validator_pipelines.py
+++ b/kerncap/tests/unit/test_validator_pipelines.py
@@ -11,8 +11,6 @@ real files written with numpy, so the dtype inference and shape comparison run
 for real rather than being mocked away.
 """
 
-import json
-import os
 import subprocess
 from unittest.mock import patch
 
@@ -141,18 +139,9 @@ class TestFormatRouting:
 
         assert triton.call_args.args[1] == {}
 
-    def test_bare_triton_reproducer_still_reads_metadata_when_present(self, tmp_path):
-        """No dispatch.json, but capture/metadata.json exists and is used."""
-        (tmp_path / "capture").mkdir()
-        (tmp_path / "reproducer.py").write_text("")
-        # Written *after* the legacy branch would have matched, so this
-        # exercises the second metadata read rather than the first.
-        (tmp_path / "capture" / "metadata.json").write_text('{"args": [{"index": 7}]}')
-
-        with patch("kerncap.validator._validate_triton") as triton:
-            validate_reproducer(str(tmp_path))
-
-        triton.assert_called_once()
+    # A metadata.json + reproducer.py combination is covered by
+    # TestUnreachableMetadataRead below, which asserts what actually happens
+    # (the legacy branch handles it) rather than the second, unreachable read.
 
     def test_nothing_recognisable_fails_clearly(self, repro):
         result = validate_reproducer(str(repro))

--- a/kerncap/tests/unit/test_validator_pipelines.py
+++ b/kerncap/tests/unit/test_validator_pipelines.py
@@ -1,0 +1,672 @@
+"""Unit tests for kerncap.validator's format routing and build/run pipelines.
+
+``validate_reproducer`` dispatches on which artifacts are present on disk, then
+each ``_validate_*`` pipeline shells out to build and run the reproducer. The
+existing ``test_validator.py`` covers the replay-comparison maths; this file
+covers the routing and the three build/run pipelines around it.
+
+``subprocess.run`` and ``_get_replay_path`` are stubbed at their call sites, so
+none of this needs ROCm, a GPU, or a compiler. Reference and output buffers are
+real files written with numpy, so the dtype inference and shape comparison run
+for real rather than being mocked away.
+"""
+
+import json
+import os
+import subprocess
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from kerncap.validator import (
+    _compare_outputs,
+    _infer_numpy_dtype,
+    _infer_numpy_dtype_from_torch,
+    _validate_hip,
+    _validate_hsaco,
+    _validate_triton,
+    validate_reproducer,
+)
+
+
+def completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
+
+
+def sequence(*results):
+    """Return a ``subprocess.run`` stub yielding *results* in order."""
+    calls = []
+
+    def _run(argv, **kwargs):
+        calls.append((list(argv), kwargs))
+        return results[min(len(calls) - 1, len(results) - 1)]
+
+    _run.calls = calls
+    return _run
+
+
+@pytest.fixture
+def repro(tmp_path):
+    """An empty reproducer directory with a capture/ subdir."""
+    (tmp_path / "capture").mkdir()
+    return tmp_path
+
+
+def write_buffers(repro_dir, idx, ref, out, ref_name="arg_0.bin"):
+    """Write a reference buffer and a reproducer output buffer to disk."""
+    (repro_dir / "capture").mkdir(exist_ok=True)
+    (repro_dir / "reference_output").mkdir(exist_ok=True)
+    ref.tofile(repro_dir / "capture" / ref_name)
+    out.tofile(repro_dir / "reference_output" / f"output_{idx}.bin")
+
+
+def out_arg(idx=0, **overrides):
+    """A metadata entry for an output (non-const pointer) argument."""
+    arg = {
+        "index": idx,
+        "is_pointer": True,
+        "is_const": False,
+        "file": "arg_0.bin",
+        "type": "float*",
+    }
+    arg.update(overrides)
+    return arg
+
+
+# --------------------------------------------------------------------------
+# validate_reproducer — format routing
+# --------------------------------------------------------------------------
+
+
+class TestFormatRouting:
+    def test_dispatch_json_routes_to_the_replay_path(self, repro):
+        """The VA-faithful format wins whenever dispatch.json is present."""
+        (repro / "capture" / "dispatch.json").write_text("{}")
+
+        with patch("kerncap.validator._validate_replay") as replay:
+            validate_reproducer(str(repro), tolerance=1e-4, rtol=1e-3, hsaco="/x.hsaco")
+
+        replay.assert_called_once_with(str(repro), 1e-4, 1e-3, hsaco="/x.hsaco")
+
+    @pytest.mark.parametrize(
+        ("artifact", "target"),
+        [
+            ("harness.hip", "_validate_hsaco"),
+            ("reproducer.hip", "_validate_hip"),
+            ("reproducer.py", "_validate_triton"),
+        ],
+    )
+    def test_legacy_metadata_routes_by_artifact(self, repro, artifact, target):
+        (repro / "capture" / "metadata.json").write_text('{"args": []}')
+        (repro / artifact).write_text("")
+
+        with patch(f"kerncap.validator.{target}") as fn:
+            validate_reproducer(str(repro))
+
+        fn.assert_called_once()
+
+    def test_harness_wins_over_the_other_two(self, repro):
+        """All three can coexist; the branch order decides."""
+        (repro / "capture" / "metadata.json").write_text('{"args": []}')
+        for name in ("harness.hip", "reproducer.hip", "reproducer.py"):
+            (repro / name).write_text("")
+
+        with (
+            patch("kerncap.validator._validate_hsaco") as hsaco,
+            patch("kerncap.validator._validate_hip") as hip,
+            patch("kerncap.validator._validate_triton") as triton,
+        ):
+            validate_reproducer(str(repro))
+
+        hsaco.assert_called_once()
+        hip.assert_not_called()
+        triton.assert_not_called()
+
+    def test_metadata_is_parsed_and_forwarded(self, repro):
+        (repro / "capture" / "metadata.json").write_text('{"args": [{"index": 3}]}')
+        (repro / "reproducer.hip").write_text("")
+
+        with patch("kerncap.validator._validate_hip") as hip:
+            validate_reproducer(str(repro))
+
+        assert hip.call_args.args[1] == {"args": [{"index": 3}]}
+
+    def test_bare_triton_reproducer_needs_no_capture_dir(self, repro):
+        """A Triton reproducer can be validated with no metadata at all."""
+        (repro / "reproducer.py").write_text("")
+
+        with patch("kerncap.validator._validate_triton") as triton:
+            validate_reproducer(str(repro))
+
+        assert triton.call_args.args[1] == {}
+
+    def test_bare_triton_reproducer_still_reads_metadata_when_present(self, tmp_path):
+        """No dispatch.json, but capture/metadata.json exists and is used."""
+        (tmp_path / "capture").mkdir()
+        (tmp_path / "reproducer.py").write_text("")
+        # Written *after* the legacy branch would have matched, so this
+        # exercises the second metadata read rather than the first.
+        (tmp_path / "capture" / "metadata.json").write_text('{"args": [{"index": 7}]}')
+
+        with patch("kerncap.validator._validate_triton") as triton:
+            validate_reproducer(str(tmp_path))
+
+        triton.assert_called_once()
+
+    def test_nothing_recognisable_fails_clearly(self, repro):
+        result = validate_reproducer(str(repro))
+
+        assert result.passed is False
+        assert "No dispatch.json, metadata.json, or reproducer.py found" in result.details[0]
+
+
+# --------------------------------------------------------------------------
+# _validate_hsaco
+# --------------------------------------------------------------------------
+
+
+class TestValidateHsaco:
+    def test_build_failure_reports_stderr(self, repro):
+        with patch("subprocess.run", sequence(completed(2, stderr="undefined reference"))):
+            result = _validate_hsaco(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        assert result.passed is False
+        assert result.mode == "numeric"
+        assert "Build failed" in result.details[0]
+        assert "undefined reference" in result.details[0]
+
+    def test_builds_with_make_in_the_reproducer_dir(self, repro):
+        (repro / "kernel.hsaco").write_bytes(b"\x7fELF")
+        stub = sequence(completed(), completed())
+        with patch("subprocess.run", stub):
+            _validate_hsaco(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        build_argv = stub.calls[0][0]
+        assert build_argv == ["make", "-C", str(repro), "all"]
+
+    def test_missing_hsaco_after_a_successful_build(self, repro):
+        """Build can succeed while producing nothing runnable."""
+        with patch("subprocess.run", sequence(completed())):
+            result = _validate_hsaco(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        assert result.passed is False
+        assert result.details[0] == "Build: OK"
+        assert "kernel.hsaco not found" in result.details[1]
+
+    def test_run_failure_keeps_the_build_detail(self, repro):
+        (repro / "kernel.hsaco").write_bytes(b"\x7fELF")
+        with patch("subprocess.run", sequence(completed(), completed(134, stderr="SIGABRT"))):
+            result = _validate_hsaco(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        assert result.passed is False
+        assert result.details[0] == "Build: OK"
+        assert "Run failed (exit 134)" in result.details[1]
+        assert "SIGABRT" in result.details[1]
+
+    def test_runs_the_harness_against_the_hsaco(self, repro):
+        (repro / "kernel.hsaco").write_bytes(b"\x7fELF")
+        stub = sequence(completed(), completed(stdout="ok"))
+        with patch("subprocess.run", stub):
+            _validate_hsaco(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        run_argv, run_kwargs = stub.calls[1]
+        assert run_argv == ["./harness", "kernel.hsaco"]
+        assert run_kwargs["cwd"] == str(repro)
+
+    def test_success_flows_into_output_comparison(self, repro):
+        (repro / "kernel.hsaco").write_bytes(b"\x7fELF")
+        with (
+            patch("subprocess.run", sequence(completed(), completed(stdout="ran 1 iter"))),
+            patch("kerncap.validator._compare_outputs") as cmp,
+        ):
+            _validate_hsaco(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        details = cmp.call_args.args[4]
+        assert details[0] == "Build: OK"
+        assert "ran 1 iter" in details[1]
+
+
+# --------------------------------------------------------------------------
+# _validate_hip
+# --------------------------------------------------------------------------
+
+
+class TestValidateHip:
+    def test_build_failure(self, repro):
+        with patch("subprocess.run", sequence(completed(1, stderr="hipcc: error"))):
+            result = _validate_hip(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        assert result.passed is False
+        assert "hipcc: error" in result.details[0]
+
+    def test_runs_the_reproducer_binary(self, repro):
+        stub = sequence(completed(), completed(stdout="done"))
+        with patch("subprocess.run", stub):
+            _validate_hip(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        run_argv, run_kwargs = stub.calls[1]
+        assert run_argv == ["./reproducer"]
+        assert run_kwargs["cwd"] == str(repro)
+
+    def test_run_failure(self, repro):
+        with patch("subprocess.run", sequence(completed(), completed(1, stderr="segfault"))):
+            result = _validate_hip(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        assert result.passed is False
+        assert "Run failed (exit 1)" in result.details[1]
+
+    def test_no_hsaco_check_on_this_path(self, repro):
+        """Unlike the HSACO path, a HIP reproducer needs no separate artifact."""
+        with (
+            patch("subprocess.run", sequence(completed(), completed())),
+            patch("kerncap.validator._compare_outputs") as cmp,
+        ):
+            _validate_hip(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        cmp.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# _validate_triton
+# --------------------------------------------------------------------------
+
+
+class TestValidateTriton:
+    def test_runs_the_python_reproducer_with_no_build_step(self, repro):
+        """Triton re-JITs itself, so there is nothing to make."""
+        stub = sequence(completed(stdout="jitted"))
+        with patch("subprocess.run", stub):
+            _validate_triton(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        assert len(stub.calls) == 1
+        run_argv, run_kwargs = stub.calls[0]
+        assert run_argv == ["python3", "reproducer.py"]
+        assert run_kwargs["cwd"] == str(repro)
+
+    def test_run_failure_has_no_build_detail_to_keep(self, repro):
+        with patch("subprocess.run", sequence(completed(1, stderr="ImportError: triton"))):
+            result = _validate_triton(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        assert result.passed is False
+        assert len(result.details) == 1
+        assert "ImportError: triton" in result.details[0]
+
+    def test_success_flows_into_output_comparison(self, repro):
+        with (
+            patch("subprocess.run", sequence(completed(stdout="ok"))),
+            patch("kerncap.validator._compare_outputs") as cmp,
+        ):
+            _validate_triton(str(repro), {"args": []}, 1e-6, 1e-5)
+
+        assert "ok" in cmp.call_args.args[4][0]
+
+
+# --------------------------------------------------------------------------
+# _compare_outputs
+# --------------------------------------------------------------------------
+
+
+class TestCompareOutputs:
+    def test_matching_buffers_pass(self, repro):
+        data = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        write_buffers(repro, 0, data, data.copy())
+
+        result = _compare_outputs(str(repro), {"args": [out_arg()]}, 1e-6, 1e-5, [])
+
+        assert result.passed is True
+
+    def test_const_pointers_are_not_treated_as_outputs(self, repro):
+        """Inputs should not be compared — only non-const pointers are outputs."""
+        meta = {"args": [out_arg(is_const=True), {"index": 1, "is_pointer": False}]}
+
+        result = _compare_outputs(str(repro), meta, 1e-6, 1e-5, [])
+
+        assert result.passed is True
+
+    def test_missing_output_file_fails(self, repro):
+        data = np.array([1.0], dtype=np.float32)
+        (repro / "capture").mkdir(exist_ok=True)
+        data.tofile(repro / "capture" / "arg_0.bin")
+
+        result = _compare_outputs(str(repro), {"args": [out_arg()]}, 1e-6, 1e-5, [])
+
+        assert result.passed is False
+        assert any("MISSING output file" in d for d in result.details)
+
+    def test_missing_reference_file_fails(self, repro):
+        (repro / "reference_output").mkdir()
+        np.array([1.0], dtype=np.float32).tofile(repro / "reference_output" / "output_0.bin")
+
+        result = _compare_outputs(str(repro), {"args": [out_arg()]}, 1e-6, 1e-5, [])
+
+        assert result.passed is False
+        assert any("MISSING reference file" in d for d in result.details)
+
+    def test_prefers_the_post_kernel_reference(self, repro):
+        """ref_output_file is the post-kernel snapshot; file is pre-kernel."""
+        (repro / "capture").mkdir(exist_ok=True)
+        (repro / "reference_output").mkdir()
+        np.array([9.0], dtype=np.float32).tofile(repro / "capture" / "arg_0.bin")
+        np.array([1.0], dtype=np.float32).tofile(repro / "capture" / "arg_0_out.bin")
+        np.array([1.0], dtype=np.float32).tofile(repro / "reference_output" / "output_0.bin")
+
+        meta = {"args": [out_arg(ref_output_file="arg_0_out.bin")]}
+        result = _compare_outputs(str(repro), meta, 1e-6, 1e-5, [])
+
+        assert result.passed is True
+
+    def test_falls_back_to_the_pre_kernel_capture(self, repro):
+        """When ref_output_file names a file that was never written."""
+        data = np.array([4.0], dtype=np.float32)
+        write_buffers(repro, 0, data, data.copy())
+
+        meta = {"args": [out_arg(ref_output_file="absent.bin")]}
+        result = _compare_outputs(str(repro), meta, 1e-6, 1e-5, [])
+
+        assert result.passed is True
+
+    def test_shape_mismatch_fails(self, repro):
+        write_buffers(
+            repro,
+            0,
+            np.array([1.0, 2.0], dtype=np.float32),
+            np.array([1.0], dtype=np.float32),
+        )
+
+        result = _compare_outputs(str(repro), {"args": [out_arg()]}, 1e-6, 1e-5, [])
+
+        assert result.passed is False
+        assert any("SHAPE MISMATCH" in d for d in result.details)
+
+    def test_empty_buffers_are_reported_but_not_a_failure(self, repro):
+        """A zero-element output is degenerate, not wrong."""
+        empty = np.array([], dtype=np.float32)
+        write_buffers(repro, 0, empty, empty)
+
+        result = _compare_outputs(str(repro), {"args": [out_arg()]}, 1e-6, 1e-5, [])
+
+        assert any("EMPTY (0 elements)" in d for d in result.details)
+        assert result.passed is True
+
+    def test_torch_dtype_takes_priority_over_c_type(self, repro):
+        """Triton captures carry torch_dtype; misreading it changes the shape."""
+        data = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float16)
+        write_buffers(repro, 0, data, data.copy())
+
+        meta = {"args": [out_arg(torch_dtype="torch.float16", type="float*")]}
+        result = _compare_outputs(str(repro), meta, 1e-6, 1e-5, [])
+
+        assert result.passed is True
+
+    def test_a_wrong_dtype_shows_up_as_a_shape_mismatch(self, repro):
+        """8 float16 bytes read as float32 is 2 elements, not 4."""
+        (repro / "capture").mkdir(exist_ok=True)
+        (repro / "reference_output").mkdir()
+        np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float16).tofile(repro / "capture" / "arg_0.bin")
+        np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32).tofile(
+            repro / "reference_output" / "output_0.bin"
+        )
+
+        result = _compare_outputs(str(repro), {"args": [out_arg()]}, 1e-6, 1e-5, [])
+
+        assert result.passed is False
+        assert any("SHAPE MISMATCH" in d for d in result.details)
+
+
+# --------------------------------------------------------------------------
+# dtype inference
+# --------------------------------------------------------------------------
+
+
+class TestDtypeInference:
+    @pytest.mark.parametrize(
+        ("torch_str", "expected"),
+        [
+            ("torch.float16", np.float16),
+            ("torch.float32", np.float32),
+            ("torch.float64", np.float64),
+            ("torch.int8", np.int8),
+            ("torch.int16", np.int16),
+            ("torch.int32", np.int32),
+            ("torch.int64", np.int64),
+            ("torch.bool", np.bool_),
+            ("torch.uint8", np.uint8),
+        ],
+    )
+    def test_torch_dtypes_map_directly(self, torch_str, expected):
+        assert _infer_numpy_dtype_from_torch(torch_str) == np.dtype(expected)
+
+    def test_bfloat16_is_carried_as_raw_bits(self):
+        """numpy has no native bf16, so the bytes are compared as uint16."""
+        assert _infer_numpy_dtype_from_torch("torch.bfloat16") == np.dtype(np.uint16)
+
+    def test_unknown_torch_dtype_falls_back_to_float32(self):
+        assert _infer_numpy_dtype_from_torch("torch.complex128") == np.dtype(np.float32)
+
+    def test_unknown_c_type_falls_back_to_float32(self):
+        assert _infer_numpy_dtype("struct Foo*") == np.dtype(np.float32)
+
+
+# --------------------------------------------------------------------------
+# _validate_replay — routing, auto-detect, and failure paths
+# --------------------------------------------------------------------------
+
+
+class TestValidateReplay:
+    def test_missing_replay_binary_is_reported(self, repro):
+        (repro / "capture" / "dispatch.json").write_text("{}")
+
+        with patch(
+            "kerncap._get_replay_path", side_effect=FileNotFoundError("kerncap-replay missing")
+        ):
+            result = validate_reproducer(str(repro))
+
+        assert result.passed is False
+        assert "kerncap-replay missing" in result.details[0]
+
+    @pytest.mark.parametrize("name", ["candidate.hsaco", "optimized.hsaco"])
+    def test_auto_detects_a_rebuilt_hsaco(self, repro, name):
+        """The documented edit loop: rebuild then `kerncap validate <dir>`.
+
+        Triton's reproducer.py writes candidate.hsaco; `make recompile`
+        writes optimized.hsaco. Either must be picked up without a flag.
+        """
+        (repro / "capture" / "dispatch.json").write_text("{}")
+        (repro / name).write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap._get_replay_path", return_value="/bin/replay"),
+            patch("kerncap.validator._validate_replay_variant") as variant,
+        ):
+            validate_reproducer(str(repro))
+
+        assert variant.call_args.args[2] == str(repro / name)
+        details = variant.call_args.args[3]
+        assert any("Auto-detected rebuilt HSACO" in d for d in details)
+
+    def test_candidate_wins_over_optimized(self, repro):
+        (repro / "capture" / "dispatch.json").write_text("{}")
+        (repro / "candidate.hsaco").write_bytes(b"\x7fELF")
+        (repro / "optimized.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap._get_replay_path", return_value="/bin/replay"),
+            patch("kerncap.validator._validate_replay_variant") as variant,
+        ):
+            validate_reproducer(str(repro))
+
+        assert variant.call_args.args[2].endswith("candidate.hsaco")
+
+    def test_an_explicit_hsaco_skips_auto_detection(self, repro):
+        (repro / "capture" / "dispatch.json").write_text("{}")
+        (repro / "candidate.hsaco").write_bytes(b"\x7fELF")
+
+        with (
+            patch("kerncap._get_replay_path", return_value="/bin/replay"),
+            patch("kerncap.validator._validate_replay_variant") as variant,
+        ):
+            validate_reproducer(str(repro), hsaco="/explicit.hsaco")
+
+        assert variant.call_args.args[2] == "/explicit.hsaco"
+        assert not any("Auto-detected" in d for d in variant.call_args.args[3])
+
+    def test_no_rebuilt_hsaco_runs_the_smoke_test(self, repro):
+        (repro / "capture" / "dispatch.json").write_text("{}")
+
+        with (
+            patch("kerncap._get_replay_path", return_value="/bin/replay"),
+            patch("kerncap.validator._validate_replay_baseline") as baseline,
+        ):
+            validate_reproducer(str(repro))
+
+        baseline.assert_called_once()
+
+
+class TestRunReplay:
+    def test_reports_ok_without_a_timing_line(self, repro):
+        """Not every replay prints timing; the header must still appear."""
+        from kerncap.validator import _run_replay
+
+        details = []
+        with patch("subprocess.run", sequence(completed(stdout="Replaying\nDone\n"))):
+            proc = _run_replay("/bin/replay", str(repro), details, label="Replay")
+
+        assert proc is not None
+        assert details[0] == "Replay: OK"
+
+    def test_reports_ok_with_a_timing_line(self, repro):
+        from kerncap.validator import _run_replay
+
+        details = []
+        stdout = "Replaying\nAverage GPU time: 12.5 us\n"
+        with patch("subprocess.run", sequence(completed(stdout=stdout))):
+            _run_replay("/bin/replay", str(repro), details, label="Baseline")
+
+        assert details[0] == "Baseline: OK (Average GPU time: 12.5 us)"
+
+    def test_builds_the_command_with_flags(self, repro):
+        from kerncap.validator import _run_replay
+
+        stub = sequence(completed())
+        with patch("subprocess.run", stub):
+            _run_replay("/bin/replay", str(repro), [], hsaco="/v.hsaco", dump_output=True)
+
+        argv = stub.calls[0][0]
+        assert argv[:2] == ["/bin/replay", str(repro)]
+        assert "--dump-output" in argv
+        assert argv[argv.index("--hsaco") + 1] == "/v.hsaco"
+
+
+class TestValidateReplayVariantFailures:
+    def test_baseline_producing_no_output_dir_fails(self, repro):
+        from kerncap.validator import _validate_replay_variant
+
+        details = []
+        with patch("subprocess.run", sequence(completed())):
+            result = _validate_replay_variant(
+                "/bin/replay", str(repro / "capture"), "/v.hsaco", details
+            )
+
+        assert result.passed is False
+        assert result.mode == "byte-exact"
+        assert "Baseline produced no output directory" in details
+
+    def test_variant_replay_failure_is_reported(self, repro):
+        """Baseline succeeds and dumps output; the variant run then fails."""
+        from kerncap.validator import _validate_replay_variant
+
+        capture = repro / "capture"
+
+        def _run(argv, **kwargs):
+            if "--hsaco" in argv:
+                return completed(1, stderr="variant crashed")
+            (capture / "output").mkdir(exist_ok=True)
+            (capture / "output" / "region_0.bin").write_bytes(b"\x00")
+            return completed()
+
+        details = []
+        with patch("subprocess.run", _run):
+            result = _validate_replay_variant("/bin/replay", str(capture), "/v.hsaco", details)
+
+        assert result.passed is False
+        assert any("variant crashed" in d for d in details)
+
+    def test_variant_producing_no_output_dir_fails(self, repro):
+        from kerncap.validator import _validate_replay_variant
+
+        capture = repro / "capture"
+        calls = []
+
+        def _run(argv, **kwargs):
+            calls.append(argv)
+            if len(calls) == 1:
+                (capture / "output").mkdir(exist_ok=True)
+                (capture / "output" / "region_0.bin").write_bytes(b"\x00")
+            return completed()
+
+        details = []
+        with patch("subprocess.run", _run):
+            result = _validate_replay_variant("/bin/replay", str(capture), "/v.hsaco", details)
+
+        assert result.passed is False
+        assert "Variant produced no output directory" in details
+
+
+class TestCompareReplayOutputExtras:
+    def test_a_region_only_in_the_variant_is_reported(self, tmp_path):
+        """Asymmetric: extra regions matter as much as missing ones."""
+        from kerncap.validator import _compare_replay_outputs
+
+        base = tmp_path / "base"
+        var = tmp_path / "var"
+        base.mkdir()
+        var.mkdir()
+        (base / "region_a.bin").write_bytes(b"\x01")
+        (var / "region_a.bin").write_bytes(b"\x01")
+        (var / "region_b.bin").write_bytes(b"\x02")
+
+        details = []
+        result = _compare_replay_outputs(str(base), str(var), details)
+
+        assert result.passed is False
+        assert any("region_b.bin: MISSING in baseline output" in d for d in details)
+
+    def test_empty_regions_count_as_identical(self, tmp_path):
+        from kerncap.validator import _compare_replay_outputs
+
+        base = tmp_path / "base"
+        var = tmp_path / "var"
+        base.mkdir()
+        var.mkdir()
+        (base / "region_a.bin").write_bytes(b"")
+        (var / "region_a.bin").write_bytes(b"")
+
+        result = _compare_replay_outputs(str(base), str(var), [])
+
+        assert result.passed is True
+        assert result.regions_identical == 1
+        assert any("PASS (empty)" in line for line in result.region_lines)
+
+
+class TestUnreachableMetadataRead:
+    def test_the_second_metadata_read_cannot_run(self, repro):
+        """``validate_reproducer``'s bare-Triton metadata read is dead code.
+
+        Reaching it needs ``reproducer.py`` present *and* the legacy branch
+        not to have returned — but the legacy branch returns whenever
+        ``metadata.json`` exists and ``reproducer.py`` is present. So when
+        control reaches the second block, ``metadata.json`` is always absent
+        and the inner ``if`` is always False.
+
+        Pinned so the dead branch is visible rather than looking like
+        untested behaviour.
+        """
+        (repro / "capture" / "metadata.json").write_text('{"args": [{"index": 7}]}')
+        (repro / "reproducer.py").write_text("")
+
+        with patch("kerncap.validator._validate_triton") as triton:
+            validate_reproducer(str(repro))
+
+        # Routed by the legacy branch, which passes the parsed metadata.
+        assert triton.call_args.args[1] == {"args": [{"index": 7}]}


### PR DESCRIPTION
Part 3 of 3, following #162, #161 and #158. Stacked on part 2 #174;
**base is `colramos/kerncap-coverage-2`**, not `main`. Retarget as the stack
merges.

Raises kerncap source coverage from **84% to 91%**, clearing the 90% bar. Three
new test files, **no source changes**. 137 new tests, 648 pass in ~14s.

| module | stmts | before | after |
|---|---:|---:|---:|
| `validator.py` | 279 | 72% | **99%** |
| `capturer.py` | 39 | 87% | **100%** |
| `__init__.py` | 92 | 88% | **98%** |
| `source_finder.py` | 798 | 71% | **82%** |
| **TOTAL** | **2452** | **84%** | **91%** |

Across the three parts kerncap goes **58% → 91%**.

## What is covered, and why these

**`validator.py`** — the three `_validate_*` build/run pipelines are plain
`subprocess.run` shell-outs, structurally identical to `profiler.run_profile`.
Also covers format routing (`dispatch.json` vs legacy `metadata.json` vs bare
`reproducer.py`), the `candidate.hsaco` / `optimized.hsaco` auto-detect that the
documented edit loop depends on, and the numeric comparison paths — dtype
inference, shape mismatch, empty buffers.

**`__init__.py` / `capturer.py`** — artifact-path resolution and the capture
wrapper's failure paths. `_get_lib_path` and `_get_replay_path` are the first
thing to fail on a broken install and their `Searched:` message is all a user
has to debug from, so the search order and that message are pinned.

**`source_finder.py`** — the `compile_commands.json` family only. This is the
highest-value part of the PR and worth reviewing on its own merits rather than
for the coverage number: `_defines_from_compile_commands` and
`_includes_from_compile_commands` decide which preprocessor defines and include
paths a reproducer is rebuilt with. Getting them wrong does not fail loudly —
it produces a reproducer that compiles into something subtly different from the
kernel that was captured. Same for `_match_tu_via_object_symbols`, which picks
the right instantiation of a templated kernel by running `nm` on the object
file; the motivating case is llama.cpp's `mmq-instance-*.cu`.

All pure JSON/string parsing, a filesystem walk, and stubbed subprocesses — no
ROCm, compiler or GPU needed.

## A dead branch this surfaced

`validate_reproducer`'s second metadata read — the bare-Triton block — cannot
execute. Reaching it needs `reproducer.py` present *and* the legacy branch not
to have returned, but the legacy branch returns whenever `metadata.json` exists
and `reproducer.py` is present. So when control arrives, `metadata.json` is
always absent and the inner `if` is always False. Pinned with a test so it reads
as dead code rather than untested behaviour. Not changed here — this part adds
no source changes.

## Deliberately not covered

`reproducer.py` stays at 88%. Its remaining 48 statements are scattered
singletons deep inside `generate_triton_hsa_reproducer`'s kernarg-slot walking
and need elaborate fixtures (`kernarg_raw.bin`, `memory_regions.json`, tensor
layouts). Worst value-per-effort of the candidates, and not needed to clear 90%
— so it remains as headroom if a higher bar is ever wanted.

`_subprocess.py` stays at 91%; the remainder is signal-race handlers that cannot
be triggered deterministically.

`source_finder.py`'s deeper paths — `#include` tracing, DWARF-based discovery,
Triton import tracing — are out of scope.

## Test plan

**AMD Instinct MI210, ROCm 7.2.3, Python 3.12.3**, via Slurm. `kerncap` installed as CI installs it
(`pip install -e kerncap`), so `libkerncap.so` is built from `src/` against ROCm.

```
before (b14d495):  511 passed, 0 skipped   84%   (2452 stmts, 385 missed)
after  (3b15737):  648 passed, 0 skipped   91%   (2452 stmts, 211 missed)
```

Both legs back to back in one allocation, same venv, same build. Zero skips in
either leg — with `libkerncap.so` really built, the `test_kernarg_metadata.py`
tests that drive the C kernarg parser through ctypes execute rather than
skipping.

Pre-existing integration suite, same node, unaffected: `16 passed, 3 skipped,
2 deselected in 27.33s`.

`ruff check` and `ruff format --check` clean at **0.15.22** from the repo root.

Coverage measured against the **package** (`--cov=kerncap/kerncap`). The
directory form `--cov=kerncap` that #155's workflow uses scores the test files
too and reads higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)