### PR TITLE
Restore container runtime autodetection and add a ROCm 10 apptainer def

### DIFF
--- a/.github/scripts/container_build.sh
+++ b/.github/scripts/container_build.sh
@@ -16,15 +16,12 @@ apptainer_can_build() {
     unshare --user --map-root-user true 2>/dev/null
 }
 
-# CONTAINER_RUNTIME forces a runtime. This matters when apptainer is installed
-# but cannot build: on a host with kernel.apparmor_restrict_unprivileged_userns=1,
-# no setuid starter and no /etc/subuid entry, `apptainer build` fails in %post
-# while docker works. Autodetection alone would pick apptainer and fail there.
-# Apptainer is disabled for now: the CI hosts either cannot build with it
-# (no setuid starter, no usable user namespace) or do not have it at all,
-# and the runner has no root to install it. Remove this line to restore
-# autodetection.
-CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+# CONTAINER_RUNTIME forces a runtime, and is only honoured when the caller sets
+# it. It used to be defaulted to "docker" here, which made the branch below
+# always take the "forced" path and left the autodetection underneath it
+# unreachable -- on a runner without docker every build died at
+# "CONTAINER_RUNTIME=docker but it is not installed" instead of falling back to
+# apptainer. Leave it unset so apptainer_can_build() actually gets to decide.
 
 if [ -n "$CONTAINER_RUNTIME" ]; then
     if ! command -v "$CONTAINER_RUNTIME" &> /dev/null; then
@@ -52,9 +49,12 @@ else
 fi
 
 if [ "$CONTAINER_RUNTIME" = "apptainer" ]; then
-    DEF_FILE="apptainer/intellikit.def"
-    IMAGE_FILE=~/apptainer/intellikit-dev.sif
-    HASH_FILE=~/apptainer/intellikit.def.sha256
+    # APPTAINER_DEF mirrors DOCKERFILE below: it selects the ROCm version, so the
+    # apptainer leg can follow the same matrix rather than being pinned to ROCm 7.
+    DEF_FILE="${APPTAINER_DEF:-apptainer/intellikit.def}"
+    IMAGE_NAME="${APPTAINER_IMAGE_NAME:-intellikit-dev}"
+    IMAGE_FILE=~/apptainer/${IMAGE_NAME}.sif
+    HASH_FILE=~/apptainer/${IMAGE_NAME}.def.sha256
 
     mkdir -p ~/apptainer
     CURRENT_HASH=$(sha256sum "$DEF_FILE" | awk '{print $1}')

--- a/.github/scripts/container_exec.sh
+++ b/.github/scripts/container_exec.sh
@@ -25,12 +25,12 @@ apptainer_can_build() {
     unshare --user --map-root-user true 2>/dev/null
 }
 
-# See container_build.sh for why an explicit override exists.
-# Apptainer is disabled for now: the CI hosts either cannot build with it
-# (no setuid starter, no usable user namespace) or do not have it at all,
-# and the runner has no root to install it. Remove this line to restore
-# autodetection.
-CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+# See container_build.sh: CONTAINER_RUNTIME is honoured only when the caller sets
+# it. Defaulting it here had the same effect it had there -- the branch below is
+# `if [ -n "$CONTAINER_RUNTIME" ]`, so a default made every run take the "forced"
+# path and left the autodetection beneath it unreachable. This file is the twin of
+# container_build.sh and has to move with it: with only the build side fixed, the
+# image built under apptainer and then every exec step still died demanding docker.
 
 if [ -n "$CONTAINER_RUNTIME" ]; then
     if ! command -v "$CONTAINER_RUNTIME" &> /dev/null; then
@@ -58,7 +58,9 @@ else
 fi
 
 if [ "$CONTAINER_RUNTIME" = "apptainer" ]; then
-    IMAGE=~/apptainer/intellikit-dev.sif
+    # Mirrors APPTAINER_IMAGE_NAME in container_build.sh so exec picks up the
+    # image that build just produced for this matrix leg.
+    IMAGE=~/apptainer/${APPTAINER_IMAGE_NAME:-intellikit-dev}.sif
     if [ ! -f "$IMAGE" ]; then
         echo "[ERROR] Apptainer image not found at $IMAGE" >&2
         exit 1

