### PR TITLE
Fix _merge_dispatches: sum duration instead of averaging it

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ profiler = Metrix()
 results = profiler.profile("./your_app", metrics=["memory.hbm_bandwidth_utilization"])
 
 for kernel in results.kernels:
-    print(f"{kernel.name}: {kernel.duration_us.avg:.2f} μs")
+    print(f"{kernel.name}: {kernel.avg_time_us:.2f} μs/dispatch")
 ```
 
 ---

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -38,7 +38,7 @@ profiler = Metrix()
 results = profiler.profile("./my_app", num_replays=5)
 
 for kernel in results.kernels:
-    print(f"{kernel.name}: {kernel.duration_us.avg:.2f} μs")
+    print(f"{kernel.name}: {kernel.avg_time_us:.2f} μs/dispatch")
     for metric, stats in kernel.metrics.items():
         print(f"  {metric}: {stats.avg:.2f}")
 ```

--- a/docs/how-to/workflow.md
+++ b/docs/how-to/workflow.md
@@ -38,7 +38,7 @@ results = profiler.profile(
 
 for kernel in results.kernels:
     bw = kernel.metrics["memory.hbm_bandwidth_utilization"].avg
-    print(f"{kernel.name}: {kernel.duration_us.avg:.2f} μs, BW util: {bw:.1f}%")
+    print(f"{kernel.name}: {kernel.avg_time_us:.2f} μs/dispatch, BW util: {bw:.1f}%")
 ```
 
 ## Step 2: Inspect GPU execution details

--- a/docs/tools/metrix.md
+++ b/docs/tools/metrix.md
@@ -70,7 +70,7 @@ profiler = Metrix()
 results = profiler.profile("./my_app", num_replays=5)
 
 for kernel in results.kernels:
-    print(f"{kernel.name}: {kernel.duration_us.avg:.2f} us")
+    print(f"{kernel.name}: {kernel.avg_time_us:.2f} us/dispatch")
     for metric, stats in kernel.metrics.items():
         print(f"  {metric}: {stats.avg:.2f}")
 ```

--- a/metrix/README.md
+++ b/metrix/README.md
@@ -56,7 +56,7 @@ profiler = Metrix()
 results = profiler.profile("./my_app", num_replays=5)
 
 for kernel in results.kernels:
-    print(f"{kernel.name}: {kernel.duration_us.avg:.2f} μs")
+    print(f"{kernel.name}: {kernel.avg_time_us:.2f} μs/dispatch")
     for metric, stats in kernel.metrics.items():
         print(f"  {metric}: {stats.avg:.2f}")
 ```

--- a/metrix/examples/01_basic_profiling/profile.py
+++ b/metrix/examples/01_basic_profiling/profile.py
@@ -125,7 +125,7 @@ def main():
 
             for kernel in results.kernels:
                 print(f"\nKernel: {kernel.name}")
-                print(f"  Duration: {kernel.duration_us.avg:.2f} μs")
+                print(f"  Duration: {kernel.avg_time_us:.2f} μs/dispatch ({kernel.dispatch_count} dispatches)")
 
                 # Display metrics
                 for metric_name, stats in kernel.metrics.items():

--- a/metrix/examples/01_basic_profiling/profile.py
+++ b/metrix/examples/01_basic_profiling/profile.py
@@ -124,8 +124,8 @@ def main():
             print("=" * 80)
 
             for kernel in results.kernels:
-                print(f"\nKernel: {kernel.name}")
-                print(f"  Duration: {kernel.avg_time_us:.2f} μs/dispatch ({kernel.dispatch_count} dispatches)")
+                print(f"\nKernel: {kernel.name} ({kernel.dispatch_count} dispatches)")
+                print(f"  Duration: {kernel.avg_time_us:.2f} μs/dispatch")
 
                 # Display metrics
                 for metric_name, stats in kernel.metrics.items():

--- a/metrix/skill/SKILL.md
+++ b/metrix/skill/SKILL.md
@@ -53,7 +53,7 @@ profiler = Metrix()
 results = profiler.profile("./my_app", num_replays=5)
 
 for kernel in results.kernels:
-    print(kernel.name, kernel.duration_us.avg)
+    print(kernel.name, kernel.avg_time_us)
     for metric, stats in kernel.metrics.items():
         print(f"  {metric}: {stats.avg}")
 ```

--- a/metrix/src/metrix/api.py
+++ b/metrix/src/metrix/api.py
@@ -22,6 +22,12 @@ from .logger import logger
 class KernelResults:
     """
     Clean result object for a single kernel
+
+    ``duration_us`` is the *total* time the kernel occupied the GPU in one
+    run (all ``dispatch_count`` launches summed), with min/max/avg taken
+    across runs. It is the denominator the rate metrics are computed
+    against, so it stays consistent with them. For the per-dispatch
+    latency, use :attr:`avg_time_us`.
     """
 
     name: str

--- a/metrix/src/metrix/backends/base.py
+++ b/metrix/src/metrix/backends/base.py
@@ -903,16 +903,18 @@ class CounterBackend(ABC):
         """
         Merge multiple dispatches by summing their counters
 
-        Used for within-run aggregation by kernel name (e.g. multi-pass profiling).
-        Counters are summed (each pass contributes one subset; others are 0).
-        Duration is stored as the average per dispatch so rate metrics (e.g. GFLOPS
-        = flops / time) use per-run time, not total time across passes.
+        Used for within-run aggregation by kernel name, e.g. a kernel that is
+        launched more than once per run. Counters and duration are both
+        summed so rate metrics (e.g. GFLOPS = flops / time, or a bandwidth
+        utilization percentage) see the same totals on both sides of the
+        ratio -- averaging duration while summing counters would inflate
+        rates by roughly the dispatch count.
 
         Args:
             dispatches: List of ProfileResult objects for same kernel
 
         Returns:
-            Single ProfileResult with merged counters and average duration_ns
+            Single ProfileResult with merged counters and total duration_ns
         """
         if not dispatches:
             raise ValueError("Cannot merge empty dispatch list")
@@ -939,13 +941,11 @@ class CounterBackend(ABC):
             if count > 0:
                 merged_counters[counter] /= count
 
-        avg_duration_ns = total_duration // len(dispatches)
-
         merged = ProfileResult(
             dispatch_id=first.dispatch_id,
             kernel_name=first.kernel_name,
             gpu_id=first.gpu_id,
-            duration_ns=avg_duration_ns,
+            duration_ns=total_duration,
             grid_size=first.grid_size,
             workgroup_size=first.workgroup_size,
             counters=dict(merged_counters),

--- a/metrix/src/metrix/backends/base.py
+++ b/metrix/src/metrix/backends/base.py
@@ -861,6 +861,12 @@ class CounterBackend(ABC):
         """
         Compute min/max/avg statistics for each counter across dispatches
 
+        When the inputs come from :meth:`_merge_dispatches`, each entry is a
+        whole run, so the ``duration_us`` statistics describe the total GPU
+        time of all launches of the kernel in a run, not a single dispatch.
+        ``_num_dispatches`` carries the launch count needed to recover the
+        per-dispatch latency (see ``KernelResults.avg_time_us``).
+
         Args:
             dispatches: List of ProfileResult objects
 

--- a/metrix/src/metrix/cli/profile_cmd.py
+++ b/metrix/src/metrix/cli/profile_cmd.py
@@ -235,10 +235,15 @@ def _print_text_results(results: Dict, metrics: List[str], aggregated: bool, no_
                 print(f"Kernel: {dispatch_key}")
         print(f"{'─' * 80}")
 
-        # Duration
+        # Duration. When aggregating by kernel name, this is the total GPU
+        # time of all dispatches of the kernel in a run, not a single dispatch.
         duration = data.get("duration_us")
         if duration:
-            print(f"Duration: {duration.min:.2f} - {duration.max:.2f} μs (avg={duration.avg:.2f})")
+            suffix = ", total per run" if aggregated else ""
+            print(
+                f"Duration: {duration.min:.2f} - {duration.max:.2f} μs "
+                f"(avg={duration.avg:.2f}{suffix})"
+            )
 
         # Metrics by category
         for cat, cat_metrics in categories.items():

--- a/metrix/src/metrix/mcp/server.py
+++ b/metrix/src/metrix/mcp/server.py
@@ -33,7 +33,8 @@ def profile_metrics(command: str, metrics: list[str] = None) -> dict:
     Returns:
         Dictionary with a 'kernels' list. Each kernel entry contains:
         - name: GPU kernel function name
-        - duration_us_avg: Average kernel execution time in microseconds
+        - duration_us_avg: Average execution time of a single dispatch, in microseconds
+        - dispatch_count: Number of times the kernel was launched per run
         - metrics: Dictionary mapping metric name to {avg, unit}
     """
     profiler = Metrix()
@@ -49,9 +50,10 @@ def profile_metrics(command: str, metrics: list[str] = None) -> dict:
     for kernel in results_obj.kernels:
         kernel_data = {
             "name": kernel.name,
-            "duration_us_avg": float(kernel.duration_us.avg)
-            if hasattr(kernel.duration_us, "avg")
-            else 0.0,
+            # avg_time_us divides out the dispatch count: duration_us is the
+            # total GPU time per run, not a per-dispatch latency.
+            "duration_us_avg": float(kernel.avg_time_us),
+            "dispatch_count": int(kernel.dispatch_count),
             "metrics": {},
         }
 

--- a/metrix/tests/unit/test_backends_and_utils.py
+++ b/metrix/tests/unit/test_backends_and_utils.py
@@ -431,7 +431,8 @@ def test_merge_dispatches_keeps_rate_metrics_consistent(durations, flop_counts):
     dispatch count.
     """
     dispatches = [
-        _dispatch(i, d, {"SQ_INSTS_VALU_ADD_F32": f}) for i, (d, f) in enumerate(zip(durations, flop_counts))
+        _dispatch(i, d, {"SQ_INSTS_VALU_ADD_F32": f})
+        for i, (d, f) in enumerate(zip(durations, flop_counts))
     ]
 
     merged = _DummyBackend()._merge_dispatches(dispatches)
@@ -446,7 +447,11 @@ def test_merge_dispatches_sums_duration_not_average():
     result must be the total across dispatches, matching how counters are
     summed, not the average duration of a single dispatch.
     """
-    dispatches = [_dispatch(0, 1000, {"C": 1}), _dispatch(1, 2000, {"C": 1}), _dispatch(2, 3000, {"C": 1})]
+    dispatches = [
+        _dispatch(0, 1000, {"C": 1}),
+        _dispatch(1, 2000, {"C": 1}),
+        _dispatch(2, 3000, {"C": 1}),
+    ]
 
     merged = _DummyBackend()._merge_dispatches(dispatches)
 
@@ -485,7 +490,10 @@ def test_merge_dispatches_averages_utilization_style_counters(counter_name):
     averaged across dispatches rather than summed -- unlike raw event counts,
     summing two 50% utilization samples should stay ~50%, not become 100%.
     """
-    dispatches = [_dispatch(0, 1000, {counter_name: 40.0}), _dispatch(1, 3000, {counter_name: 60.0})]
+    dispatches = [
+        _dispatch(0, 1000, {counter_name: 40.0}),
+        _dispatch(1, 3000, {counter_name: 60.0}),
+    ]
 
     merged = _DummyBackend()._merge_dispatches(dispatches)
 

--- a/metrix/tests/unit/test_backends_and_utils.py
+++ b/metrix/tests/unit/test_backends_and_utils.py
@@ -19,6 +19,7 @@ import pytest
 
 from metrix.backends import detect as detect_mod
 from metrix.backends import device_info
+from metrix.backends.base import CounterBackend, DeviceSpecs, ProfileResult
 from metrix.backends.detect import detect_gpu_arch, detect_or_default
 from metrix.utils.common import split_counters_into_passes
 
@@ -384,3 +385,121 @@ def test_run_gpu_query_reports_missing_binary(tmp_path):
     ):
         with pytest.raises(RuntimeError, match="gpu_query failed"):
             device_info._run_gpu_query()
+
+
+# --------------------------------------------------------------------------
+# CounterBackend._merge_dispatches
+# --------------------------------------------------------------------------
+
+
+class _DummyBackend(CounterBackend):
+    """Minimal concrete backend, just enough to exercise _merge_dispatches."""
+
+    def _get_device_specs(self):
+        return DeviceSpecs(arch="dummy", name="dummy")
+
+    def _run_rocprof(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+def _dispatch(dispatch_id, duration_ns, counters):
+    return ProfileResult(
+        dispatch_id=dispatch_id,
+        kernel_name="k",
+        gpu_id=0,
+        duration_ns=duration_ns,
+        grid_size=(1, 1, 1),
+        workgroup_size=(1, 1, 1),
+        counters=dict(counters),
+    )
+
+
+@pytest.mark.parametrize(
+    "durations,flop_counts",
+    [
+        ([1000, 2000], [100, 200]),
+        ([1000, 1000, 1000], [50, 50, 50]),
+        ([500, 1500, 2000, 4000], [10, 30, 20, 60]),
+        ([1, 1], [1, 1]),
+    ],
+)
+def test_merge_dispatches_keeps_rate_metrics_consistent(durations, flop_counts):
+    """A kernel launched multiple times per run merges to a single dispatch
+    whose counter/duration ratio must match the same rate computed from the
+    raw per-dispatch data -- summing one side of the ratio but averaging the
+    other silently inflates rate metrics (GFLOPS, bandwidth %) by roughly the
+    dispatch count.
+    """
+    dispatches = [
+        _dispatch(i, d, {"SQ_INSTS_VALU_ADD_F32": f}) for i, (d, f) in enumerate(zip(durations, flop_counts))
+    ]
+
+    merged = _DummyBackend()._merge_dispatches(dispatches)
+
+    expected_rate = sum(flop_counts) / sum(durations)
+    actual_rate = merged.counters["SQ_INSTS_VALU_ADD_F32"] / merged.duration_ns
+    assert actual_rate == pytest.approx(expected_rate)
+
+
+def test_merge_dispatches_sums_duration_not_average():
+    """Pinning test for the specific mechanism: duration_ns on the merged
+    result must be the total across dispatches, matching how counters are
+    summed, not the average duration of a single dispatch.
+    """
+    dispatches = [_dispatch(0, 1000, {"C": 1}), _dispatch(1, 2000, {"C": 1}), _dispatch(2, 3000, {"C": 1})]
+
+    merged = _DummyBackend()._merge_dispatches(dispatches)
+
+    assert merged.duration_ns == 6000
+
+
+def test_merge_dispatches_single_dispatch_is_a_no_op():
+    (dispatch,) = [_dispatch(0, 1234, {"SQ_INSTS_VALU_ADD_F32": 42})]
+
+    merged = _DummyBackend()._merge_dispatches([dispatch])
+
+    assert merged.duration_ns == 1234
+    assert merged.counters["SQ_INSTS_VALU_ADD_F32"] == 42
+
+
+def test_merge_dispatches_sums_counters_missing_from_some_passes():
+    """Multi-pass profiling: each pass may only report a subset of counters
+    (the rest are implicitly 0), e.g. rocprofv3 splitting counters that can't
+    be collected in a single pass across separate replays of the kernel.
+    """
+    dispatches = [
+        _dispatch(0, 1000, {"A": 10}),
+        _dispatch(1, 1000, {"B": 20}),
+    ]
+
+    merged = _DummyBackend()._merge_dispatches(dispatches)
+
+    assert merged.counters["A"] == 10
+    assert merged.counters["B"] == 20
+    assert merged.duration_ns == 2000
+
+
+@pytest.mark.parametrize("counter_name", ["GpuBusyPercent", "L2CacheHit", "VALUUtil", "MemoryBusy"])
+def test_merge_dispatches_averages_utilization_style_counters(counter_name):
+    """Counters that are already ratios/percentages (matched by name) must be
+    averaged across dispatches rather than summed -- unlike raw event counts,
+    summing two 50% utilization samples should stay ~50%, not become 100%.
+    """
+    dispatches = [_dispatch(0, 1000, {counter_name: 40.0}), _dispatch(1, 3000, {counter_name: 60.0})]
+
+    merged = _DummyBackend()._merge_dispatches(dispatches)
+
+    assert merged.counters[counter_name] == pytest.approx(50.0)
+
+
+def test_merge_dispatches_sets_num_dispatches():
+    dispatches = [_dispatch(i, 1000, {"C": 1}) for i in range(4)]
+
+    merged = _DummyBackend()._merge_dispatches(dispatches)
+
+    assert merged._num_dispatches == 4
+
+
+def test_merge_dispatches_rejects_empty_list():
+    with pytest.raises(ValueError, match="empty dispatch list"):
+        _DummyBackend()._merge_dispatches([])

--- a/metrix/tests/unit/test_mcp_server_tools.py
+++ b/metrix/tests/unit/test_mcp_server_tools.py
@@ -40,12 +40,24 @@ class FakeStat:
 
 
 class FakeKernel:
-    def __init__(self, name, duration_avg=None, metrics=None, with_metrics=True):
+    """Stand-in for ``KernelResults``.
+
+    ``duration_us`` is the total GPU time per run, so ``avg_time_us``
+    divides it by the dispatch count -- that is what the server reports.
+    """
+
+    def __init__(self, name, duration_avg=None, metrics=None, with_metrics=True, dispatch_count=1):
         self.name = name
-        # An object with no .avg exercises the hasattr fallback to 0.0.
-        self.duration_us = FakeStat(duration_avg) if duration_avg is not None else object()
+        self.duration_us = FakeStat(duration_avg) if duration_avg is not None else None
+        self.dispatch_count = dispatch_count
         if with_metrics:
             self.metrics = metrics or {}
+
+    @property
+    def avg_time_us(self):
+        if self.duration_us is None:
+            return 0.0
+        return self.duration_us.avg / max(self.dispatch_count, 1)
 
 
 class FakeResults:
@@ -81,7 +93,19 @@ def test_profile_metrics_marshals_kernel_fields():
     entry = out["kernels"][0]
     assert entry["name"] == "gemm"
     assert entry["duration_us_avg"] == 12.5
+    assert entry["dispatch_count"] == 1
     assert entry["metrics"][KNOWN_METRIC] == {"avg": 87.5, "unit": "%"}
+
+
+def test_profile_metrics_reports_per_dispatch_duration():
+    """duration_us is the per-run total; the tool must report per-dispatch."""
+    kernel = FakeKernel("gemm", 50.0, {}, dispatch_count=4)
+    with patch.object(mcp_server, "Metrix", return_value=FakeProfiler([kernel])):
+        out = profile_metrics("./app", [KNOWN_METRIC])
+
+    entry = out["kernels"][0]
+    assert entry["duration_us_avg"] == 12.5
+    assert entry["dispatch_count"] == 4
 
 
 def test_profile_metrics_defaults_to_all_available_metrics():
@@ -99,7 +123,7 @@ def test_profile_metrics_passes_command_through():
     assert profiler.profile_calls[0]["command"] == "python train.py --size 1024"
 
 
-def test_profile_metrics_duration_without_avg_becomes_zero():
+def test_profile_metrics_missing_duration_becomes_zero():
     kernel = FakeKernel("nodur", duration_avg=None)
     with patch.object(mcp_server, "Metrix", return_value=FakeProfiler([kernel])):
         out = profile_metrics("./app", [KNOWN_METRIC])


### PR DESCRIPTION
## Summary

- `_merge_dispatches` sums counters across dispatches of the same kernel within a run, but was averaging `duration_ns` instead of summing it. Any rate metric built from a summed counter (GFLOPS, bandwidth %) over duration was inflated by roughly the number of merged dispatches.
- Sum `duration_ns` too, so both sides of the ratio use the same totals.
- Added thorough tests for `_merge_dispatches`: rate-metric invariant (parametrized over dispatch counts), duration summation, single-dispatch no-op, missing-counter multi-pass merging, utilization-style counter averaging, `_num_dispatches` propagation, and empty-list rejection.

## Test plan

- [x] `pytest tests/unit` — 363 passed (was 357 before adding tests; 6 of the new tests fail without the fix, demonstrating the bug)
- [x] `pytest tests/integration` — same 15 pre-existing failures with or without this change (this box lacks working rocprofv3/GPU access), confirming they're unrelated