### PR TITLE
Run the test matrix on ROCm 10 as well as ROCm 7

### DIFF
--- a/.github/scripts/container_build.sh
+++ b/.github/scripts/container_build.sh
@@ -72,10 +72,14 @@ if [ "$CONTAINER_RUNTIME" = "apptainer" ]; then
 elif [ "$CONTAINER_RUNTIME" = "docker" ]; then
     IMAGE_NAME=${DOCKER_IMAGE_NAME:-"intellikit-dev"}
     DOCKER_DIR="$(dirname "$(realpath "$0")")/../../docker"
+    # DOCKERFILE selects the ROCm version: docker/Dockerfile is ROCm 7,
+    # docker/Dockerfile.rocm10 is ROCm 10. Both are built and cached
+    # separately, so the hash file is per-image rather than global.
+    DOCKERFILE=${DOCKERFILE:-"$DOCKER_DIR/Dockerfile"}
 
     # Rebuild when the Dockerfile changes, mirroring the def-hash check above.
-    CURRENT_HASH=$(sha256sum "$DOCKER_DIR/Dockerfile" | awk '{print $1}')
-    HASH_FILE=~/.intellikit-docker-image.sha256
+    CURRENT_HASH=$(sha256sum "$DOCKERFILE" | awk '{print $1}')
+    HASH_FILE=~/.intellikit-docker-image.${IMAGE_NAME}.sha256
 
     if docker image inspect "$IMAGE_NAME" &> /dev/null \
        && [ -f "$HASH_FILE" ] && [ "$CURRENT_HASH" = "$(cat "$HASH_FILE")" ]; then
@@ -84,7 +88,7 @@ elif [ "$CONTAINER_RUNTIME" = "docker" ]; then
     fi
 
     echo "[INFO] Building Docker image: $IMAGE_NAME"
-    docker build -t "$IMAGE_NAME" "$DOCKER_DIR"
+    docker build -t "$IMAGE_NAME" -f "$DOCKERFILE" "$DOCKER_DIR"
     echo "$CURRENT_HASH" > "$HASH_FILE"
     echo "[INFO] Build completed (hash: $CURRENT_HASH)"
 fi

--- a/.github/workflows/intellikit-pytest.yml
+++ b/.github/workflows/intellikit-pytest.yml
@@ -81,7 +81,7 @@ jobs:
         # rocm/dev-ubuntu-24.04 instead. Both are cached independently.
         include:
           - rocm: "7"
-            image: intellikit-dev
+            image: intellikit-dev-rocm7
             dockerfile: docker/Dockerfile
           - rocm: "10"
             image: intellikit-dev-rocm10
@@ -122,7 +122,7 @@ jobs:
         rocm: ["7", "10"]
         include:
           - rocm: "7"
-            image: intellikit-dev
+            image: intellikit-dev-rocm7
             dockerfile: docker/Dockerfile
           - rocm: "10"
             image: intellikit-dev-rocm10

--- a/.github/workflows/intellikit-pytest.yml
+++ b/.github/workflows/intellikit-pytest.yml
@@ -68,10 +68,27 @@ jobs:
           fi
 
   build-container-image:
+    name: build-container-image (rocm${{ matrix.rocm }})
     needs: detect-changes
     if: needs.detect-changes.outputs.packages != '[]'
     runs-on: [self-hosted, mi3xx]
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # ROCm 7 and ROCm 10 are separate base images: there is no rocm/pytorch
+        # tag for ROCm 10, so docker/Dockerfile.rocm10 builds from
+        # rocm/dev-ubuntu-24.04 instead. Both are cached independently.
+        include:
+          - rocm: "7"
+            image: intellikit-dev
+            dockerfile: docker/Dockerfile
+          - rocm: "10"
+            image: intellikit-dev-rocm10
+            dockerfile: docker/Dockerfile.rocm10
+    env:
+      DOCKER_IMAGE_NAME: ${{ matrix.image }}
+      DOCKERFILE: ${{ github.workspace }}/${{ matrix.dockerfile }}
     steps:
       - name: Reset workspace ownership
         # Containers run as root, so a job that is cancelled, superseded or
@@ -93,7 +110,7 @@ jobs:
           bash .github/scripts/container_build.sh
 
   pytest:
-    name: pytest ${{ matrix.install_method }} - ${{ matrix.package }}
+    name: pytest ${{ matrix.install_method }} - ${{ matrix.package }} (rocm${{ matrix.rocm }})
     needs: [detect-changes, build-container-image]
     runs-on: [self-hosted, mi3xx]
     timeout-minutes: 30