--- a/.github/workflows/intellikit-ci-test.yml
+++ b/.github/workflows/intellikit-ci-test.yml
@@ -85,6 +85,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Ensure a container runtime is present
+        # The runner may have neither. Apptainer is installable unprivileged-ish
+        # here and is the runtime this repo prefers; docker is left alone when it
+        # already exists so hosts that have it keep using it.
+        run: |
+          if ! command -v apptainer >/dev/null && ! command -v docker >/dev/null; then
+            echo "Neither Apptainer nor Docker found, installing Apptainer..."
+            add-apt-repository -y ppa:apptainer/ppa
+            apt-get update && apt-get install -y apptainer
+          fi
+
       - name: Build Intellikit container
         run: |
           bash .github/scripts/container_build.sh

--- a/.github/workflows/intellikit-pytest.yml
+++ b/.github/workflows/intellikit-pytest.yml
@@ -83,12 +83,16 @@ jobs:
           - rocm: "7"
             image: intellikit-dev-rocm7
             dockerfile: docker/Dockerfile
+            def: apptainer/intellikit.def
           - rocm: "10"
             image: intellikit-dev-rocm10
             dockerfile: docker/Dockerfile.rocm10
+            def: apptainer/intellikit-rocm10.def
     env:
       DOCKER_IMAGE_NAME: ${{ matrix.image }}
       DOCKERFILE: ${{ github.workspace }}/${{ matrix.dockerfile }}
+      APPTAINER_IMAGE_NAME: ${{ matrix.image }}
+      APPTAINER_DEF: ${{ matrix.def }}
     steps:
       - name: Reset workspace ownership
         # Containers run as root, so a job that is cancelled, superseded or
@@ -104,6 +108,17 @@ jobs:
           fi
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Ensure a container runtime is present
+        # The runner may have neither. Apptainer is installable unprivileged-ish
+        # here and is the runtime this repo prefers; docker is left alone when it
+        # already exists so hosts that have it keep using it.
+        run: |
+          if ! command -v apptainer >/dev/null && ! command -v docker >/dev/null; then
+            echo "Neither Apptainer nor Docker found, installing Apptainer..."
+            add-apt-repository -y ppa:apptainer/ppa
+            apt-get update && apt-get install -y apptainer
+          fi
 
       - name: Build Intellikit container
         run: |
@@ -124,12 +139,16 @@ jobs:
           - rocm: "7"
             image: intellikit-dev-rocm7
             dockerfile: docker/Dockerfile
+            def: apptainer/intellikit.def
           - rocm: "10"
             image: intellikit-dev-rocm10
             dockerfile: docker/Dockerfile.rocm10
+            def: apptainer/intellikit-rocm10.def
     env:
       DOCKER_IMAGE_NAME: ${{ matrix.image }}
       DOCKERFILE: ${{ github.workspace }}/${{ matrix.dockerfile }}
+      APPTAINER_IMAGE_NAME: ${{ matrix.image }}
+      APPTAINER_DEF: ${{ matrix.def }}
 
     steps:
       - name: Reset workspace ownership

