### PR TITLE
Read the isolated streams before Click closes them

### DIFF
--- a/kerncap/tests/unit/test_cli.py
+++ b/kerncap/tests/unit/test_cli.py
@@ -460,7 +460,9 @@ class TestPrintNextSteps:
         )
         with runner.isolation() as streams:
             cli._print_next_steps(result)
-        out = streams[0].getvalue().decode()
+            # Read inside the block: Click closes these streams on exit,
+            # so getvalue() afterwards raises "I/O operation on closed file".
+            out = streams[0].getvalue().decode()
 
         assert "edit:    /iso/attn/kernel_variant.py" in out
         assert "rebuild: cd /iso/attn && python3 reproducer.py" in out
@@ -475,7 +477,9 @@ class TestPrintNextSteps:
         )
         with runner.isolation() as streams:
             cli._print_next_steps(result)
-        out = streams[0].getvalue().decode()
+            # Read inside the block: Click closes these streams on exit,
+            # so getvalue() afterwards raises "I/O operation on closed file".
+            out = streams[0].getvalue().decode()
 
         assert "edit:    /iso/gemm/kernel_variant.cpp" in out
         assert "rebuild: cd /iso/gemm && make recompile" in out
@@ -490,7 +494,9 @@ class TestPrintNextSteps:
         )
         with runner.isolation() as streams:
             cli._print_next_steps(result)
-        out = streams[0].getvalue().decode()
+            # Read inside the block: Click closes these streams on exit,
+            # so getvalue() afterwards raises "I/O operation on closed file".
+            out = streams[0].getvalue().decode()
 
         assert "edit:" not in out
         assert "rebuild:" in out

--- a/kerncap/tests/unit/test_extract_helpers.py
+++ b/kerncap/tests/unit/test_extract_helpers.py
@@ -1002,7 +1002,9 @@ class TestGenerateReproducerRouting:
 
         with runner.isolation() as streams:
             cli._print_next_steps(result)
-        printed = streams[0].getvalue().decode()
+            # Read inside the block: Click closes these streams on exit,
+            # so getvalue() afterwards raises "I/O operation on closed file".
+            printed = streams[0].getvalue().decode()
 
         assert "make recompile" in printed
         assert "reproducer.py" not in printed


### PR DESCRIPTION
`main` is red: `pytest editable - kerncap` and `pytest non-editable - kerncap` both fail.

Three `TestPrintNextSteps` tests read the captured stream after leaving the isolation block:

```python
with runner.isolation() as streams:
    cli._print_next_steps(result)
out = streams[0].getvalue().decode()   # <- closed by now
```

Click closes those streams on exit, so the read raises `ValueError: I/O operation on closed file`.

Moving the read inside the block is the whole fix — assertions unchanged, no product code touched.

Verified on an MI350X node: `kerncap/tests/unit/test_cli.py` 86 passed, 0 failed.