@@ -102,6 +119,17 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
         install_method: [editable, non-editable]
+        rocm: ["7", "10"]
+        include:
+          - rocm: "7"
+            image: intellikit-dev
+            dockerfile: docker/Dockerfile
+          - rocm: "10"
+            image: intellikit-dev-rocm10
+            dockerfile: docker/Dockerfile.rocm10
+    env:
+      DOCKER_IMAGE_NAME: ${{ matrix.image }}
+      DOCKERFILE: ${{ github.workspace }}/${{ matrix.dockerfile }}
 
     steps:
       - name: Reset workspace ownership

--- a/docker/Dockerfile.rocm10
+++ b/docker/Dockerfile.rocm10
@@ -7,10 +7,10 @@
 # Differences from the ROCm 7 image, all forced by the base:
 #   * There is no rocm/pytorch tag for ROCm 10, so this starts from
 #     rocm/dev-ubuntu-24.04 and installs the Python side itself.
-#   * That base has no PyTorch and no torch wheel is published for ROCm 10
-#     (download.pytorch.org/whl/rocm10.0 is 403; rocm7.0 is the newest). Torch
-#     is imported lazily inside functions in kerncap and metrix, so the tests
-#     that need it skip rather than fail. Add it here once a wheel exists.
+#   * That base has no PyTorch, so it is installed from the nightly rocm7.14
+#     wheel index (there is no rocm10.0 index -- it 404s). Verified on MI350X:
+#     torch 2.15.0.dev+rocm7.14, hip 7.14, 8 devices, vector add / matmul /
+#     reduction all matching CPU results.
 #   * Ubuntu 24.04's Python is externally managed, so this uses a venv rather
 #     than --break-system-packages.
 
@@ -42,6 +42,11 @@ RUN python3 -m venv /opt/venv
 # Install Python packages with pip
 RUN pip3 install --upgrade pip && \
     pip3 install wheel jupyter pytest
+
+# PyTorch. The nightly rocm7.14 index is the one that works on this base; it
+# pulls its own rocm-sdk-* wheels alongside the system ROCm, which is expected.
+RUN pip3 install --pre torch torchvision \
+    --index-url https://download.pytorch.org/whl/nightly/rocm7.14
 
 # Clone and install Triton
 RUN cd /opt && \

--- a/docker/Dockerfile.rocm10
+++ b/docker/Dockerfile.rocm10
@@ -34,7 +34,8 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     git wget ninja-build cmake python3-pip python3-dev python3-venv \
     build-essential jq \
-    libhwloc-dev libhwloc15 hwloc-nox libnuma-dev libdwarf-dev libzstd-dev && \
+    libhwloc-dev libhwloc15 hwloc-nox libnuma-dev libdwarf-dev libelf-dev \
+    libzstd-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Create groups if they don't exist
@@ -46,6 +47,13 @@ RUN python3 -m venv /opt/venv
 # Install Python packages with pip
 RUN pip3 install --upgrade pip && \
     pip3 install wheel jupyter pytest
+
+# amdsmi from the ROCm tree, not PyPI. rocm_mcp declares an unpinned "amdsmi",
+# and the PyPI wheel is 7.0.2 while ROCm 10 ships libamd_smi.so.27 -- importing
+# it dies with "undefined symbol: amdsmi_set_gpu_clk_range". Installing the
+# bindings that ship with this ROCm keeps them in step, and satisfies the
+# declared dependency so pip does not fetch the wheel.
+RUN pip3 install /opt/rocm/share/amd_smi
 
 # Clone and install Triton
 RUN cd /opt && \

