### PR TITLE
Set every package to 0.1.1

### DIFF
--- a/accordo/accordo/__init__.py
+++ b/accordo/accordo/__init__.py
@@ -59,7 +59,7 @@ from importlib.metadata import PackageNotFoundError, version as _get_version
 try:
     __version__ = _get_version("accordo")
 except PackageNotFoundError:
-    __version__ = "0.4.0"
+    __version__ = "0.1.1"
 
 # Public API
 __all__ = [

--- a/accordo/pyproject.toml
+++ b/accordo/pyproject.toml
@@ -48,7 +48,7 @@ metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 [tool.setuptools_scm]
 version_scheme = "post-release"
 local_scheme = "node-and-date"
-fallback_version = "0.2.0"
+fallback_version = "0.1.1"
 root = ".."
 
 # ---- Ruff configuration ----

--- a/accordo/tests/test_interop_and_codegen.py
+++ b/accordo/tests/test_interop_and_codegen.py
@@ -102,12 +102,20 @@ class TestPackageVersion:
     def test_falls_back_when_distribution_missing(self):
         """An in-tree checkout with no installed dist must still import."""
         import importlib
+        import pathlib
+        import re
 
         from importlib.metadata import PackageNotFoundError
 
         import accordo
 
+        # Derive the expected fallback from the source rather than repeating the
+        # literal here. Hardcoding it meant a version bump failed this test
+        # rather than the code, and the two could disagree unnoticed until then.
+        src = pathlib.Path(accordo.__file__).read_text()
+        expected = re.search(r'__version__ = "([^"]+)"', src).group(1)
+
         with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
             reloaded = importlib.reload(accordo)
-            assert reloaded.__version__ == "0.4.0"
+            assert reloaded.__version__ == expected
         importlib.reload(accordo)  # restore the real version for other tests

--- a/kerncap/kerncap/__init__.py
+++ b/kerncap/kerncap/__init__.py
@@ -5,7 +5,7 @@ from importlib.metadata import PackageNotFoundError, version as _get_version
 try:
     __version__ = _get_version("kerncap")
 except PackageNotFoundError:
-    __version__ = "0.1.0"
+    __version__ = "0.1.1"
 
 import logging
 import os

--- a/kerncap/pyproject.toml
+++ b/kerncap/pyproject.toml
@@ -51,7 +51,7 @@ ROCM_PATH = {env="ROCM_PATH", default="/opt/rocm"}
 [tool.setuptools_scm]
 version_scheme = "post-release"
 local_scheme = "node-and-date"
-fallback_version = "0.1.0"
+fallback_version = "0.1.1"
 root = ".."
 
 # ---- Ruff configuration ----

--- a/linex/pyproject.toml
+++ b/linex/pyproject.toml
@@ -47,7 +47,7 @@ linex-mcp = "linex.mcp.server:main"
 [tool.setuptools_scm]
 version_scheme = "post-release"
 local_scheme = "node-and-date"
-fallback_version = "0.1.0"
+fallback_version = "0.1.1"
 root = ".."
 
 [tool.setuptools]

--- a/linex/src/linex/__init__.py
+++ b/linex/src/linex/__init__.py
@@ -15,5 +15,5 @@ from importlib.metadata import PackageNotFoundError, version as _get_version
 try:
     __version__ = _get_version("linex")
 except PackageNotFoundError:
-    __version__ = "0.1.0"
+    __version__ = "0.1.1"
 __all__ = ["Linex", "SourceLine", "InstructionData"]

--- a/metrix/pyproject.toml
+++ b/metrix/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
 [tool.setuptools_scm]
 version_scheme = "post-release"
 local_scheme = "node-and-date"
-fallback_version = "0.1.0"
+fallback_version = "0.1.1"
 root = ".."
 
 [tool.setuptools]

--- a/metrix/src/metrix/__init__.py
+++ b/metrix/src/metrix/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import PackageNotFoundError, version as _get_version
 try:
     __version__ = _get_version("metrix")
 except PackageNotFoundError:
-    __version__ = "0.1.0"
+    __version__ = "0.1.1"
 
 from .api import Metrix
 from .profiler.engine import Profiler

--- a/nexus/nexus/__init__.py
+++ b/nexus/nexus/__init__.py
@@ -23,7 +23,7 @@ from importlib.metadata import PackageNotFoundError, version as _get_version
 try:
     __version__ = _get_version("nexus")
 except PackageNotFoundError:
-    __version__ = "0.1.0"
+    __version__ = "0.1.1"
 
 
 def _find_nexus_lib() -> Optional[Path]:

--- a/nexus/pyproject.toml
+++ b/nexus/pyproject.toml
@@ -45,7 +45,7 @@ LLVM_INSTALL_DIR = {env="LLVM_INSTALL_DIR", default="/opt/rocm/llvm"}
 [tool.setuptools_scm]
 version_scheme = "post-release"   # .postN after last tag
 local_scheme = "node-and-date"    # add commit hash (e.g. +gabc1234) and date (e.g. +20250914)
-fallback_version = "0.1.0"        # used if git metadata unavailable
+fallback_version = "0.1.1"        # used if git metadata unavailable
 root = ".."                       # Look for git repo in parent directory
 
 # ---- Ruff configuration ----

--- a/rocm_mcp/src/rocm_mcp/_version.py
+++ b/rocm_mcp/src/rocm_mcp/_version.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 
-__version__ = "0.2.0"
+__version__ = "0.1.1"

--- a/uprof_mcp/src/uprof_mcp/_version.py
+++ b/uprof_mcp/src/uprof_mcp/_version.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 
-__version__ = "0.2.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
Versions had drifted: accordo was `fallback_version 0.2.0` / `__version__ 0.4.0`, rocm_mcp and uprof_mcp were 0.2.0, the rest 0.1.0. All seven are now 0.1.1.

Worth knowing the two mechanisms differ:

- **accordo, kerncap, linex, metrix, nexus** — setuptools-scm, version comes from the git tag. The values here only apply when git metadata is unavailable.
- **rocm_mcp, uprof_mcp** — static, `version = {attr = "..._version.__version__"}`. Tagging alone would have left these at 0.2.0.

`docs/conf.py` was already 0.1.1.