--- a/apptainer/intellikit-rocm10.def
+++ b/apptainer/intellikit-rocm10.def
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# ROCm 10 image. The apptainer counterpart of docker/Dockerfile.rocm10, kept
+# alongside apptainer/intellikit.def (ROCm 7) so the apptainer leg can cover the
+# same matrix the docker leg does; change the pair together when adding a
+# dependency.
+#
+# Differences from the ROCm 7 def, all forced by the base and identical to the
+# reasoning in docker/Dockerfile.rocm10:
+#   * There is no rocm/pytorch tag for ROCm 10, so this bootstraps from
+#     rocm/dev-ubuntu-24.04 and installs the Python side itself.
+#   * No PyTorch. The nightly rocm7.14 wheels do install and run here, but they
+#     drop rocm-sdk-* shims into the venv that shadow ~25 real ROCm tools
+#     (hipcc, hipconfig, rocprofv3, rocminfo, amd-smi ...). Those shims fail
+#     inside pip's isolated build env, and where they do work they route to
+#     ROCm 7.14 rather than the image's ROCm 10, so the leg would silently test
+#     the wrong userspace. Torch is imported lazily inside functions in kerncap
+#     and metrix, so those tests skip rather than fail.
+#   * Ubuntu 24.04's Python is externally managed, so this uses a venv rather
+#     than --break-system-packages.
+
+Bootstrap: docker
+From: rocm/dev-ubuntu-24.04:10.0.0-full
+
+%post
+    /bin/bash -c "
+    set -e
+    export TRITON_PATH=/opt/triton
+    export ROCM_PATH=/opt/rocm
+    export LD_LIBRARY_PATH=\$ROCM_PATH/lib:\$LD_LIBRARY_PATH
+    export PATH=\"/opt/venv/bin:\$ROCM_PATH/bin:\$PATH\"
+
+    # Mirrors the ROCm 7 def; python3-venv is extra because that base already
+    # provided an environment to install into and this one does not.
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        git wget ninja-build cmake python3-pip python3-dev python3-venv \
+        build-essential jq \
+        libhwloc-dev libhwloc15 hwloc-nox libnuma-dev libdwarf-dev libelf-dev \
+        libzstd-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+    groupadd -r video 2>/dev/null || true
+    groupadd -r render 2>/dev/null || true
+
+    python3 -m venv /opt/venv
+
+    pip3 install --upgrade pip
+    pip3 install wheel jupyter pytest
+
+    # amdsmi from the ROCm tree, not PyPI. rocm_mcp declares an unpinned
+    # 'amdsmi', and the PyPI wheel is 7.0.2 while ROCm 10 ships
+    # libamd_smi.so.27 -- importing it dies with 'undefined symbol:
+    # amdsmi_set_gpu_clk_range'. Installing the bindings that ship with this
+    # ROCm keeps them in step, and satisfies the declared dependency so pip
+    # does not fetch the wheel.
+    pip3 install /opt/rocm/share/amd_smi
+
+    cd /opt
+    git clone https://github.com/triton-lang/triton.git \$TRITON_PATH
+    cd \$TRITON_PATH
+    git checkout 715f6b1d442601436bf8d462db6ff8e17aec8cfb
+    pip3 install -e .
+    "
+
+%environment
+    export TRITON_PATH=/opt/triton
+    export ROCM_PATH=/opt/rocm
+    export PYTHONPATH=$TRITON_PATH
+    export LD_LIBRARY_PATH=$ROCM_PATH/lib:$LD_LIBRARY_PATH
+    export PATH="/opt/venv/bin:$ROCM_PATH/bin:$PATH"
+
+%runscript
+    echo "Welcome to the Intellikit ROCm 10 Apptainer image!"
+    exec "$@"


### PR DESCRIPTION
## What

`container_build.sh` had this:

```sh
CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
```

Because the branch underneath it is `if [ -n "$CONTAINER_RUNTIME" ]`, defaulting the
variable meant the "forced runtime" path was *always* taken and the autodetection
below it became unreachable. On a runner without docker, every build exited at

```
[ERROR] CONTAINER_RUNTIME=docker but it is not installed
```

instead of falling back to apptainer.

Leaving it unset restores the documented behaviour: `CONTAINER_RUNTIME` forces a
runtime only when the caller sets one, and otherwise `apptainer_can_build()` decides.

## Why the old comment no longer applies

It said the CI hosts "either cannot build with it (no setuid starter, no usable
user namespace) or do not have it at all, and the runner has no root to install it."

Measured on a current runner:

```
apptainer version 1.5.3
setuid starter present: no
userns usable        : YES
apptainer build      : SUCCESS   (def with an apt-installing %post, 66M sif, exec verified)
```

No setuid starter, but the user namespace is usable, so `unshare --user
--map-root-user` succeeds and `%post` runs. That is exactly the case
`apptainer_can_build()` already probes for.

## Matrix parity

The apptainer branch only ever built `apptainer/intellikit.def`, so it could not
follow the rocm7/rocm10 matrix the docker branch supports through `DOCKERFILE`.
This adds:

- `APPTAINER_DEF` / `APPTAINER_IMAGE_NAME`, mirroring `DOCKERFILE` / `DOCKER_IMAGE_NAME`
- `apptainer/intellikit-rocm10.def`, the counterpart of `docker/Dockerfile.rocm10`,
  carrying the same constraints (no rocm/pytorch tag for ROCm 10, no PyTorch to avoid
  the `rocm-sdk-*` shims shadowing the real ROCm tools, venv because 24.04's Python is
  externally managed, `amdsmi` from the ROCm tree rather than PyPI)

Both workflows now install apptainer when neither runtime is present, matching what
iris already does.

## Testing

- `bash -n` on the script, YAML parses for both workflows
- apptainer build proven end to end on a runner host as shown above
- docker path untouched: hosts that have docker still autodetect to it