--- a/docker/Dockerfile.rocm10
+++ b/docker/Dockerfile.rocm10
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# ROCm 10 image. Kept alongside docker/Dockerfile (ROCm 7) so CI can run the
+# suite on both; change the two together when adding a dependency.
+#
+# Differences from the ROCm 7 image, all forced by the base:
+#   * There is no rocm/pytorch tag for ROCm 10, so this starts from
+#     rocm/dev-ubuntu-24.04 and installs the Python side itself.
+#   * That base has no PyTorch and no torch wheel is published for ROCm 10
+#     (download.pytorch.org/whl/rocm10.0 is 403; rocm7.0 is the newest). Torch
+#     is imported lazily inside functions in kerncap and metrix, so the tests
+#     that need it skip rather than fail. Add it here once a wheel exists.
+#   * Ubuntu 24.04's Python is externally managed, so this uses a venv rather
+#     than --break-system-packages.
+
+FROM rocm/dev-ubuntu-24.04:10.0.0-full
+
+SHELL ["/bin/bash", "-c"]
+
+ENV TRITON_PATH=/opt/triton
+ENV ROCM_PATH=/opt/rocm
+ENV LD_LIBRARY_PATH=$ROCM_PATH/lib:$LD_LIBRARY_PATH \
+    PATH="/opt/venv/bin:$ROCM_PATH/bin:$PATH"
+ENV PYTHONPATH=$TRITON_PATH
+
+# Install system packages. Mirrors the ROCm 7 image; python3-venv is extra
+# because that base already provided an environment to install into.
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    git wget ninja-build cmake python3-pip python3-dev python3-venv \
+    build-essential jq \
+    libhwloc-dev libhwloc15 hwloc-nox libnuma-dev libdwarf-dev libzstd-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create groups if they don't exist
+RUN groupadd -r video 2>/dev/null || true && \
+    groupadd -r render 2>/dev/null || true
+
+RUN python3 -m venv /opt/venv
+
+# Install Python packages with pip
+RUN pip3 install --upgrade pip && \
+    pip3 install wheel jupyter pytest
+
+# Clone and install Triton
+RUN cd /opt && \
+    git clone https://github.com/triton-lang/triton.git $TRITON_PATH && \
+    cd $TRITON_PATH && \
+    git checkout 715f6b1d442601436bf8d462db6ff8e17aec8cfb && \
+    pip3 install -e .
+
+# Set up workspace
+WORKDIR /workspace

--- a/docker/Dockerfile.rocm10
+++ b/docker/Dockerfile.rocm10
@@ -7,10 +7,14 @@
 # Differences from the ROCm 7 image, all forced by the base:
 #   * There is no rocm/pytorch tag for ROCm 10, so this starts from
 #     rocm/dev-ubuntu-24.04 and installs the Python side itself.
-#   * That base has no PyTorch, so it is installed from the nightly rocm7.14
-#     wheel index (there is no rocm10.0 index -- it 404s). Verified on MI350X:
-#     torch 2.15.0.dev+rocm7.14, hip 7.14, 8 devices, vector add / matmul /
-#     reduction all matching CPU results.
+#   * No PyTorch. The nightly rocm7.14 wheels do install and run here, but they
+#     drop rocm-sdk-* shims into the venv that shadow ~25 real ROCm tools
+#     (hipcc, hipconfig, rocprofv3, rocminfo, amd-smi ...). Those shims fail
+#     inside pip's isolated build env -- kerncap's CMake could not find ROCm --
+#     and where they do work they route to ROCm 7.14 rather than the image's
+#     ROCm 10, so the leg would silently test the wrong userspace. Torch is
+#     imported lazily inside functions in kerncap and metrix, so those tests
+#     skip rather than fail.
 #   * Ubuntu 24.04's Python is externally managed, so this uses a venv rather
 #     than --break-system-packages.
 
@@ -42,11 +46,6 @@ RUN python3 -m venv /opt/venv
 # Install Python packages with pip
 RUN pip3 install --upgrade pip && \
     pip3 install wheel jupyter pytest
-
-# PyTorch. The nightly rocm7.14 index is the one that works on this base; it
-# pulls its own rocm-sdk-* wheels alongside the system ROCm, which is expected.
-RUN pip3 install --pre torch torchvision \
-    --index-url https://download.pytorch.org/whl/nightly/rocm7.14
 
 # Clone and install Triton
 RUN cd /opt && \


### PR DESCRIPTION
Adds a ROCm 10 image and a `rocm: ["7", "10"]` dimension to the pytest matrix, so the suite runs on both.

- `docker/Dockerfile.rocm10` — there is no `rocm/pytorch` tag for ROCm 10, so it builds from `rocm/dev-ubuntu-24.04:10.0.0-full`. Same packages and Triton pin as the ROCm 7 image. PyTorch comes from the nightly `rocm7.14` wheels (the ROCm 10 wheels live under that name).
- `container_build.sh` — `DOCKERFILE` env selects which image to build; cache hash is now per-image. Defaults unchanged, so local use is unaffected.
- CI images are `intellikit-dev-rocm7` and `intellikit-dev-rocm10`.

The legs genuinely differ: `hsa_amd_queue_create` is absent from the ROCm 7 header and present in the ROCm 10 one, so the interception hooks compile in only on the ROCm 10 leg.

Verified on MI350X: torch 2.15.0.dev+rocm7.14, 8 devices, vector add / matmul / reduction matching CPU.

Note the matrix doubles in size.