### PR TITLE
Move the workflow actions off Node 20

### DIFF
--- a/.github/workflows/intellikit-ci-test.yml
+++ b/.github/workflows/intellikit-ci-test.yml
@@ -24,10 +24,10 @@ jobs:
       packages: ${{ steps.build-matrix.outputs.packages }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect changed paths
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -83,7 +83,7 @@ jobs:
               chown -R "$(id -u):$(id -g)" /w 2>/dev/null || true
           fi
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build Intellikit container
         run: |
@@ -114,7 +114,7 @@ jobs:
               chown -R "$(id -u):$(id -g)" /w 2>/dev/null || true
           fi
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
 
       - name: Test ${{ matrix.install_method }} install - ${{ matrix.package }}

--- a/.github/workflows/intellikit-pytest.yml
+++ b/.github/workflows/intellikit-pytest.yml
@@ -25,10 +25,10 @@ jobs:
       packages: ${{ steps.build-matrix.outputs.packages }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect changed paths
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -103,7 +103,7 @@ jobs:
               chown -R "$(id -u):$(id -g)" /w 2>/dev/null || true
           fi
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build Intellikit container
         run: |
@@ -145,7 +145,7 @@ jobs:
               chown -R "$(id -u):$(id -g)" /w 2>/dev/null || true
           fi
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pytest ${{ matrix.install_method }} - ${{ matrix.package }}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@v4
         with:
           version: "0.15.22"
 


### PR DESCRIPTION
Silences the warning on every run:

```
Warning: Node.js 20 is deprecated. The following actions target Node.js 20
but are being forced to run on Node.js 24: actions/checkout@v4
```

`checkout@v4` declares `using: node20`; **v5** is the first major on node24, so this takes the smallest step that clears it rather than jumping to the current v7. `paths-filter` and `ruff-action` move to their node24 majors for the same reason.

10 references across the three workflows. No behaviour change intended — if CI is green, it's done its job.